### PR TITLE
Explorer E.1: wire contract + jailed read-only fs module

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2596,6 +2596,162 @@ in nested lists are tabbable and axe-clean.
 
 ---
 
+## Phase M — Mission control (opened 2026-07-24; Kyle-directed — the cockpit fleetview, promoted from POST-RELEASE.md)
+
+The "Cockpit fleetview" intake entry, promoted to active work: grow FleetView
+(4.6) into a true cockpit — at-a-glance live state of every session, and acting
+on sessions from the grid rather than only entering them. Design settled with
+Kyle 2026-07-24. The governing principles:
+
+- **Shell-owned end to end.** Same trust rule as the permission bar: agent
+  output never paints here, and every engine-derived string on a row (activity
+  label, permission detail) renders as inert plain text — never markdown, never
+  HTML.
+- **Extends the watch_sessions path, additively.** All live state rides
+  optional `SessionMeta` fields in the existing per-viewport `sessions`
+  snapshot (never broadcast, never replay-buffered, no `seq`); all grid acts
+  are new sessionId-addressed `ClientMsg` types on the `end_session`
+  precedent. No new stream, no new transport.
+- **Agent-neutral by construction.** Every new field is derived in the
+  registry from the WireMsg stream it already fans out (status / bang /
+  permission_request / usage) — no adapter cooperation, no per-agent code.
+- **Grid acts = viewport acts, same gates.** Acting from the grid grants
+  nothing a local viewport couldn't do by attaching. The one real gate carries
+  over: a REMOTE (relay) watcher may not drive a subscription-backed session
+  (R.4i), so quick-prompt and permission-answer are refused when
+  `remote && !allowedOverRelay(kind)` — interrupt stays ungated, like
+  `end_session` (teardown, not model use).
+- **Stable rows, needs-you first** (Kyle's ordering call): rows hold creation
+  order so eyes can park on a session; the one exception is sessions awaiting
+  permission, which surface to a group at the top — the "act here" zone. The
+  recency sort is retired on this page.
+- **The archived-session fleetview stays unprecluded.** The `sessions`
+  snapshot remains live-only; the future archived fleetview (POST-RELEASE.md)
+  arrives as its own additive message + a second page section, never by
+  reshaping this one.
+
+Accepted v1 limits, on purpose: no live output preview on rows (Kyle's call —
+activity + permission + usage are the glance set); no one-click default
+new-session (the picker stays the only create); the pending-permission display
+mirrors the 4.6 status stickiness (the queue clears when the stream moves, so a
+second concurrently-pending request can be invisible on the fleet until its own
+timeout — same honesty as the status dot today); usage mirrors the status bar's
+exact rule (per-turn tokens summed, cost taken cumulative — the same numbers
+the in-session bar shows); elapsed time ticks client-side from `since`, the
+server sends no timers.
+
+- [ ] **Step M.1 — Live cockpit state on the wire (registry-derived, additive SessionMeta)**
+  - Goal: a fleet watcher's snapshot says what each session is DOING — current
+    activity + since-when, the pending-permission queue, session usage totals,
+    and creation time — derived entirely in the registry.
+  - Build: `protocol.ts` additive optional `SessionMeta` fields:
+    `createdAt?: number`, `activity?: { label: string; since: number }`,
+    `permissions?: { id: string; tool: string; detail: string }[]`,
+    `usage?: { inputTokens: number; outputTokens: number; costUsd?: number }`.
+    `registry.ts`: `SessionEntry` gains the backing fields; the existing status
+    derivation in `broadcast()` grows the capture — a `status` msg sets
+    activity (`thinking` → "thinking", `tool` → its label), `bang_start` sets
+    `! <command>`, terminal messages (turn_end/error/bang_end) clear it;
+    `permission_request` appends `{id, tool, detail}` to the queue; any message
+    that flips status off "permission" clears the queue (the 4.6 stickiness
+    rule, mirrored); a `usage` msg adds per-turn tokens and TAKES `costUsd`
+    (session-cumulative per T2.6 — never summed; Shell.tsx's exact rule).
+    `notifyWatchers()` fires on metadata change (activity label change, queue
+    change, usage turn) through the existing 100 ms coalescer — text_delta
+    storms change nothing and stay silent. `summary()` carries the new fields;
+    all absent when empty, so old clients strip them (R.4h).
+  - Files: `server/protocol.ts` (additive), `server/sessions/registry.ts`.
+  - Done when: Tier 2 (new `fleet-cockpit.itest.ts`, real daemon + real
+    sockets, mock-forced): a watcher sees activity appear during a working turn
+    and clear at turn_end; a `dangerous` mock prompt puts `{tool, detail}` on
+    the session's meta and an in-session answer clears it; usage totals
+    accumulate across two turns with cost taken-not-summed; `createdAt` is
+    stable across snapshots. `yarn typecheck` clean; all existing tests green.
+
+- [ ] **Step M.2 — Acting from the grid, server side (sessionId-addressed ClientMsg)**
+  - Goal: a fleet watcher can answer a permission, interrupt a turn, and
+    dispatch a prompt on any session by id — validated, throw-wrapped,
+    relay-gated where it drives the model — without attaching.
+  - Build: `protocol.ts` additive `ClientMsg` types:
+    `{ type: "answer_permission"; sessionId: string; id: string; allow: boolean }`,
+    `{ type: "interrupt_session"; sessionId: string }`,
+    `{ type: "prompt_session"; sessionId: string; text: string }`.
+    `connection.ts`: own NEW switch cases only (nothing existing is touched):
+    validate inputs first (typeof checks; prompt text trimmed non-empty with a
+    sane length cap); unknown sessionId → error reply, never a crash; then
+    `answer_permission` → the session's `resolvePermission` plus dropping the
+    id from the entry's pending queue (+ notify); `interrupt_session` →
+    `session.interrupt()`; `prompt_session` → the `prompt` case's exact
+    semantics addressed by id (broadcast `user_prompt` + `pushPrompt`). The
+    relay gate: on a `remote` connection, `prompt_session` and
+    `answer_permission` against `!allowedOverRelay(entry.kind)` get the attach
+    gate's refusal wording as an error reply.
+  - Files: `server/protocol.ts` (additive), `server/sessions/connection.ts`
+    (new cases only), `server/sessions/registry.ts` (queue-drop helper).
+  - Done when: Tier 2 `fleet-cockpit.itest.ts` over a real socket: a watcher's
+    allow resolves a mock `dangerous` permission (the session's own viewport
+    sees the tool run) and deny refuses it; `interrupt_session` halts a working
+    mock turn and the session still answers the next prompt;
+    `prompt_session` round-trips (user_prompt broadcast + turn runs); unknown
+    sessionId, malformed fields, and empty text each get an error reply with
+    the daemon still alive; the remote gate refuses prompt/answer on a
+    subscription-kind session for a remote-flagged connection. All tiers green.
+
+- [ ] **Step M.3 — The cockpit rows (front end)**
+  - Goal: the fleet page shows each session's live state and carries the three
+    acts — needs-you rows answerable in place — in the enriched-row shape,
+    stable-ordered with needs-you first.
+  - Build: `FleetView.tsx`: client-side sort — needs-you group first (oldest
+    pending first), then creation order (`createdAt`, wire order as the
+    old-daemon fallback); the row gains the activity readout ("⚙ Bash · 14s" —
+    label from meta, elapsed ticked client-side ~1 s while any row is active)
+    and compact usage ("12.3k tok · $0.42" — own small formatter; never import
+    from StatusBar). A needs-you row grows a second line: `tool · detail`
+    (inert plain text, ellipsized, `+N more` when the queue is deeper) with
+    Allow / Deny buttons sending `answer_permission` (disabled once clicked
+    until the next snapshot). A working row gets an armed two-click stop
+    (`useArmedConfirm`, the end-button precedent) sending
+    `interrupt_session`. A per-row quick-prompt affordance (❯) expands an
+    inline one-line input — Enter sends `prompt_session` and collapses, Escape
+    collapses, autofocus on open. Fleet-action error replies render as a
+    dismissible line in the fleet header region (only picker-open errors keep
+    routing to the onboarding card). An `sr-only` polite live region announces
+    the needs-you count change. All controls carry real aria-labels naming the
+    session. New CSS blocks only, appended (`.fleet-activity`, `.fleet-usage`,
+    `.fleet-perm…`, `.fleet-stop`, `.fleet-prompt…`).
+  - Files: `web/src/components/FleetView.tsx`, `web/src/styles.css` (additive
+    blocks only).
+  - Done when: Tier 3 (new `server/testing/fleet.e2e.ts`, its own suite,
+    desktop width): a mock turn shows the activity label live and clears to
+    idle; a `dangerous` prompt surfaces the needs-you second line with the
+    tool detail and the row moves to the top group; Allow from the grid runs
+    the tool (observed in the session tab) and the line clears; Deny refuses
+    it; the armed stop interrupts a working turn; a quick prompt from the row
+    lands as a user_prompt strip in the session tab; an idle session's row
+    holds its place while another works (no jumping); the axe scan of the
+    cockpit with a permission row visible has no serious/critical hits.
+
+- [ ] **Step M.4 — Phone width**
+  - Goal: at ≤640 px the cockpit rows fold without side-scroll — the glance
+    set survives, targets stay ≥40 px, the second-line controls remain usable.
+  - Build: additive media-query CSS for the new row elements (the existing
+    fleet phone folding is the precedent); tests ride `fleet.e2e.ts` with a
+    phone-sized context, reusing the existing `noSideScroll`/target-size
+    helpers.
+  - Files: `web/src/styles.css` (additive), `server/testing/fleet.e2e.ts`.
+  - Done when: `fleet.e2e.ts` at phone width: Allow/Deny tap targets ≥40 px,
+    `noSideScroll` passes with activity + permission + usage visible, the
+    quick prompt opens and sends, the axe scan is clean.
+
+- [ ] **Step M.5 — Polish (optional; the cut line)**
+  - A needs-you signal on the fleet page's TAB: title count ("Mirafold — 1
+    needs you") + the corner-badge favicon via `tab-status.ts` (the session
+    page's existing mechanism, reused); the row's viewport count (meta already
+    carries it); quick-prompt remembering its open state per row. Everything
+    here is safe to drop.
+
+---
+
 ## Stretch goals (unscheduled — polish, no milestone gates on these)
 
 Pick one up only when the phases above are quiet.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2319,6 +2319,22 @@ anywhere; each is independent.
 
 - [x] **Step Q.5 — Pin the `.env` guard's edges** — done 2026-07-12; traversal + cross-cwd denials pinned across all four guarded readers, non-vacuous by weakening the guard. (Symlink bypass stays the documented accepted residual.) → PLAN-ARCHIVE.md.
 
+- **WATCH ITEM (2026-07-24): the follow-tail re-arm race** — seen once on the
+  CI runner (app.e2e.ts "re-follows once back at the bottom", sat 188px above
+  the tail), green on rerun and on every local run; ROOT-CAUSED same day, fix
+  deferred. Mechanism: re-arming depends on `use-follow-tail.ts`'s `onScroll`
+  measuring within `BOTTOM_SLACK_PX` (24) of the bottom, but scroll events
+  fire a frame after the scroll — under load the stream can paint >24px in
+  that gap, so a reader (or the test's single programmatic jump) landing at
+  the bottom mid-stream measures as "not at bottom" and follow never re-arms.
+  A REAL product race, not only test fragility — narrow, and a human recovers
+  by scrolling again, which is why it's a watch item not a blocker. Proposed
+  fix shape when picked up: arm on INTENT like detach already does (a
+  downward wheel/touch ending near the bottom re-arms), so re-arming stops
+  depending on winning a paint race; the hook's two locked decisions
+  (2026-07-20 trace) must be re-read first. The test's single jump + single
+  sample then stops being timing-sensitive on its own.
+
 ---
 
 ## Phase S — Theme system: six themes at launch (✅ COMPLETE 2026-07-16)

--- a/PLAN.md
+++ b/PLAN.md
@@ -2447,7 +2447,7 @@ dirs); independently-capped diff sides can overstate changes past the cap
 `role="tree"` arrow-key grammar is deferred to Phase KB territory — buttons
 in nested lists are tabbable and axe-clean.
 
-- [ ] **Step E.1 — Wire contract + server fs module (no git yet)** (~1–1.5 days)
+- [x] **Step E.1 — Wire contract + server fs module (no git yet)**
   - Goal: a viewport can request the working tree's file list and any file's
     content over the existing WS — per-viewport, jailed, secret-safe, capped —
     against any directory, repo or not.
@@ -2483,6 +2483,20 @@ in nested lists are tabbable and axe-clean.
     request with no session attached errors cleanly; a deleted session root
     errors, never crashes. `yarn typecheck` clean; all existing tests green
     (Tier 1 ≥318 / Tier 2 ≥86 / Tier 3 37, counts as of 2026-07-23).
+  - *2026-07-24: DONE, on `feat/explorer-e1`. Shipped as specced with one
+    Build deviation: the read cap is applied via bounded fd reads (own
+    `FS_FILE_CAP_BYTES` knob, same 64 KB default and honesty contract as
+    `capOutput`) instead of calling `capOutput` — that function needs the
+    whole string in memory, so a multi-GB file would have been loaded just to
+    be truncated; the fd path reads at most sniff + cap bytes. Every "Done
+    when" case observed: Tier-1 fs-explorer suite (walk shape/caps, symlink
+    leaf, jail incl. symlink-out, secret basenames, binary sniff, cap math,
+    lossy UTF-8, empty file) + `isSecretFile` pin + the Q.2 protocol fixtures;
+    Tier-2 `fs-explorer.itest.ts` (round-trip, secret/jail refusals as error
+    replies with the daemon proven alive after, throttle answers then
+    recovers, no-session, deleted-root) + 6 hostile Explorer frames in the
+    Q.4 sweep (bad ids dropped whole and leak-checked against viewport B).
+    All tiers green **336 / 91 / 38**.*
 
 - [ ] **Step E.2 — Git layer: tracked tree, change status, per-file diff** (~1 day)
   - Goal: in a repo, the tree is git's view (tracked + untracked-unignored)

--- a/PLAN.md
+++ b/PLAN.md
@@ -2498,7 +2498,7 @@ in nested lists are tabbable and axe-clean.
     Q.4 sweep (bad ids dropped whole and leak-checked against viewport B).
     All tiers green **336 / 91 / 38**.*
 
-- [ ] **Step E.2 — Git layer: tracked tree, change status, per-file diff** (~1 day)
+- [x] **Step E.2 — Git layer: tracked tree, change status, per-file diff**
   - Goal: in a repo, the tree is git's view (tracked + untracked-unignored)
     with per-file change status, and any file answers "what changed" as
     `{before, after}` — degrading to E.1 behavior when there's no repo, no git
@@ -2530,6 +2530,24 @@ in nested lists are tabbable and axe-clean.
     deleted, and renamed files all diff correctly; a session rooted in a repo
     SUBDIRECTORY labels statuses correctly; a non-repo dir and an unborn-HEAD
     repo degrade instead of erroring; all tiers green.
+  - *2026-07-24: DONE, on `feat/explorer-e1` (same PR as E.1). As specced,
+    with two additions beyond the Build text: (1) `cleanRelPath` — a pure
+    TEXTUAL containment check applied to `fs_diff` paths before git ever sees
+    them, because `git show HEAD:./<rel>` resolves against the REPO, not the
+    filesystem, so the realpath jail can't cover it and a `../` could read
+    repo files above a subdirectory session's root; (2) porcelain COPY
+    records keep their source unmarked (only a rename's source is D — a
+    copy's source still exists unchanged). One deviation carried from E.1:
+    before-side capping via `capBuffer` (same 64 KB + honesty contract as
+    capOutput, applied to the in-memory git blob). One E.1 test taught a
+    lesson worth keeping: the throttle error is sync while the served reply
+    is now async, so replies are correlated by echoed id, never arrival
+    order — the itest pins that. Observed: Tier-1 parser pins (rename
+    two-field alignment, copy source, collapse chars, cleanRelPath); Tier-2
+    `fs-git.itest.ts` against a scripted repo — git's-view tree (ignored
+    excluded, staged delete + rename source visible), modified/added/
+    deleted/renamed diffs, the SUBDIRECTORY prefix-strip session, unborn
+    HEAD, `.env`-diff refusal, `../` refusal. All tiers green **342/95/38**.*
 
 - [ ] **Step E.3 — Desktop: the Files side panel** (~1.5–2 days)
   - Goal: a collapsible left column beside the transcript — tree → click a

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -51,7 +51,15 @@ has a home in this plan, the entry points there instead of duplicating it.
 
 - [ ] **Cockpit fleetview** — grow FleetView (4.6) into a true cockpit:
   at-a-glance live state of every session, and acting on sessions from the
-  grid rather than only entering them.
+  grid rather than only entering them. The v1 (live activity / pending
+  permission / usage on enriched rows; permission allow/deny, interrupt, and
+  quick prompt from the grid) was promoted to active work 2026-07-24 and is
+  tracked in PLAN.md as **Phase M — Mission control**; this entry parks the
+  post-v1 depth — a live output-preview line on rows, one-click default
+  new-session, a card-grid presentation (all considered and deliberately not
+  picked for v1). The **archived-session fleetview** below stays its own
+  entry — Phase M leaves the `sessions` snapshot live-only so it can arrive
+  additively.
 
 - [ ] **Folder & file & diff view** — shell-owned project browsing: the
   working tree, file contents, and diffs of what the agent changed. The

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -135,6 +135,25 @@ const WIRE: WireByType = {
   bang_output: { type: "bang_output", data: "PASS\n", id: "b1" },
   bang_end: { type: "bang_end", id: "b1", exitCode: 0 },
   pong: { type: "pong" },
+  fs_tree: {
+    type: "fs_tree",
+    id: "f1",
+    root: "/home/u/proj",
+    entries: [{ path: "src/app.ts" }, { path: "README.md", status: "M" }],
+    git: false,
+    truncated: true,
+    error: "the session workspace is not readable",
+  },
+  fs_file: {
+    type: "fs_file",
+    id: "f2",
+    path: "src/app.ts",
+    content: "export {};\n",
+    size: 11,
+    truncatedBytes: 0,
+    binary: false,
+    error: "path is outside the session workspace",
+  },
   sessions: { type: "sessions", sessions: [SESSION_META] },
   session_ended: { type: "session_ended", sessionId: "s1" },
 };
@@ -161,6 +180,8 @@ const CLIENT: ClientByType = {
   rename: { type: "rename", sessionId: "s1", name: "renamed" },
   end_session: { type: "end_session", sessionId: "s1" },
   refresh_agents: { type: "refresh_agents" },
+  fs_list: { type: "fs_list", id: "f1" },
+  fs_read: { type: "fs_read", id: "f2", path: "src/app.ts" },
   client_error: { type: "client_error", message: "TypeError: x is undefined", clientVersion: "0.0.1" },
 };
 

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -154,6 +154,17 @@ const WIRE: WireByType = {
     binary: false,
     error: "path is outside the session workspace",
   },
+  fs_file_diff: {
+    type: "fs_file_diff",
+    id: "f3",
+    path: "src/app.ts",
+    before: "export {};\n",
+    after: "export default {};\n",
+    beforeTruncatedBytes: 0,
+    afterTruncatedBytes: 0,
+    binary: false,
+    error: "no diff available for this entry",
+  },
   sessions: { type: "sessions", sessions: [SESSION_META] },
   session_ended: { type: "session_ended", sessionId: "s1" },
 };
