### PR TITLE
Plan: vim support for the terminal-native audience (embedded terminal pane + keyboard power-user layer)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1364,6 +1364,56 @@ rule]] in memory):
 
 ---
 
+## Phase KB — Keyboard power-user layer (opened 2026-07-22; candidate pre-launch, the vim-user wedge)
+
+Distinct from Phase A: that phase is the *accessibility floor* (WCAG 2.1 AA —
+can you reach everything by Tab). This is the *ceiling* — never needing the
+mouse OR the Tab-slog: fast, discoverable keys plus a prompt box that speaks
+vim. It targets exactly Mirafold's terminal-native wedge, so it reads as
+identity, not polish. Not yet sequenced against C/D/etc.; steps get written
+(Goal/Build/Files/Done-when) when Kyle slots it. Full breakdown + the
+post-launch depth live in **POST-RELEASE.md** ("Keyboard power-user layer");
+this note is the pre-launch pointer.
+
+The two governing constraints (both Kyle's, 2026-07-22) turn out to point at
+the *cheapest* architecture, not a costlier one:
+
+- **Nothing changes for non-vim users** — verbatim Kyle's standing A.3 rule.
+  Satisfied structurally: prompt-box vim mode is an opt-in setting, **default
+  off = today's exact `<textarea>`, element unswapped**; global shortcuts fire
+  **only when focus is not in the prompt**, so a user who lives in the prompt
+  never triggers one.
+- **Mirror how vim users already work in a terminal** — so the decisions are
+  easy. The same focus-state rule *is* the modal mapping: typing a prompt =
+  insert mode, `Esc` out = normal mode where shortcuts wake. ~80% of "modality"
+  falls out of focus state with no mode system invented.
+
+Candidate pre-launch slice (the identity part, ~1.5–2 wks, mostly hung off
+machinery that already exists — the overlay pattern, `useFocusTrap`,
+`useEscapeKey`, and the bus actions `interrupt`/`create`/pin):
+
+- **Focus-visibility fixes** (hours). Reveal-on-hover controls must also reveal
+  on keyboard focus. Confirmed gap: `.pin-btn` is `opacity:0` (styles.css:187)
+  revealed only by `:hover` (styles.css:191) — a keyboard user Tabs onto an
+  invisible button (WCAG 2.4.7). Add a `:focus-within`/`:focus-visible` reveal;
+  sweep for siblings. Invisible to mouse users → under Kyle's standing rule.
+- **`?` shortcuts overlay** (~½ day) — static keymap list, reuses the overlay +
+  focus-trap machinery.
+- **Command palette + core bindings** (~2–4 days) — a shell-owned overlay
+  (leader `:` or Space) calling the existing bus actions; gated to
+  focus-not-in-prompt.
+- **Prompt-box vim mode** (~4–6 days, the long pole and the only real
+  integration risk) — mount CodeMirror-with-vim in place of the textarea *only*
+  when the setting is on, preserving auto-grow, Enter-to-send, the `❯` glyph,
+  and all seven themes.
+
+The ~3 small picks the terminal doesn't answer for you: Enter-in-normal-mode
+(→ always send from the prompt), leader key (`:` vs Space), and focus-gated
+shortcuts (v1) vs a true app-wide normal mode (post-launch). None
+controversial.
+
+---
+
 ## Phase C — CI/CD (opened 2026-07-20; pre-launch)
 
 Kyle is standing up CI/CD shortly. As of 2026-07-20 there is **none** in any

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -56,6 +56,38 @@ has a home in this plan, the entry points there instead of duplicating it.
 - [ ] **Folder & file & diff view** — shell-owned project browsing: the
   working tree, file contents, and diffs of what the agent changed.
 
+- [ ] **Embedded terminal pane — interactive full-screen programs (vim, top)**
+  (2026-07-22) — the deferred **Tier 2** of the `!` passthrough (Step 4.9): a
+  real terminal box *inside* the session (a tmux-style split pane, NOT a
+  separate window or app) where curses programs run, so a `!vim`/`!top` reflex
+  just works instead of garbling through the ANSI-stripped Tier-1 stream.
+  Serves the vim user who lives in vim beside their terminal agent today and
+  would otherwise lose that when the browser replaces their tmux pane. Scope
+  settled in discussion:
+  - **Viewport-local, not session-shared.** The live keystroke stream is tied
+    to the one viewport that opened it — explicitly NOT fanned out to the
+    session's other viewports and NOT written to the replay ring. This is the
+    first stream that opts out of the broadcast/replay model, so it's the part
+    to design deliberately rather than bolt on. The *work* stays session-bound:
+    same cwd/files, and the agent is handed the resulting **diff** on exit,
+    never the keystroke stream (which would blow up tokens).
+  - **Desktop/laptop viewports only.** Not offered on a phone viewport — a
+    touch keyboard plus a small screen make full-screen modal editing a
+    non-use-case, and gating it here sidesteps both relay keystroke latency and
+    the narrow-split layout problem. Phone degrades gracefully (the "open in
+    vim" affordance simply isn't shown).
+  - **Cheap on the backend, ordinary on the front.** The PTY is already
+    `xterm-256color` and stdin already flows (`server/pty/pty.ts`); the deltas
+    are a raw (un-stripped) output path beside `cleanPtyOutput` plus a `resize`
+    on `BangProc`, additive wire messages (raw bytes as base64 since
+    `bang_output` is text today; resize; keystroke routing — add, never
+    reshape), and an xterm.js split pane with focus management on the front
+    end. Auto-open when a program enters the alternate screen (`\x1b[?1049h`),
+    collapse on exit. Adjacent to "Folder & file & diff view" above but
+    distinct (a live terminal, not a viewer). Rough size: ~a week for a solid
+    v1; the viewport-local stream is the only part that touches a core
+    assumption.
+
 - [ ] **Multiuser chat** — multiple people in one session's conversation;
   rides Phase 4's multi-user seam (Locked decisions: "architected so
   multi-user is additive later").

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -88,6 +88,34 @@ has a home in this plan, the entry points there instead of duplicating it.
     v1; the viewport-local stream is the only part that touches a core
     assumption.
 
+- [ ] **Keyboard power-user layer — the "vim guys" keymap** (2026-07-22) —
+  never needing the mouse OR the Tab-slog: fast, discoverable keys plus a
+  prompt box that speaks vim. Same terminal-native persona as the embedded
+  terminal pane above, and they share one design decision (below). The
+  **pre-launch identity slice** (focus-visibility fixes, `?` overlay, command
+  palette, opt-in prompt-box vim mode) is tracked in PLAN.md as **Phase KB**;
+  this entry parks the **post-launch depth**. Two constraints govern the whole
+  thing and point at the *cheapest* build: (1) nothing changes for non-vim
+  users — Kyle's standing A.3 rule — met by making vim mode an opt-in setting
+  (default off = today's exact textarea) and gating global shortcuts to
+  focus-not-in-prompt; (2) mirror how vim users already work in a terminal,
+  which the same focus-state rule delivers (prompt focused = insert mode, `Esc`
+  out = normal mode where shortcuts wake — no invented mode system). Post-launch
+  depth parked here:
+  - **Transcript keyboard navigation** — `j`/`k` + `Ctrl-d`/`Ctrl-u` to move,
+    jump next/prev turn, expand/collapse the focused tool/thinking block, pin
+    the focused block. The real work is a "current entry" cursor that survives
+    streaming (the transcript mutates under you), so it's post-launch, not part
+    of the identity slice. ~3–5 days.
+  - **True app-wide normal mode** (optional, ambitious) — beyond focus-gated
+    shortcuts, a real vim-style normal mode over the whole UI (h/j/k/l +
+    operators). The focus-gated v1 is 80% of the value; only build this on
+    demand.
+  - **Shared decision with the embedded terminal pane** — once keystrokes can
+    reach the prompt, an app shortcut, OR the vim pane, the modal routing
+    (which context owns the key) must be settled once and reused by both. Decide
+    it with whichever of the two ships first.
+
 - [ ] **Multiuser chat** — multiple people in one session's conversation;
   rides Phase 4's multi-user seam (Locked decisions: "architected so
   multi-user is additive later").


### PR DESCRIPTION
## What this is

Planning/backlog only — **no code or product behavior changes.** Captures the design worked out for serving vim users, so the decisions aren't lost.

Two related features for the same terminal-native persona, both scoped and parked deliberately:

### 1. Embedded terminal pane — `!vim`/`!top` (post-launch)
`POST-RELEASE.md` — the deferred **Tier 2** of the Step 4.9 `!` passthrough: a real terminal box *inside* the session (a tmux-style split pane, not a separate window/app) where full-screen curses programs run. Scoping settled:
- **Viewport-local, not session-shared** — the live keystroke stream is tied to the one viewport that opened it, explicitly not broadcast to other viewports or written to the replay ring. This is the first stream to opt out of the fan-out/replay model, so it's the part to design deliberately. Work stays session-bound (same cwd/files; the agent gets the resulting diff on exit, not the keystroke stream).
- **Desktop/laptop only** — a phone's touch keyboard + small screen make full-screen modal editing a non-use-case, and gating it here sidesteps relay keystroke latency and the narrow-split layout problem.
- **Cheap backend** — the PTY is already `xterm-256color` and stdin already flows; deltas are a raw (un-stripped) output path + a `resize`, additive wire messages, and an xterm.js split pane. Auto-open on alternate-screen enter (`\x1b[?1049h`).

### 2. Keyboard power-user layer — the vim keymap (Phase KB, candidate pre-launch)
`PLAN.md` new **Phase KB**, distinct from Phase A: Phase A is the accessibility *floor* (reach everything by Tab); this is the *ceiling* (never need the mouse or the Tab-slog — fast discoverable keys + a prompt box that speaks vim). Two governing constraints, both of which point at the *cheapest* architecture:
- **Nothing changes for non-vim users** (Kyle's standing A.3 rule) — met by making prompt-box vim mode an opt-in setting (default off = today's exact textarea, unswapped) and gating global shortcuts to focus-not-in-prompt.
- **Mirror how vim users already work in a terminal** — the same focus-state rule *is* the modal mapping (prompt focused = insert, `Esc` out = normal), so ~80% of modality falls out with no invented mode system.

Pre-launch identity slice (~1.5–2 wks, mostly on existing overlay/focus machinery): focus-visibility fixes → `?` shortcuts overlay → command palette → prompt-box vim mode (the long pole). Post-launch depth (transcript keyboard navigation, optional app-wide normal mode) parked in `POST-RELEASE.md` next to feature #1, since both share the modal keystroke-routing decision.

## Note: a real bug surfaced (not fixed here)
While verifying current keyboard operability, found a genuine focus-visibility gap: `.pin-btn` is `opacity:0` (`web/src/styles.css:187`) revealed only on `:hover` (`:191`), so a keyboard user Tabs onto an invisible button (WCAG 2.4.7). Recorded in Phase KB; it's also a straightforward Phase A.3 one-line CSS fix if you'd rather close it directly.

## Changed files
- `PLAN.md` — new Phase KB
- `POST-RELEASE.md` — embedded terminal pane + keyboard power-user layer entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJKM4LY5CtEkJFaanSwmHh)_