### PR TITLE
fix(mobile): new-session button hung on 'connecting' over the relay

### DIFF
--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { ConnectDevice, type RelayInfo } from "./ConnectDevice";
 import { useArmedConfirm } from "../use-armed-confirm";
+import { newSessionHref } from "../ws";
 
 // The workbench strip — model, session, cwd, connection, and token/cost
 // usage at a glance. Shell-owned (the agent can't paint here) and collapsible
@@ -115,10 +116,13 @@ export function StatusBar({
       {/* "new" sits beside home (2026-07-20, Kyle): a new browser tab on the
           startup screen, so a session can be spun up from inside any session.
           ?new opens mission control with the picker already up. End moved to
-          the far right, past the theme pill. */}
+          the far right, past the theme pill. On the relay path the href carries
+          the pairing fragment forward — a new tab inherits neither the fragment
+          nor sessionStorage, so without this the new tab has no daemon to reach
+          and hangs on "connecting" (mobile new-session bug, 2026-07-24). */}
       <a
         className="sb-new"
-        href="/?new=1"
+        href={newSessionHref()}
         target="_blank"
         rel="noopener"
         title="New session (opens a new tab)"

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -4,12 +4,28 @@ import { CLIENT_VERSION } from "./version";
 import {
   SocketClient,
   relayTargetFromFragment,
+  newSessionHref,
   viewportRefusalReason,
   PING_INTERVAL_MS,
   PONG_DEADLINE_MS,
   BACKOFF_MIN_MS,
   BACKOFF_MAX_MS,
 } from "./ws";
+
+/** In-memory Storage stub for newSessionHref (which takes storage injected). */
+function fakeStorage(init: Record<string, string> = {}): Storage {
+  const m = new Map(Object.entries(init));
+  return {
+    getItem: (k: string) => m.get(k) ?? null,
+    setItem: (k: string, v: string) => void m.set(k, String(v)),
+    removeItem: (k: string) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i: number) => [...m.keys()][i] ?? null,
+    get length() {
+      return m.size;
+    },
+  } as Storage;
+}
 
 // L.2b3: the reconnect state machine, driven through a stubbed WebSocket —
 // no browser, no jsdom. The stub exposes what the client touches (readyState,
@@ -382,4 +398,42 @@ test("client_error is stamped with the bundle version (one choke point)", (t) =>
     .find((m) => m.type === "client_error");
   assert.ok(report, "queued report leaves on open");
   assert.equal(report.clientVersion, CLIENT_VERSION);
+});
+
+// The mobile new-session bug (2026-07-24): the in-session "new" button opens
+// a fresh tab, which inherits neither the URL fragment nor sessionStorage — so
+// on the relay path the new-tab href MUST re-encode the pairing target, or the
+// new tab falls back to a daemon-less local ws and hangs on "connecting".
+test("newSessionHref: local path (no stored code) → plain URL", () => {
+  assert.equal(newSessionHref("/?new=1", fakeStorage()), "/?new=1");
+});
+
+test("newSessionHref: relay path w/ separate app origin → fragment carries code AND relay", () => {
+  const href = newSessionHref(
+    "/?new=1",
+    fakeStorage({
+      "mirafold-relay-code": "pair-code-abc_123",
+      "mirafold-relay-ws": "wss://relay.mirafold.sh",
+    }),
+  );
+  // The invariant that fixes the bug: the fragment parses back to the SAME
+  // target the current tab holds, so the new tab re-hydrates and dials the
+  // relay instead of a dead local ws.
+  const hash = href.slice(href.indexOf("#"));
+  assert.deepEqual(relayTargetFromFragment(hash), {
+    code: "pair-code-abc_123",
+    ws: "wss://relay.mirafold.sh",
+  });
+});
+
+test("newSessionHref: relay path w/ same-origin (no stored ws) → fragment carries code only", () => {
+  const href = newSessionHref(
+    "/?new=1",
+    fakeStorage({ "mirafold-relay-code": "just-a-code_9" }),
+  );
+  assert.equal(href, "/?new=1#code=just-a-code_9");
+  assert.deepEqual(relayTargetFromFragment(href.slice(href.indexOf("#"))), {
+    code: "just-a-code_9",
+    ws: null,
+  });
 });

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -103,6 +103,27 @@ function relayTargetFromPage(): { code: string; ws: string | null } | null {
   return code ? { code, ws: sessionStorage.getItem("mirafold-relay-ws") } : null;
 }
 
+/** The href for the "new session" affordance, which opens a FRESH TAB. A new
+ *  tab inherits neither the URL fragment nor — reliably, and never on a
+ *  `noopener` open or on mobile — the opener's sessionStorage. So on the relay
+ *  path the pairing target must be re-encoded into the new tab's fragment, or
+ *  that tab finds no code, falls back to a local `ws://` origin with no daemon
+ *  behind it, and hangs on "connecting" forever with the picker never arriving
+ *  (the mobile new-session bug, 2026-07-24). The fragment stays client-side
+ *  exactly as the QR's did — it is never sent to the relay, and the new tab
+ *  scrubs it on load. A local page has no stored code and gets the plain URL.
+ *  Reads storage lazily so tests can drive it; `base` defaults to the real
+ *  new-session URL. */
+export function newSessionHref(base = "/?new=1", storage: Storage = sessionStorage): string {
+  const code = storage.getItem("mirafold-relay-code");
+  if (!code) return base;
+  const ws = storage.getItem("mirafold-relay-ws");
+  const frag = ws
+    ? `#code=${encodeURIComponent(code)}&relay=${encodeURIComponent(ws)}`
+    : `#code=${encodeURIComponent(code)}`;
+  return base + frag;
+}
+
 /**
  * The shell's WebSocket client. Lives in the trusted shell — agent output
  * never touches it. Reconnects automatically on drop; every (re)open first


### PR DESCRIPTION
**Serious mobile bug** (found in beta): starting a new session on a phone hung on "connecting…" forever — the agent picker never appeared. Desktop was fine.

**Root cause:** the in-session "new" button opens a fresh tab (`target="_blank" rel="noopener"`). On the relay path the pairing code lives only in per-tab `sessionStorage` (the QR fragment is scrubbed after load), and a `noopener` new tab inherits neither the fragment nor sessionStorage. So the new tab found no relay code, fell back to a local `ws://` origin with no daemon behind it, and hung. Desktop worked because that local fallback *is* the daemon; mobile resume worked because fleet links stay in the same tab. Diagnosed from the daemon flight-recorder log + relay structured logs (phone viewports opened then closed, no session forming).

**Fix:** `newSessionHref()` re-encodes the stored relay target into the new tab's URL fragment, so it re-hydrates and dials the relay. Client-side only, exactly as the QR fragment was. Tested incl. the round-trip invariant (produced fragment → `relayTargetFromFragment` → same target). Tier 1: 322 pass.

**⚠️ Deploy note:** the phone loads the bundle from **app.mirafold.com** — merging this is not enough; that static origin must be redeployed with the new build for phones to get the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)