@@ -182,6 +193,7 @@ const CLIENT: ClientByType = {
   refresh_agents: { type: "refresh_agents" },
   fs_list: { type: "fs_list", id: "f1" },
   fs_read: { type: "fs_read", id: "f2", path: "src/app.ts" },
+  fs_diff: { type: "fs_diff", id: "f3", path: "src/app.ts" },
   client_error: { type: "client_error", message: "TypeError: x is undefined", clientVersion: "0.0.1" },
 };
 

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -253,6 +253,24 @@ type WireMsgBody =
       binary?: boolean;
       error?: string;
     }
+  // The fs_diff reply (E.2): one file's change as BEFORE/AFTER text — never
+  // hunk/patch text (the render_diff lesson: snippets need no bookkeeping;
+  // the client diffs them with the same differ ToolBlock uses). `before` is
+  // HEAD's version (absent in HEAD / unborn HEAD → ""), `after` the working
+  // tree (deleted → ""). Sides are capped independently and honestly;
+  // `binary` on either side withholds both texts. Same per-viewport rules as
+  // fs_tree/fs_file.
+  | {
+      type: "fs_file_diff";
+      id: string;
+      path: string;
+      before?: string;
+      after?: string;
+      beforeTruncatedBytes?: number;
+      afterTruncatedBytes?: number;
+      binary?: boolean;
+      error?: string;
+    }
   // Reply to a client ping — connection liveness only, never
   // buffered or sequenced (4.4).
   | { type: "pong" }
@@ -426,6 +444,9 @@ export type ClientMsg =
   // per connection (throttled requests still get an error reply).
   | { type: "fs_list"; id: string }
   | { type: "fs_read"; id: string; path: string }
+  // E.2: "what changed in this file" — answered as fs_file_diff. Same id
+  // grammar, same jail, same throttle family as fs_read.
+  | { type: "fs_diff"; id: string; path: string }
   // The browser half's uncaught errors (window "error"/"unhandledrejection"),
   // forwarded so the daemon's flight-recorder log hears about a front-end
   // crash — otherwise a "it went blank" bug report arrives with an empty log

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -221,6 +221,38 @@ type WireMsgBody =
   | { type: "bang_output"; data: string; id: string }
   // exitCode null = killed by signal (user stop, session close).
   | { type: "bang_end"; id: string; exitCode: number | null }
+  // Phase E (Explorer): the shell's read-only file browser. Per-viewport
+  // request/reply — like `pong`/`sessions`, never buffered or sequenced:
+  // current disk state is a query, not session history, so it must not enter
+  // the replay ring. `id` echoes the client's mint so racing replies
+  // correlate. Entry paths are session-root-relative and /-separated (the
+  // client nests them; the wire stays non-recursive, the file-tree rule).
+  // Every request gets exactly one reply — an error rides the reply
+  // (`error` set, other fields best-effort), never silence. `git` is false
+  // until E.2's git layer lands (then: git's view of the tree + `status`
+  // chars on entries). `truncated` marks a capped walk, honestly.
+  | {
+      type: "fs_tree";
+      id: string;
+      root: string;
+      entries: FsEntry[];
+      git: boolean;
+      truncated?: boolean;
+      error?: string;
+    }
+  // One file's content (the fs_read reply). `binary` = NUL-sniffed, content
+  // withheld. `truncatedBytes` mirrors tool_result's honest cap: how many
+  // bytes of the real file were elided after the content cap.
+  | {
+      type: "fs_file";
+      id: string;
+      path: string;
+      content?: string;
+      size?: number;
+      truncatedBytes?: number;
+      binary?: boolean;
+      error?: string;
+    }
   // Reply to a client ping — connection liveness only, never
   // buffered or sequenced (4.4).
   | { type: "pong" }
@@ -290,6 +322,13 @@ export type BackendChoice = {
   provider?: string;
   model?: string;
 };
+
+/** One Explorer tree entry (Phase E.1): a FILE, by root-relative /-separated
+ *  path — directories are inferred client-side (git's `ls-files` view has no
+ *  directory rows either, so repo and non-repo trees stay one shape; the
+ *  known cost is that empty directories are invisible). `status` arrives with
+ *  E.2's git layer: a single collapsed change char (M/A/D/U). */
+export type FsEntry = { path: string; status?: string };
 
 /** One fleet row (4.6). `lastActivity` is epoch ms of the last broadcast. */
 export type SessionMeta = {
@@ -379,6 +418,14 @@ export type ClientMsg =
   // "start your local server and it appears here" promise is live — no
   // reload. Server-side throttled; a burst degrades to the cached answer.
   | { type: "refresh_agents" }
+  // Phase E (Explorer): the read-only file browser's per-viewport queries.
+  // `id` is client-minted (the bang-id grammar) so the issuing component can
+  // correlate the one reply each request gets. The path is a REQUEST — the
+  // server jails every resolution to the session root and refuses secret env
+  // files; the client is never trusted with a path. Both types are throttled
+  // per connection (throttled requests still get an error reply).
+  | { type: "fs_list"; id: string }
+  | { type: "fs_read"; id: string; path: string }
   // The browser half's uncaught errors (window "error"/"unhandledrejection"),
   // forwarded so the daemon's flight-recorder log hears about a front-end
   // crash — otherwise a "it went blank" bug report arrives with an empty log

--- a/server/security/permissions.test.ts
+++ b/server/security/permissions.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { mkdtempSync } from "node:fs";
-import { makeCanUseTool, type PermissionAsker } from "./permissions";
+import { isSecretFile, makeCanUseTool, type PermissionAsker } from "./permissions";
 
 // The SDK's canUseTool passes an options object; our policy ignores it, so a
 // minimal-but-complete stub is enough to exercise the callback.
@@ -122,4 +122,13 @@ test("the deny message names the declined tool", async () => {
   const r = await call("Bash", { command: "ls" });
   assert.equal(r.behavior, "deny");
   if (r.behavior === "deny") assert.match(r.message, /Bash/);
+});
+
+test("isSecretFile: basename rule — env files anywhere, nothing else (E.1)", () => {
+  for (const p of ["/x/.env", "/x/deep/nest/.env.local", ".env", "sub/.env"]) {
+    assert.equal(isSecretFile(p), true, `${p} is secret`);
+  }
+  for (const p of ["/x/.envrc", "/x/env", "/x/foo.env", "/x/.env.example", "/x/environment.ts"]) {
+    assert.equal(isSecretFile(p), false, `${p} is not`);
+  }
 });

--- a/server/security/permissions.ts
+++ b/server/security/permissions.ts
@@ -33,7 +33,19 @@ const DETAIL_FIELD: Record<string, string> = {
 // return file contents / paths and would otherwise sidestep the Read guard.
 // Defense-in-depth: still string-based (a symlink or `Bash cat .env` isn't
 // caught — but Bash asks), so it closes the obvious routes, not every one.
-const SECRET_PATHS = new Set([path.resolve(".env"), path.resolve(".env.local")]);
+// One source for WHICH filenames are secret: the tool guard below derives its
+// daemon-cwd absolute pair from it, and the Explorer's file viewer
+// (fs-explorer.ts, E.1) applies it by basename to any file under a session
+// root — stricter there on purpose (a browsing UI invites wandering in a way
+// a typed command doesn't), and derived from the same set so the two guards
+// can't drift.
+export const SECRET_FILE_BASENAMES = new Set([".env", ".env.local"]);
+const SECRET_PATHS = new Set([...SECRET_FILE_BASENAMES].map((n) => path.resolve(n)));
+
+/** True when `p` names a secret env file (by basename) — the Explorer's
+ *  content-read denial. Listing may still SHOW the file (honesty over
+ *  hiding); only reading its contents is refused. */
+export const isSecretFile = (p: string) => SECRET_FILE_BASENAMES.has(path.basename(p));
 const READ_PATH_FIELD: Record<string, string> = {
   Read: "file_path",
   NotebookRead: "notebook_path",

--- a/server/sessions/actions.ts
+++ b/server/sessions/actions.ts
@@ -22,8 +22,9 @@ type ActionTool = {
 // symlinks, so a link planted in the workspace can't point the listing out of
 // it. realpathSync throws on a missing path (nothing to list anyway → treat as
 // outside). `root` is realpath'd too, so the prefix compare is against the
-// canonical base.
-const inside = (root: string, candidate: string): string | null => {
+// canonical base. Exported since E.1: fs-explorer.ts jails every Explorer
+// path through this same guard — one containment rule, no drift.
+export const inside = (root: string, candidate: string): string | null => {
   let real: string;
   let realRoot: string;
   try {

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -5,7 +5,9 @@ import path from "node:path";
 import type { AgentName, ClientMsg, WireMsg } from "../protocol";
 import type { SessionEntry, SessionRegistry } from "./registry";
 import { runActionTool } from "./actions";
-import { listTree, readWorkspaceFile } from "./fs-explorer";
+import { capBuffer, listTree, readWorkspaceFile, sniffBinary } from "./fs-explorer";
+import { cleanRelPath, gitShowHead, gitTree } from "./git";
+import { isSecretFile } from "../security/permissions";
 import {
   ADAPTER_AGENTS,
   availableAgents,
@@ -276,6 +278,10 @@ export function openConnection(
   // Explorer throttles (E.1), one clock per request type.
   let lastFsListAt = 0;
   let lastFsReadAt = 0;
+  let lastFsDiffAt = 0;
+  // At most one git child per connection (E.2) — like the bang
+  // already-running refusal; a second request while busy errors, not queues.
+  let gitInFlight = false;
 
   // Identity first, then the replayed history, then the live stream. 4.4:
   // a valid afterSeq turns the replay into a tail-only resume — the client
@@ -567,25 +573,52 @@ export function openConnection(
           break;
         }
         lastFsListAt = Date.now();
-        // try/catch: this runs on the local WS path with no net above it —
-        // an escaped throw exits the daemon (the null-frame lesson).
-        try {
-          const r = listTree(entry.cwd);
-          if ("error" in r) {
-            treeErr(entry.cwd, r.error);
-          } else {
-            viewport({
-              type: "fs_tree",
-              id: msg.id,
-              root: entry.cwd,
-              entries: r.entries,
-              git: false, // E.2 turns this on when the root is a git repo
-              ...(r.truncated ? { truncated: true } : {}),
-            });
-          }
-        } catch (err) {
-          treeErr(entry.cwd, errText(err));
+        if (gitInFlight) {
+          treeErr(entry.cwd, "a git query is already running — retry shortly");
+          break;
         }
+        // Git's view first (E.2); not-a-repo / no-git degrades to the E.1
+        // walk. Async now, so: root captured before the await (the viewport
+        // may switch sessions under it), `closed` checked before replying,
+        // and every path caught — an escaped throw exits the daemon.
+        const root = entry.cwd;
+        gitInFlight = true;
+        void gitTree(root)
+          .then((g) => {
+            if (closed) return;
+            if ("error" in g) {
+              treeErr(root, g.error);
+            } else if ("entries" in g) {
+              viewport({
+                type: "fs_tree",
+                id: msg.id,
+                root,
+                entries: g.entries,
+                git: true,
+                ...(g.truncated ? { truncated: true } : {}),
+              });
+            } else {
+              const r = listTree(root);
+              if ("error" in r) {
+                treeErr(root, r.error);
+              } else {
+                viewport({
+                  type: "fs_tree",
+                  id: msg.id,
+                  root,
+                  entries: r.entries,
+                  git: false,
+                  ...(r.truncated ? { truncated: true } : {}),
+                });
+              }
+            }
+          })
+          .catch((err) => {
+            if (!closed) treeErr(root, errText(err));
+          })
+          .finally(() => {
+            gitInFlight = false;
+          });
         break;
       }
       case "fs_read": {
@@ -626,6 +659,102 @@ export function openConnection(
         } catch (err) {
           fileErr(msg.path, errText(err));
         }
+        break;
+      }
+      case "fs_diff": {
+        // Explorer per-file diff (E.2): before = HEAD's version, after = the
+        // working tree — the client diffs the pair; no hunk text on the wire.
+        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
+        const diffErr = (p: string, error: string) =>
+          viewport({ type: "fs_file_diff", id: msg.id, path: p, error });
+        if (typeof msg.path !== "string") {
+          diffErr("", "bad path");
+          break;
+        }
+        // Textual containment BEFORE git sees the path: `git show` resolves
+        // against the repo, not the fs, so the realpath jail can't cover it —
+        // a `../` here could read repo files above a subdirectory session.
+        const rel = cleanRelPath(msg.path);
+        if (!rel) {
+          diffErr(msg.path.slice(0, 200), "bad path");
+          break;
+        }
+        if (!entry) {
+          diffErr(rel, "no session attached");
+          break;
+        }
+        if (isSecretFile(rel)) {
+          diffErr(rel, "environment files are never readable here");
+          break;
+        }
+        if (Date.now() - lastFsDiffAt < FS_MIN_INTERVAL_MS) {
+          diffErr(rel, "requests are arriving too fast — retry shortly");
+          break;
+        }
+        lastFsDiffAt = Date.now();
+        if (gitInFlight) {
+          diffErr(rel, "a git query is already running — retry shortly");
+          break;
+        }
+        const diffRoot = entry.cwd;
+        gitInFlight = true;
+        void gitShowHead(diffRoot, rel)
+          .then((show) => {
+            if (closed) return;
+            if ("notGit" in show) {
+              diffErr(rel, "not a git repository — no diff available");
+              return;
+            }
+            if ("error" in show) {
+              diffErr(rel, show.error);
+              return;
+            }
+            const beforeBuf = "content" in show ? show.content : Buffer.alloc(0);
+            if (sniffBinary(beforeBuf)) {
+              viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
+              return;
+            }
+            // The after side. A missing working file is a REAL case (deleted
+            // → after ""), not an error — but only plain absence; an
+            // existing-but-unreadable path stays an error.
+            let after = "";
+            let afterTruncatedBytes: number | undefined;
+            let exists = true;
+            try {
+              lstatSync(path.join(diffRoot, rel));
+            } catch {
+              exists = false;
+            }
+            if (exists) {
+              const r = readWorkspaceFile(diffRoot, rel);
+              if ("error" in r) {
+                diffErr(rel, r.error);
+                return;
+              }
+              if ("binary" in r) {
+                viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
+                return;
+              }
+              after = r.content;
+              afterTruncatedBytes = r.truncatedBytes;
+            }
+            const before = capBuffer(beforeBuf);
+            viewport({
+              type: "fs_file_diff",
+              id: msg.id,
+              path: rel,
+              before: before.text,
+              after,
+              ...(before.truncatedBytes ? { beforeTruncatedBytes: before.truncatedBytes } : {}),
+              ...(afterTruncatedBytes ? { afterTruncatedBytes } : {}),
+            });
+          })
+          .catch((err) => {
+            if (!closed) diffErr(rel, errText(err));
+          })
+          .finally(() => {
+            gitInFlight = false;
+          });
         break;
       }
       case "client_error":

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import type { AgentName, ClientMsg, WireMsg } from "../protocol";
 import type { SessionEntry, SessionRegistry } from "./registry";
 import { runActionTool } from "./actions";
+import { listTree, readWorkspaceFile } from "./fs-explorer";
 import {
   ADAPTER_AGENTS,
   availableAgents,
@@ -47,6 +48,17 @@ const CWD_HANDOFF_MAX_BYTES = 4096;
 // (N.3). The picker polls every few seconds; anything faster serves the
 // cached answer instead of re-probing localhost.
 const REFRESH_MIN_INTERVAL_MS = Number(process.env.REFRESH_MIN_INTERVAL_MS ?? 1_000);
+
+// Minimum gap between Explorer requests per connection AND per type (E.1) —
+// fs_list walks the tree, so a hostile client must not turn it into a CPU
+// grinder; the per-type split keeps a legitimate list-then-read pair from
+// tripping it. Throttled requests still get a reply (an error), never
+// silence — the client's request/reply correlation must always resolve.
+const FS_MIN_INTERVAL_MS = Number(process.env.FS_MIN_INTERVAL_MS ?? 250);
+
+// Same shape rule as bang ids: client-minted correlation ids are short and
+// word-safe or the message is dropped whole.
+const FS_ID_RE = /^[\w-]{1,64}$/;
 
 /**
  * The transcript is fenced by <bash-input>/<bash-output>; output that itself
@@ -261,6 +273,9 @@ export function openConnection(
   // hostile client could spam — bound the probe rate per connection. A
   // throttled refresh still answers, from the cache.
   let lastProbeAt = 0;
+  // Explorer throttles (E.1), one clock per request type.
+  let lastFsListAt = 0;
+  let lastFsReadAt = 0;
 
   // Identity first, then the replayed history, then the live stream. 4.4:
   // a valid afterSeq turns the replay into a tail-only resume — the client
@@ -534,6 +549,85 @@ export function openConnection(
           if (!closed) sendAgents();
         });
         break;
+      case "fs_list": {
+        // Explorer tree query (E.1) — answered on THIS connection only, like
+        // pong/sessions: disk state is a query, not session history, so it
+        // must never enter the broadcast stream or the replay ring. A bad id
+        // drops the message whole (nothing to correlate a reply to); every
+        // well-formed request gets exactly one reply.
+        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
+        const treeErr = (root: string, error: string) =>
+          viewport({ type: "fs_tree", id: msg.id, root, entries: [], git: false, error });
+        if (!entry) {
+          treeErr("", "no session attached");
+          break;
+        }
+        if (Date.now() - lastFsListAt < FS_MIN_INTERVAL_MS) {
+          treeErr(entry.cwd, "requests are arriving too fast — retry shortly");
+          break;
+        }
+        lastFsListAt = Date.now();
+        // try/catch: this runs on the local WS path with no net above it —
+        // an escaped throw exits the daemon (the null-frame lesson).
+        try {
+          const r = listTree(entry.cwd);
+          if ("error" in r) {
+            treeErr(entry.cwd, r.error);
+          } else {
+            viewport({
+              type: "fs_tree",
+              id: msg.id,
+              root: entry.cwd,
+              entries: r.entries,
+              git: false, // E.2 turns this on when the root is a git repo
+              ...(r.truncated ? { truncated: true } : {}),
+            });
+          }
+        } catch (err) {
+          treeErr(entry.cwd, errText(err));
+        }
+        break;
+      }
+      case "fs_read": {
+        // Explorer file read (E.1) — same per-viewport reply rules as
+        // fs_list; the path is validated raw here and jailed in the module.
+        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
+        const fileErr = (p: string, error: string) =>
+          viewport({ type: "fs_file", id: msg.id, path: p, error });
+        if (typeof msg.path !== "string" || msg.path.length === 0 || msg.path.length > 4_096) {
+          fileErr("", "bad path");
+          break;
+        }
+        if (!entry) {
+          fileErr(msg.path, "no session attached");
+          break;
+        }
+        if (Date.now() - lastFsReadAt < FS_MIN_INTERVAL_MS) {
+          fileErr(msg.path, "requests are arriving too fast — retry shortly");
+          break;
+        }
+        lastFsReadAt = Date.now();
+        try {
+          const r = readWorkspaceFile(entry.cwd, msg.path);
+          if ("error" in r) {
+            fileErr(msg.path, r.error);
+          } else if ("binary" in r) {
+            viewport({ type: "fs_file", id: msg.id, path: msg.path, binary: true, size: r.size });
+          } else {
+            viewport({
+              type: "fs_file",
+              id: msg.id,
+              path: msg.path,
+              content: r.content,
+              size: r.size,
+              ...(r.truncatedBytes ? { truncatedBytes: r.truncatedBytes } : {}),
+            });
+          }
+        } catch (err) {
+          fileErr(msg.path, errText(err));
+        }
+        break;
+      }
       case "client_error":
         // The browser half's uncaught errors, landing in the flight-recorder
         // log so a front-end crash leaves a trace a bug report can attach.

--- a/server/sessions/fs-explorer.itest.ts
+++ b/server/sessions/fs-explorer.itest.ts
@@ -1,0 +1,149 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ClientMsg, WireMsg } from "../protocol";
+import { startDaemon, TestClient, type Daemon } from "../testing/itest-harness";
+
+// E.1 over a REAL daemon and socket: the fs_list/fs_read round-trip against a
+// scripted temp workspace, the jail + secret denial refusing with error
+// REPLIES (daemon alive after every attempt), the per-type throttle answering
+// instead of dropping, the no-session case, and a deleted session root.
+// Replies must be per-viewport: no seq, ever.
+
+type Any = WireMsg & Record<string, any>;
+
+let d: Daemon;
+let ws: string; // the session workspace
+let outside: string; // where the planted symlink points
+
+// The throttle window under test — small so the suite stays fast, real so
+// the burst case actually trips it.
+const THROTTLE_MS = 150;
+const settle = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const openSession = async (cwd: string) => {
+  const c = new TestClient(d.port);
+  await c.opened();
+  await c.type("agents");
+  c.send({ type: "create", agent: "claude-code", cwd } as ClientMsg);
+  await c.type("session_created");
+  return c;
+};
+
+before(async () => {
+  ws = mkdtempSync(path.join(os.tmpdir(), "fsx-ws-"));
+  outside = mkdtempSync(path.join(os.tmpdir(), "fsx-out-"));
+  mkdirSync(path.join(ws, "src"));
+  mkdirSync(path.join(ws, "node_modules"));
+  writeFileSync(path.join(ws, "README.md"), "# readme\n");
+  writeFileSync(path.join(ws, "src", "app.ts"), "export {};\n");
+  writeFileSync(path.join(ws, ".env"), "SECRET=1\n");
+  writeFileSync(path.join(ws, "node_modules", "x.js"), "never listed");
+  writeFileSync(path.join(ws, "img.bin"), Buffer.from([1, 0, 2]));
+  writeFileSync(path.join(outside, "loot.txt"), "outside\n");
+  symlinkSync(path.join(outside, "loot.txt"), path.join(ws, "innocent.txt"));
+  d = await startDaemon({ FS_MIN_INTERVAL_MS: String(THROTTLE_MS) });
+});
+after(async () => {
+  await d.stop();
+  rmSync(ws, { recursive: true, force: true });
+  rmSync(outside, { recursive: true, force: true });
+});
+
+test("E.1: fs_list round-trips the workspace tree, per-viewport (no seq)", async () => {
+  const c = await openSession(ws);
+  c.send({ type: "fs_list", id: "t1" } as ClientMsg);
+  const tree = (await c.waitFor((m) => m.type === "fs_tree", "fs_tree")) as Any;
+  assert.equal(tree.id, "t1");
+  assert.equal(tree.git, false);
+  assert.equal(tree.error, undefined);
+  assert.ok(!("seq" in tree), "per-viewport replies are never sequenced");
+  const paths = (tree.entries as { path: string }[]).map((e) => e.path);
+  assert.deepEqual(paths, [".env", "README.md", "img.bin", "innocent.txt", "src/app.ts"]);
+  // .env LISTED (honesty over hiding), node_modules pruned, symlink a leaf.
+  c.close();
+});
+
+test("E.1: fs_read serves content; jail and secret denial answer with error replies; daemon lives", async () => {
+  const c = await openSession(ws);
+  const read = async (id: string, p: string) => {
+    await settle(THROTTLE_MS + 30);
+    c.send({ type: "fs_read", id, path: p } as ClientMsg);
+    return (await c.waitFor((m) => m.type === "fs_file" && (m as Any).id === id, `fs_file ${id}`)) as Any;
+  };
+
+  const ok = await read("r1", "README.md");
+  assert.equal(ok.content, "# readme\n");
+  assert.equal(ok.size, 9);
+  assert.ok(!("seq" in ok));
+
+  const secret = await read("r2", ".env");
+  assert.equal(typeof secret.error, "string");
+  assert.equal(secret.content, undefined, "denied content never rides an error reply");
+
+  const escape = await read("r3", "../" + path.basename(outside) + "/loot.txt");
+  assert.equal(typeof escape.error, "string");
+
+  const absolute = await read("r4", path.join(outside, "loot.txt"));
+  assert.equal(typeof absolute.error, "string");
+
+  const symlinkOut = await read("r5", "innocent.txt");
+  assert.equal(typeof symlinkOut.error, "string", "a planted symlink can't read outside the root");
+
+  const binary = await read("r6", "img.bin");
+  assert.equal(binary.binary, true);
+  assert.equal(binary.content, undefined);
+  assert.equal(binary.size, 3);
+
+  // Every refusal above left the daemon standing: a real read still works.
+  const alive = await read("r7", "src/app.ts");
+  assert.equal(alive.content, "export {};\n");
+  assert.doesNotMatch(d.logs(), /crashed \(uncaughtException\)/);
+  c.close();
+});
+
+test("E.1: a burst is throttled but ANSWERED — then works again past the window", async () => {
+  const c = await openSession(ws);
+  c.send({ type: "fs_list", id: "b1" } as ClientMsg);
+  c.send({ type: "fs_list", id: "b2" } as ClientMsg);
+  const first = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b1", "b1")) as Any;
+  const second = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b2", "b2")) as Any;
+  assert.equal(first.error, undefined);
+  assert.match(String(second.error), /too fast/);
+  await settle(THROTTLE_MS + 30);
+  c.send({ type: "fs_list", id: "b3" } as ClientMsg);
+  const third = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b3", "b3")) as Any;
+  assert.equal(third.error, undefined);
+  c.close();
+});
+
+test("E.1: no session attached — both queries answer with an error reply, not silence", async () => {
+  const c = new TestClient(d.port);
+  await c.opened();
+  await c.type("agents"); // connected, but never created/attached
+  c.send({ type: "fs_list", id: "n1" } as ClientMsg);
+  const tree = (await c.waitFor((m) => m.type === "fs_tree", "fs_tree")) as Any;
+  assert.match(String(tree.error), /no session/);
+  c.send({ type: "fs_read", id: "n2", path: "README.md" } as ClientMsg);
+  const file = (await c.waitFor((m) => m.type === "fs_file", "fs_file")) as Any;
+  assert.match(String(file.error), /no session/);
+  c.close();
+});
+
+test("E.1: a session root deleted after create errors cleanly, never crashes", async () => {
+  const doomed = mkdtempSync(path.join(os.tmpdir(), "fsx-doomed-"));
+  writeFileSync(path.join(doomed, "a.txt"), "a");
+  const c = await openSession(doomed);
+  rmSync(doomed, { recursive: true, force: true });
+  c.send({ type: "fs_list", id: "d1" } as ClientMsg);
+  const tree = (await c.waitFor((m) => m.type === "fs_tree", "fs_tree")) as Any;
+  assert.equal(typeof tree.error, "string");
+  await settle(THROTTLE_MS + 30);
+  c.send({ type: "fs_read", id: "d2", path: "a.txt" } as ClientMsg);
+  const file = (await c.waitFor((m) => m.type === "fs_file", "fs_file")) as Any;
+  assert.equal(typeof file.error, "string");
+  assert.doesNotMatch(d.logs(), /crashed \(uncaughtException\)/);
+  c.close();
+});

--- a/server/sessions/fs-explorer.itest.ts
+++ b/server/sessions/fs-explorer.itest.ts
@@ -108,10 +108,15 @@ test("E.1: a burst is throttled but ANSWERED — then works again past the windo
   const c = await openSession(ws);
   c.send({ type: "fs_list", id: "b1" } as ClientMsg);
   c.send({ type: "fs_list", id: "b2" } as ClientMsg);
-  const first = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b1", "b1")) as Any;
-  const second = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b2", "b2")) as Any;
-  assert.equal(first.error, undefined);
-  assert.match(String(second.error), /too fast/);
+  // Since E.2 the served reply is async (git) while the throttle error is
+  // sync — b2's error legitimately arrives BEFORE b1's tree. Correlate by
+  // echoed id, never by arrival order: that's the wire contract.
+  const first = (await c.waitFor((m) => m.type === "fs_tree", "first fs_tree")) as Any;
+  const second = (await c.waitFor((m) => m.type === "fs_tree", "second fs_tree")) as Any;
+  const byId = new Map<string, Any>([first, second].map((m) => [m.id, m]));
+  assert.ok(byId.has("b1") && byId.has("b2"), "one reply per request");
+  assert.equal(byId.get("b1")!.error, undefined);
+  assert.match(String(byId.get("b2")!.error), /too fast/);
   await settle(THROTTLE_MS + 30);
   c.send({ type: "fs_list", id: "b3" } as ClientMsg);
   const third = (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === "b3", "b3")) as Any;

--- a/server/sessions/fs-explorer.test.ts
+++ b/server/sessions/fs-explorer.test.ts
@@ -1,0 +1,156 @@
+import { test, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { listTree, readWorkspaceFile } from "./fs-explorer";
+
+// E.1's module contract, on real temp directories: the walk's shape and caps,
+// the jail, the secret denial, and the read's binary/truncation/UTF-8 honesty.
+
+const madeDirs: string[] = [];
+const tmp = () => {
+  const d = mkdtempSync(path.join(os.tmpdir(), "fsx-"));
+  madeDirs.push(d);
+  return d;
+};
+
+after(() => {
+  for (const d of madeDirs) rmSync(d, { recursive: true, force: true });
+});
+
+test("listTree: nested files as /-relative paths, alphabetical per dir, skip dirs pruned", () => {
+  const root = tmp();
+  mkdirSync(path.join(root, "src", "deep"), { recursive: true });
+  mkdirSync(path.join(root, ".git"));
+  mkdirSync(path.join(root, "node_modules", "pkg"), { recursive: true });
+  writeFileSync(path.join(root, "zz.txt"), "z");
+  writeFileSync(path.join(root, "README.md"), "r");
+  writeFileSync(path.join(root, "src", "app.ts"), "a");
+  writeFileSync(path.join(root, "src", "deep", "x.ts"), "x");
+  writeFileSync(path.join(root, ".git", "HEAD"), "ref");
+  writeFileSync(path.join(root, "node_modules", "pkg", "index.js"), "m");
+  const r = listTree(root);
+  assert.ok(!("error" in r));
+  assert.deepEqual(
+    r.entries.map((e) => e.path),
+    ["README.md", "src/app.ts", "src/deep/x.ts", "zz.txt"],
+  );
+  assert.equal(r.truncated, false);
+});
+
+test("listTree: a symlink is a leaf — even to a directory, it is never followed", () => {
+  const root = tmp();
+  mkdirSync(path.join(root, "real"));
+  writeFileSync(path.join(root, "real", "inner.txt"), "i");
+  symlinkSync(path.join(root, "real"), path.join(root, "link"));
+  const r = listTree(root);
+  assert.ok(!("error" in r));
+  const paths = r.entries.map((e) => e.path);
+  assert.ok(paths.includes("link"), "the symlink itself is listed");
+  assert.ok(!paths.includes("link/inner.txt"), "the link's target is not recursed into");
+  assert.ok(paths.includes("real/inner.txt"), "the real directory still walks");
+});
+
+test("listTree: entry cap trips honestly", () => {
+  const root = tmp();
+  for (let i = 0; i < 5; i++) writeFileSync(path.join(root, `f${i}.txt`), "x");
+  const r = listTree(root, { maxEntries: 3 });
+  assert.ok(!("error" in r));
+  assert.equal(r.entries.length, 3);
+  assert.equal(r.truncated, true);
+});
+
+test("listTree: path-byte cap trips honestly", () => {
+  const root = tmp();
+  for (let i = 0; i < 5; i++) writeFileSync(path.join(root, `file-with-a-name-${i}.txt`), "x");
+  const r = listTree(root, { maxPathBytes: 50 });
+  assert.ok(!("error" in r));
+  assert.equal(r.truncated, true);
+  assert.ok(r.entries.length < 5);
+});
+
+test("listTree: unreadable root is the error case, not a throw", () => {
+  const r = listTree(path.join(os.tmpdir(), "fsx-does-not-exist-ever"));
+  assert.ok("error" in r);
+});
+
+test("readWorkspaceFile: content round-trip with size", () => {
+  const root = tmp();
+  writeFileSync(path.join(root, "a.txt"), "hello mirafold\n");
+  const r = readWorkspaceFile(root, "a.txt");
+  assert.ok("content" in r);
+  assert.equal(r.content, "hello mirafold\n");
+  assert.equal(r.size, 15);
+  assert.equal(r.truncatedBytes, undefined);
+});
+
+test("readWorkspaceFile: the jail — ../, absolute, and symlink-out all refuse", () => {
+  const root = tmp();
+  const outside = tmp();
+  writeFileSync(path.join(outside, "loot.txt"), "outside");
+  symlinkSync(path.join(outside, "loot.txt"), path.join(root, "innocent.txt"));
+  for (const p of ["../loot.txt", path.join(outside, "loot.txt"), "innocent.txt"]) {
+    const r = readWorkspaceFile(root, p);
+    assert.ok("error" in r, `${p} must refuse`);
+  }
+});
+
+test("readWorkspaceFile: secret env files refuse by basename, anywhere in the tree", () => {
+  const root = tmp();
+  mkdirSync(path.join(root, "sub"));
+  writeFileSync(path.join(root, ".env"), "SECRET=1");
+  writeFileSync(path.join(root, "sub", ".env.local"), "SECRET=2");
+  writeFileSync(path.join(root, "sub", "envy.txt"), "fine");
+  assert.ok("error" in readWorkspaceFile(root, ".env"));
+  assert.ok("error" in readWorkspaceFile(root, "sub/.env.local"));
+  assert.ok("content" in readWorkspaceFile(root, "sub/envy.txt"));
+  // Listing still SHOWS them — honesty over hiding; only content is refused.
+  const tree = listTree(root);
+  assert.ok(!("error" in tree));
+  assert.ok(tree.entries.some((e) => e.path === ".env"));
+});
+
+test("readWorkspaceFile: a directory and a missing file are errors", () => {
+  const root = tmp();
+  mkdirSync(path.join(root, "d"));
+  assert.ok("error" in readWorkspaceFile(root, "d"));
+  assert.ok("error" in readWorkspaceFile(root, "nope.txt"));
+});
+
+test("readWorkspaceFile: NUL sniff marks binary and withholds content", () => {
+  const root = tmp();
+  writeFileSync(path.join(root, "img.png"), Buffer.from([0x89, 0x50, 0x00, 0x47, 0x0d]));
+  const r = readWorkspaceFile(root, "img.png");
+  assert.ok("binary" in r && r.binary === true);
+  assert.equal(r.size, 5);
+  assert.ok(!("content" in r));
+});
+
+test("readWorkspaceFile: cap is honest — truncatedBytes = size minus kept", () => {
+  const root = tmp();
+  writeFileSync(path.join(root, "big.txt"), "a".repeat(100_000));
+  const r = readWorkspaceFile(root, "big.txt");
+  assert.ok("content" in r);
+  assert.equal(Buffer.byteLength(r.content, "utf8"), 64_000);
+  assert.equal(r.size, 100_000);
+  assert.equal(r.truncatedBytes, 36_000);
+});
+
+test("readWorkspaceFile: invalid UTF-8 decodes lossily, never throws", () => {
+  const root = tmp();
+  writeFileSync(path.join(root, "weird.txt"), Buffer.from([0x68, 0x69, 0xff, 0xfe, 0x21]));
+  const r = readWorkspaceFile(root, "weird.txt");
+  assert.ok("content" in r);
+  assert.ok(r.content.startsWith("hi"));
+  assert.ok(r.content.includes("�"));
+});
+
+test("readWorkspaceFile: empty file is empty content, not an error", () => {
+  const root = tmp();
+  writeFileSync(path.join(root, "empty.txt"), "");
+  const r = readWorkspaceFile(root, "empty.txt");
+  assert.ok("content" in r);
+  assert.equal(r.content, "");
+  assert.equal(r.size, 0);
+});

--- a/server/sessions/fs-explorer.ts
+++ b/server/sessions/fs-explorer.ts
@@ -34,6 +34,19 @@ const SKIP_DIRS = new Set([".git", "node_modules"]);
 const SNIFF_BYTES = 8_192;
 const FS_FILE_CAP_BYTES = Number(process.env.FS_FILE_CAP_BYTES ?? 64_000);
 
+/** NUL in the sniff window = binary. E.2 applies the same rule to git blobs
+ *  (the fd path below sniffs its own window the same way). */
+export const sniffBinary = (buf: Buffer): boolean =>
+  buf.subarray(0, Math.min(buf.length, SNIFF_BYTES)).includes(0);
+
+/** Cap an in-memory blob (a `git show` result) to the file cap with the same
+ *  honesty contract as the fd read path: lossy decode, byte-true elision. */
+export function capBuffer(buf: Buffer): { text: string; truncatedBytes?: number } {
+  const kept = buf.subarray(0, Math.min(buf.length, FS_FILE_CAP_BYTES));
+  const text = new TextDecoder().decode(kept);
+  return { text, ...(buf.length > kept.length ? { truncatedBytes: buf.length - kept.length } : {}) };
+}
+
 export type TreeResult = { entries: FsEntry[]; truncated: boolean } | { error: string };
 
 export type FileResult =

--- a/server/sessions/fs-explorer.ts
+++ b/server/sessions/fs-explorer.ts
@@ -1,0 +1,138 @@
+// The Explorer's server half (Phase E.1): the shell's read-only view of a
+// session's working tree — the tree walk behind `fs_list` and the file read
+// behind `fs_read`. Everything resolves through `inside()`'s realpath
+// containment against the session root (a planted symlink can't walk out)
+// with the secret-env denial layered on top. Results are per-viewport
+// replies; nothing here is broadcast, buffered, or replayed. Deliberately
+// synchronous (the workspace_ls precedent): every walk and read is capped,
+// so no call holds the event loop meaningfully — and sync means the reply
+// can never race a closed socket.
+
+import { closeSync, openSync, readdirSync, readSync, statSync } from "node:fs";
+import path from "node:path";
+import type { FsEntry } from "../protocol";
+import { inside } from "./actions";
+import { isSecretFile } from "../security/permissions";
+
+// Walk caps. The whole fs_tree reply must stay far under MAX_WS_PAYLOAD
+// (1 MB inbound; replies should honor the same order of magnitude — the
+// relay envelope allows 1.5×) even on a monorepo, and JSON escaping can
+// inflate exotic filenames — so the cap is on entry COUNT and path BYTES
+// both. Honest: `truncated: true`, never a silent cut.
+const FS_TREE_MAX_ENTRIES = Number(process.env.FS_TREE_MAX_ENTRIES ?? 4_000);
+const FS_TREE_MAX_PATH_BYTES = Number(process.env.FS_TREE_MAX_PATH_BYTES ?? 400_000);
+
+// Directories nobody browses that would drown the tree (and blow the caps
+// instantly). E.2's git view gets this pruning for free via .gitignore;
+// this is the non-repo walk's equivalent floor.
+const SKIP_DIRS = new Set([".git", "node_modules"]);
+
+// A file read is bounded twice: the sniff window that decides binary vs
+// text, and the content cap — same size and same honesty contract as the
+// tool_result cap (TOOL_OUTPUT_CAP_BYTES), but applied via bounded fd reads
+// so a multi-GB file never gets loaded to be truncated.
+const SNIFF_BYTES = 8_192;
+const FS_FILE_CAP_BYTES = Number(process.env.FS_FILE_CAP_BYTES ?? 64_000);
+
+export type TreeResult = { entries: FsEntry[]; truncated: boolean } | { error: string };
+
+export type FileResult =
+  | { content: string; size: number; truncatedBytes?: number }
+  | { binary: true; size: number }
+  | { error: string };
+
+/**
+ * Walk the session root and return every FILE as a root-relative /-separated
+ * path, alphabetical within each directory. Symlinks are leaves — never
+ * followed, even when they point at directories, so a link can't graft an
+ * outside tree (or a cycle) into the listing. Unreadable subdirectories are
+ * skipped, not fatal; an unreadable ROOT is the error case.
+ */
+export function listTree(
+  root: string,
+  caps: { maxEntries?: number; maxPathBytes?: number } = {},
+): TreeResult {
+  const maxEntries = caps.maxEntries ?? FS_TREE_MAX_ENTRIES;
+  const maxPathBytes = caps.maxPathBytes ?? FS_TREE_MAX_PATH_BYTES;
+  const realRoot = inside(root, ".");
+  if (!realRoot) return { error: "the session workspace is not readable" };
+  const entries: FsEntry[] = [];
+  let pathBytes = 0;
+  let truncated = false;
+  const walk = (dir: string, relPrefix: string) => {
+    if (truncated) return;
+    let dirents;
+    try {
+      dirents = readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return; // unreadable subdir: skip it, keep the rest of the tree
+    }
+    dirents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    for (const d of dirents) {
+      if (truncated) return;
+      const rel = relPrefix ? `${relPrefix}/${d.name}` : d.name;
+      // Dirent types come from lstat semantics: a symlink-to-dir reports as
+      // a symlink (not a directory), which is exactly the leaf rule.
+      if (d.isDirectory()) {
+        if (!SKIP_DIRS.has(d.name)) walk(path.join(dir, d.name), rel);
+        continue;
+      }
+      if (entries.length >= maxEntries || pathBytes + rel.length > maxPathBytes) {
+        truncated = true;
+        return;
+      }
+      entries.push({ path: rel });
+      pathBytes += Buffer.byteLength(rel, "utf8");
+    }
+  };
+  walk(realRoot, "");
+  return { entries, truncated };
+}
+
+/**
+ * Read one workspace file for the viewer: jailed, secret-denied, binary-
+ * sniffed, cap-honest. `rel` is the client's requested root-relative path —
+ * a REQUEST, never trusted: it resolves through `inside()` or not at all.
+ */
+export function readWorkspaceFile(root: string, rel: string): FileResult {
+  const real = inside(root, rel);
+  if (!real) return { error: "path is outside the session workspace" };
+  if (isSecretFile(real)) return { error: "environment files are never readable here" };
+  let st;
+  try {
+    st = statSync(real);
+  } catch {
+    return { error: "file is not readable" };
+  }
+  if (st.isDirectory()) return { error: "path is a directory" };
+  // A FIFO/socket would stall a read and, with it, the daemon's event loop —
+  // the same lesson as the cwd-handoff lstat gate.
+  if (!st.isFile()) return { error: "not a regular file" };
+  const size = st.size;
+  let fd;
+  try {
+    fd = openSync(real, "r");
+  } catch {
+    return { error: "file is not readable" };
+  }
+  try {
+    const sniffLen = Math.min(size, SNIFF_BYTES);
+    const sniff = Buffer.alloc(sniffLen);
+    const sniffed = readSync(fd, sniff, 0, sniffLen, 0);
+    if (sniff.subarray(0, sniffed).includes(0)) return { binary: true, size };
+    const keptLen = Math.min(size, FS_FILE_CAP_BYTES);
+    const buf = Buffer.alloc(keptLen);
+    let read = 0;
+    while (read < keptLen) {
+      const n = readSync(fd, buf, read, keptLen - read, read);
+      if (n <= 0) break; // file shrank under us — keep what's real
+      read += n;
+    }
+    // Lossy decode: invalid UTF-8 (and a cap-split trailing char) becomes
+    // U+FFFD rather than an error — same behavior as capOutput's slice.
+    const content = new TextDecoder().decode(buf.subarray(0, read));
+    return { content, size, ...(size > read ? { truncatedBytes: size - read } : {}) };
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/server/sessions/fs-git.itest.ts
+++ b/server/sessions/fs-git.itest.ts
@@ -1,0 +1,167 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ClientMsg, WireMsg } from "../protocol";
+import { startDaemon, TestClient, type Daemon } from "../testing/itest-harness";
+
+// E.2 against a REAL daemon and a scripted temp repo: git's view of the tree
+// (tracked + untracked, ignored excluded, statuses collapsed, staged deletes
+// kept visible), the before/after diff for modified/added/deleted/renamed
+// files, the SUBDIRECTORY-session path relativity trap, and the unborn-HEAD
+// degrade. The non-repo fallback is pinned by fs-explorer.itest.ts.
+
+type Any = WireMsg & Record<string, any>;
+
+const THROTTLE_MS = 150;
+const settle = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+const git = (cwd: string, ...args: string[]) =>
+  execFileSync(
+    "git",
+    ["-C", cwd, "-c", "user.email=t@t.t", "-c", "user.name=t", "-c", "commit.gpgsign=false", ...args],
+    { stdio: "pipe" },
+  );
+
+let d: Daemon;
+let repo: string;
+let unborn: string;
+
+const openSession = async (cwd: string) => {
+  const c = new TestClient(d.port);
+  await c.opened();
+  await c.type("agents");
+  c.send({ type: "create", agent: "claude-code", cwd } as ClientMsg);
+  await c.type("session_created");
+  return c;
+};
+
+const fsList = async (c: TestClient, id: string) => {
+  await settle(THROTTLE_MS + 30);
+  c.send({ type: "fs_list", id } as ClientMsg);
+  return (await c.waitFor((m) => m.type === "fs_tree" && (m as Any).id === id, `fs_tree ${id}`)) as Any;
+};
+
+const fsDiff = async (c: TestClient, id: string, p: string) => {
+  await settle(THROTTLE_MS + 30);
+  c.send({ type: "fs_diff", id, path: p } as ClientMsg);
+  return (await c.waitFor(
+    (m) => m.type === "fs_file_diff" && (m as Any).id === id,
+    `fs_file_diff ${id}`,
+  )) as Any;
+};
+
+before(async () => {
+  // The scripted repo: commit a baseline, then produce one of every change
+  // shape — modified, untracked, unstaged delete, staged rename, ignored,
+  // and a modified file inside a subdirectory (the prefix-strip case).
+  repo = mkdtempSync(path.join(os.tmpdir(), "fsg-repo-"));
+  git(repo, "init", "-q");
+  mkdirSync(path.join(repo, "sub"));
+  writeFileSync(path.join(repo, "tracked.txt"), "one\n");
+  writeFileSync(path.join(repo, "gone.txt"), "bye\n");
+  writeFileSync(path.join(repo, "moveme.txt"), "movable\n");
+  writeFileSync(path.join(repo, "sub", "inner.txt"), "inner-one\n");
+  writeFileSync(path.join(repo, ".gitignore"), "ignored.txt\n");
+  git(repo, "add", "-A");
+  git(repo, "commit", "-q", "-m", "c1");
+  writeFileSync(path.join(repo, "tracked.txt"), "one\ntwo\n");
+  writeFileSync(path.join(repo, "untracked.txt"), "new\n");
+  writeFileSync(path.join(repo, "ignored.txt"), "invisible\n");
+  writeFileSync(path.join(repo, "sub", "inner.txt"), "inner-two\n");
+  unlinkSync(path.join(repo, "gone.txt"));
+  git(repo, "mv", "moveme.txt", "moved.txt");
+
+  // A repo with no commits: HEAD is unborn, everything is untracked.
+  unborn = mkdtempSync(path.join(os.tmpdir(), "fsg-unborn-"));
+  git(unborn, "init", "-q");
+  writeFileSync(path.join(unborn, "fresh.txt"), "fresh\n");
+
+  d = await startDaemon({ FS_MIN_INTERVAL_MS: String(THROTTLE_MS) });
+});
+after(async () => {
+  await d.stop();
+  rmSync(repo, { recursive: true, force: true });
+  rmSync(unborn, { recursive: true, force: true });
+});
+
+test("E.2: fs_list is git's view — statuses collapsed, ignored excluded, staged delete visible", async () => {
+  const c = await openSession(repo);
+  const tree = await fsList(c, "g1");
+  assert.equal(tree.error, undefined);
+  assert.equal(tree.git, true);
+  const by = new Map((tree.entries as Any[]).map((e) => [e.path, e.status]));
+  assert.equal(by.get("tracked.txt"), "M");
+  assert.equal(by.get("untracked.txt"), "U");
+  assert.equal(by.get("gone.txt"), "D", "an unstaged delete stays listed");
+  assert.equal(by.get("moved.txt"), "A", "rename target");
+  assert.equal(by.get("moveme.txt"), "D", "rename source, merged from status-only paths");
+  assert.equal(by.get("sub/inner.txt"), "M");
+  assert.equal(by.get(".gitignore"), undefined, "unchanged tracked file carries no status");
+  assert.ok(by.has(".gitignore"));
+  assert.ok(!by.has("ignored.txt"), "gitignored files are git's view — not listed");
+  assert.ok(![...by.keys()].some((p) => (p as string).startsWith(".git/")));
+  // Deterministic order.
+  const paths = (tree.entries as Any[]).map((e) => e.path);
+  assert.deepEqual(paths, [...paths].sort());
+  c.close();
+});
+
+test("E.2: diffs — modified, added, deleted, rename target", async () => {
+  const c = await openSession(repo);
+  const mod = await fsDiff(c, "d1", "tracked.txt");
+  assert.equal(mod.before, "one\n");
+  assert.equal(mod.after, "one\ntwo\n");
+  assert.ok(!("seq" in mod));
+
+  const added = await fsDiff(c, "d2", "untracked.txt");
+  assert.equal(added.before, "", "absent in HEAD diffs against empty");
+  assert.equal(added.after, "new\n");
+
+  const deleted = await fsDiff(c, "d3", "gone.txt");
+  assert.equal(deleted.before, "bye\n");
+  assert.equal(deleted.after, "", "deleted diffs to empty — not an error");
+
+  const renamed = await fsDiff(c, "d4", "moved.txt");
+  assert.equal(renamed.before, "");
+  assert.equal(renamed.after, "movable\n");
+
+  const secret = await fsDiff(c, "d5", ".env");
+  assert.equal(typeof secret.error, "string", "env files refuse diffs too");
+
+  const escape = await fsDiff(c, "d6", "../outside.txt");
+  assert.equal(typeof escape.error, "string", "textual containment before git sees the path");
+  c.close();
+});
+
+test("E.2: a session rooted in a repo SUBDIRECTORY labels statuses and diffs correctly", async () => {
+  const c = await openSession(path.join(repo, "sub"));
+  const tree = await fsList(c, "s1");
+  assert.equal(tree.git, true);
+  const by = new Map((tree.entries as Any[]).map((e) => [e.path, e.status]));
+  assert.equal(by.get("inner.txt"), "M", "porcelain's repo-root path is prefix-stripped");
+  assert.ok(!by.has("sub/inner.txt"));
+  assert.ok(!by.has("tracked.txt"), "changes outside the session subtree are not its story");
+
+  const diff = await fsDiff(c, "s2", "inner.txt");
+  assert.equal(diff.before, "inner-one\n");
+  assert.equal(diff.after, "inner-two\n");
+  c.close();
+});
+
+test("E.2: unborn HEAD — tree works, everything diffs against empty, never crashes", async () => {
+  const c = await openSession(unborn);
+  const tree = await fsList(c, "u1");
+  assert.equal(tree.git, true);
+  const by = new Map((tree.entries as Any[]).map((e) => [e.path, e.status]));
+  assert.equal(by.get("fresh.txt"), "U");
+
+  const diff = await fsDiff(c, "u2", "fresh.txt");
+  assert.equal(diff.error, undefined);
+  assert.equal(diff.before, "");
+  assert.equal(diff.after, "fresh\n");
+  assert.doesNotMatch(d.logs(), /crashed \(uncaughtException\)/);
+  c.close();
+});

--- a/server/sessions/git.test.ts
+++ b/server/sessions/git.test.ts
@@ -1,0 +1,58 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { cleanRelPath, parseStatusZ } from "./git";
+
+// E.2's pure parsing pins: the -z rename two-field trap, status collapsing,
+// and the textual path containment that guards `git show`.
+
+test("parseStatusZ: plain records collapse to single chars", () => {
+  const m = parseStatusZ("M  a.txt\0?? new.txt\0 D gone.txt\0A  staged.txt\0 M work.txt\0");
+  assert.equal(m.get("a.txt"), "M");
+  assert.equal(m.get("new.txt"), "U");
+  assert.equal(m.get("gone.txt"), "D");
+  assert.equal(m.get("staged.txt"), "A");
+  assert.equal(m.get("work.txt"), "M");
+});
+
+test("parseStatusZ: a rename record is TWO fields — later records stay aligned", () => {
+  // R: `XY to\0from\0`. A naive one-field split would read `old.txt` as a
+  // record and misparse everything after it.
+  const m = parseStatusZ("R  new-name.txt\0old-name.txt\0M  after-the-rename.txt\0");
+  assert.equal(m.get("new-name.txt"), "A");
+  assert.equal(m.get("old-name.txt"), "D");
+  assert.equal(m.get("after-the-rename.txt"), "M", "alignment survives the rename record");
+});
+
+test("parseStatusZ: a copy's source is NOT marked deleted", () => {
+  const m = parseStatusZ("C  copy.txt\0source.txt\0");
+  assert.equal(m.get("copy.txt"), "A");
+  assert.equal(m.get("source.txt"), undefined, "the copy source still exists unchanged");
+});
+
+test("parseStatusZ: trailing empty field and junk are ignored", () => {
+  const m = parseStatusZ("M  a.txt\0\0x\0");
+  assert.equal(m.size, 1);
+});
+
+test("cleanRelPath: accepts plain relative paths, normalizes ./", () => {
+  assert.equal(cleanRelPath("src/app.ts"), "src/app.ts");
+  assert.equal(cleanRelPath("./src/app.ts"), "src/app.ts");
+  assert.equal(cleanRelPath("a"), "a");
+});
+
+test("cleanRelPath: rejects traversal, absolute, empty, backslash, NUL, oversized", () => {
+  for (const bad of [
+    "../loot",
+    "a/../b",
+    "..",
+    "/etc/passwd",
+    "",
+    "a//b",
+    "a\\b",
+    "a\0b",
+    ".",
+    "x".repeat(5_000),
+  ]) {
+    assert.equal(cleanRelPath(bad), null, JSON.stringify(bad));
+  }
+});

--- a/server/sessions/git.ts
+++ b/server/sessions/git.ts
@@ -1,0 +1,176 @@
+// The Explorer's git layer (Phase E.2): one-shot, bounded `git` invocations
+// for the session root — the tracked+untracked tree with change status
+// behind `fs_list`, and HEAD's version of a file behind `fs_diff`. Every
+// call is execFile (no shell), timeboxed, buffer-capped, and settles to a
+// TYPED result — "not a repo" and "no git binary" are ordinary degrade
+// values, never throws, so a non-repo workspace falls back to the walk.
+// Nothing here touches the wire or the registry; connection.ts composes.
+
+import { execFile } from "node:child_process";
+import path from "node:path";
+import type { FsEntry } from "../protocol";
+
+const GIT_TIMEOUT_MS = Number(process.env.FS_GIT_TIMEOUT_MS ?? 5_000);
+// `git show` of a big blob is the largest legitimate output; the caller caps
+// content for the wire — this only bounds process memory.
+const GIT_MAX_BUFFER = 10 * 1024 * 1024;
+
+type RunResult =
+  | { ok: true; stdout: Buffer }
+  | { ok: false; notGit: boolean; code: number | null; stderr: string };
+
+/** One bounded git invocation in `root`. Buffer stdout — `show` can be binary. */
+const runGit = (root: string, args: string[]): Promise<RunResult> =>
+  new Promise((resolve) => {
+    execFile(
+      "git",
+      ["-C", root, ...args],
+      { timeout: GIT_TIMEOUT_MS, maxBuffer: GIT_MAX_BUFFER, encoding: "buffer" },
+      (err, stdout, stderr) => {
+        if (!err) return resolve({ ok: true, stdout });
+        const errno = (err as NodeJS.ErrnoException).code;
+        const text = String(stderr);
+        resolve({
+          ok: false,
+          // No git binary anywhere ≡ not a repo for our purposes: degrade.
+          notGit: errno === "ENOENT" || /not a git repository/i.test(text),
+          code: typeof errno === "number" ? errno : null,
+          stderr: text,
+        });
+      },
+    );
+  });
+
+/**
+ * Reject a wire path before it goes anywhere near `git show`: git resolves
+ * `HEAD:./<rel>` against the repo, not the filesystem, so `inside()`'s
+ * realpath jail can't see it — and a `../` here could read repo files above
+ * a subdirectory session's root. Pure textual containment: relative, /-
+ * separated, no `..` segments, no NUL/backslash. Exported for the Tier-1 pin.
+ */
+export const cleanRelPath = (rel: string): string | null => {
+  if (rel.length === 0 || rel.length > 4_096) return null;
+  if (rel.includes("\0") || rel.includes("\\")) return null;
+  if (path.isAbsolute(rel)) return null;
+  const segments = rel.split("/");
+  if (segments.some((s) => s === ".." || s === "")) return null;
+  return segments.filter((s) => s !== ".").join("/") || null;
+};
+
+/**
+ * Parse `git status --porcelain=v1 -z` output into root-relative path →
+ * collapsed status char. -z records are `XY <path>\0`, EXCEPT renames/copies:
+ * `XY <to>\0<from>\0` — TWO fields, and a naive single-field split misaligns
+ * every record after the first rename. Renames collapse to A(to) + D(from)
+ * for v1. Status collapse: `??` → U (untracked); any D → D; any A → A;
+ * everything else that reaches porcelain (M/T/U-conflict/…) → M. Exported
+ * pure for the Tier-1 pin.
+ */
+export const parseStatusZ = (out: string): Map<string, string> => {
+  const byPath = new Map<string, string>();
+  const fields = out.split("\0");
+  for (let i = 0; i < fields.length; i++) {
+    const rec = fields[i];
+    if (rec.length < 4) continue; // trailing empty field / junk
+    const xy = rec.slice(0, 2);
+    const p = rec.slice(3);
+    if (xy.includes("R") || xy.includes("C")) {
+      const from = fields[++i]; // the second field of this record
+      byPath.set(p, "A");
+      // Rename: the source is gone → D. Copy: the source still exists,
+      // unchanged — marking it D would lie about a file sitting on disk.
+      if (xy.includes("R") && from) byPath.set(from, "D");
+      continue;
+    }
+    if (xy === "??") byPath.set(p, "U");
+    else if (xy.includes("D")) byPath.set(p, "D");
+    else if (xy.includes("A")) byPath.set(p, "A");
+    else byPath.set(p, "M");
+  }
+  return byPath;
+};
+
+export type GitTree =
+  | { entries: FsEntry[]; truncated: boolean }
+  | { notGit: true }
+  | { error: string };
+
+// Same caps as the walk in fs-explorer.ts — the reply rides the same wire.
+const MAX_ENTRIES = Number(process.env.FS_TREE_MAX_ENTRIES ?? 4_000);
+const MAX_PATH_BYTES = Number(process.env.FS_TREE_MAX_PATH_BYTES ?? 400_000);
+
+/**
+ * Git's view of the session root: tracked + untracked-unignored files
+ * (`ls-files --cached --others --exclude-standard`, cwd-relative), each with
+ * its collapsed status char. Two path relativities meet here: ls-files
+ * speaks CWD-relative, porcelain speaks REPO-ROOT-relative — the
+ * `rev-parse --show-prefix` strip reconciles them (the subdirectory-session
+ * trap). Staged deletions are gone from ls-files but still real: status-only
+ * D paths are merged in, so a deleted file stays visible in the tree.
+ */
+export async function gitTree(root: string): Promise<GitTree> {
+  const ls = await runGit(root, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"]);
+  if (!ls.ok) return ls.notGit ? { notGit: true } : { error: gitErr("ls-files", ls) };
+  const [status, prefixRes] = await Promise.all([
+    runGit(root, ["status", "--porcelain=v1", "-z", "--", "."]),
+    runGit(root, ["rev-parse", "--show-prefix"]),
+  ]);
+  if (!status.ok) return status.notGit ? { notGit: true } : { error: gitErr("status", status) };
+  const prefix = prefixRes.ok ? String(prefixRes.stdout).trim() : "";
+
+  const rawStatus = parseStatusZ(String(status.stdout));
+  // Re-key repo-root-relative status paths to session-root-relative; changes
+  // outside a subdirectory session's subtree are not this session's story.
+  const statusByRel = new Map<string, string>();
+  for (const [p, s] of rawStatus) {
+    if (prefix === "") statusByRel.set(p, s);
+    else if (p.startsWith(prefix)) statusByRel.set(p.slice(prefix.length), s);
+  }
+
+  const seen = new Set<string>();
+  const entries: FsEntry[] = [];
+  let pathBytes = 0;
+  let truncated = false;
+  const push = (rel: string) => {
+    if (rel === "" || seen.has(rel)) return;
+    seen.add(rel);
+    if (entries.length >= MAX_ENTRIES || pathBytes + rel.length > MAX_PATH_BYTES) {
+      truncated = true;
+      return;
+    }
+    const status = statusByRel.get(rel);
+    entries.push({ path: rel, ...(status ? { status } : {}) });
+    pathBytes += Buffer.byteLength(rel, "utf8");
+  };
+  for (const rel of String(ls.stdout).split("\0")) push(rel);
+  // Status-only paths: staged deletes (and rename sources) missing from
+  // ls-files. Sorted merge keeps the reply deterministic.
+  for (const rel of [...statusByRel.keys()].sort()) push(rel);
+  entries.sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0));
+  return { entries, truncated };
+}
+
+export type GitShow =
+  | { content: Buffer }
+  | { absentInHead: true }
+  | { notGit: true }
+  | { error: string };
+
+// `git show` failures that mean "this path has no HEAD version" — a brand-new
+// file, or any path in a repo whose HEAD is unborn (fresh init, no commits).
+const ABSENT_RE =
+  /(exists on disk, but not in|does not exist in|bad revision|unknown revision|invalid object name|ambiguous argument 'HEAD')/i;
+
+/** HEAD's version of `rel` (a cleanRelPath-validated session-root-relative
+ *  path). The `./` form makes git resolve it cwd-relative — no prefix math. */
+export async function gitShowHead(root: string, rel: string): Promise<GitShow> {
+  const r = await runGit(root, ["show", `HEAD:./${rel}`]);
+  if (r.ok) return { content: r.stdout };
+  if (r.notGit) return { notGit: true };
+  if (ABSENT_RE.test(r.stderr)) return { absentInHead: true };
+  // Submodules (gitlinks), weird objects: honest degrade, never a throw.
+  return { error: "no diff available for this entry" };
+}
+
+const gitErr = (op: string, r: { code: number | null; stderr: string }): string =>
+  `git ${op} failed${r.stderr ? `: ${r.stderr.slice(0, 200)}` : ""}`;

--- a/server/sessions/hostile-client.itest.ts
+++ b/server/sessions/hostile-client.itest.ts
@@ -71,6 +71,16 @@ test("Q.4 garbage frames mid-session: daemon survives, 2nd viewport stays quiet,
   // --- end_session: non-string / missing id — MUST NOT tear down the session ---
   a.send({ type: "end_session", sessionId: 12345 } as never);
   a.send({ type: "end_session" } as never);
+  // --- fs_list / fs_read (E.1): a bad id drops the message whole (nothing to
+  //     correlate a reply to); a well-formed id with a bad path is answered
+  //     with an error REPLY on this viewport only — never broadcast, never
+  //     silence ---
+  a.send({ type: "fs_list", id: 7 } as never);
+  a.send({ type: "fs_list", id: "bad id !!" } as never);
+  a.send({ type: "fs_list" } as never);
+  a.send({ type: "fs_read", id: "ok-1", path: 42 } as never);
+  a.send({ type: "fs_read", id: "ok-2" } as never);
+  a.send({ type: "fs_read", id: "ok-3", path: "x".repeat(5_000) } as never);
   // --- raw frames: bad JSON, and the primitives that used to crash the daemon ---
   a.sendRaw("this is not json {{{");
   a.sendRaw("null"); // the crash vector — null.type throws
@@ -88,6 +98,12 @@ test("Q.4 garbage frames mid-session: daemon survives, 2nd viewport stays quiet,
   assert.equal(aTail.filter((m) => m.type === "pong").length, 1);
   const malformed = aTail.filter((m) => m.type === "error" && m.message === "malformed client message");
   assert.equal(malformed.length, 4);
+  // The three valid-id/bad-path fs_reads each got exactly one error reply;
+  // the three bad-id Explorer frames got nothing at all (E.1).
+  const fsFiles = aTail.filter((m) => m.type === "fs_file") as Any[];
+  assert.equal(fsFiles.length, 3);
+  assert.ok(fsFiles.every((m) => typeof m.error === "string"));
+  assert.equal(aTail.filter((m) => m.type === "fs_tree").length, 0);
   // The daemon did NOT crash: no last-gasp line in its log.
   assert.doesNotMatch(d.logs(), /crashed \(uncaughtException\)/);
 


### PR DESCRIPTION
Step E.1 of PLAN.md Phase E — Explorer (the folder/file/diff view).

- Additive wire types: `fs_list`/`fs_read` → `fs_tree`/`fs_file` — per-viewport request/reply (no `seq`, never buffered), client-minted echoed ids, every well-formed request answered exactly once (errors ride the reply).
- New `server/sessions/fs-explorer.ts`: capped recursive walk (symlinks are leaves, `.git`/`node_modules` pruned, honest `truncated`), bounded-fd file reads (NUL sniff → `binary`, 64 KB cap with `truncatedBytes`, lossy UTF-8), all jailed via `inside()` + secret-env basename denial.
- `connection.ts`: throw-wrapped handlers, per-type throttle that answers rather than drops.
- Tests: 13 Tier-1 module tests + `isSecretFile` pin + Q.2 protocol fixtures; 5 Tier-2 itests (round-trip, jail/secret refusals with the daemon proven alive, throttle recovery, no-session, deleted root); 6 hostile frames added to the Q.4 sweep with the viewport-B leak check.
- All tiers green: 336 / 91 / 38.

🤖 Generated with [Claude Code](https://claude.com/claude-code)