### PR TITLE
Phase M — Mission control: the cockpit fleetview (M.1–M.5)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2833,7 +2833,17 @@ server sends no timers.
     `noSideScroll` passes with activity + permission + usage visible, the
     quick prompt opens and sends, the axe scan is clean.
 
-- [ ] **Step M.5 — Polish (optional; the cut line)**
+- [x] **Step M.5 — Polish (optional; the cut line)**
+  - Status 2026-07-24: ✅ done (two of three; the cut line used once), on
+    `feat/cockpit-m`. Landed: the fleet TAB as a cockpit signal —
+    `paintTabStatus` badge (amber = needs you, blue = fleet busy) with a
+    fleet-worded title carrying the count ("⚠ 1 needs you — Mirafold");
+    and the per-row viewport count (⧉ N — 0 being the interesting number,
+    an unwatched session still working; hidden at phone width like the id
+    column). Dropped, per the cut line: quick-prompt open-state memory
+    (marginal). fleet.e2e.ts covers the title transitions (polled — the
+    title rides a React effect) and the count. Tiers 357 / 94 / 47 green.
+    **Phase M is complete.**
   - A needs-you signal on the fleet page's TAB: title count ("Mirafold — 1
     needs you") + the corner-badge favicon via `tab-status.ts` (the session
     page's existing mechanism, reused); the row's viewport count (meta already

--- a/PLAN.md
+++ b/PLAN.md
@@ -2712,7 +2712,22 @@ server sends no timers.
     accumulate across two turns with cost taken-not-summed; `createdAt` is
     stable across snapshots. `yarn typecheck` clean; all existing tests green.
 
-- [ ] **Step M.2 — Acting from the grid, server side (sessionId-addressed ClientMsg)**
+- [x] **Step M.2 — Acting from the grid, server side (sessionId-addressed ClientMsg)**
+  - Status 2026-07-24: ✅ done, on `feat/cockpit-m`. Two deliberate deltas
+    from the draft: (1) malformed fields are SILENTLY ignored (the repo's
+    malformed-input convention — rename/permission_response posture); only
+    an unknown sessionId and the relay gate answer with an error reply.
+    (2) The remote-gate proof is Tier-1 in-process (new
+    `fleet-acts.test.ts`, `openConnection` driven with the `remote` flag in
+    hand) rather than a full relay rig in Tier 2; the socket round-trips
+    (grid allow runs the tool / deny runs nothing / interrupt leaves the
+    session warm / prompt_session echoes + runs / unknown-id errors with
+    the daemon alive) are in `fleet-cockpit.itest.ts`. `answer_permission`
+    drops only the answered id from the queue immediately (a concurrent
+    second request stays visible); protocol.test.ts gained the three
+    ClientMsg fixtures + a separate enriched-row fixture so the base
+    SessionMeta keeps proving the M.1 fields optional. All tiers green
+    (337/94/38), typecheck clean.
   - Goal: a fleet watcher can answer a permission, interrupt a turn, and
     dispatch a prompt on any session by id — validated, throw-wrapped,
     relay-gated where it drives the model — without attaching.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2756,7 +2756,27 @@ server sends no timers.
     the daemon still alive; the remote gate refuses prompt/answer on a
     subscription-kind session for a remote-flagged connection. All tiers green.
 
-- [ ] **Step M.3 — The cockpit rows (front end)**
+- [x] **Step M.3 — The cockpit rows (front end)**
+  - Status 2026-07-24: ✅ done, on `feat/cockpit-m`. As specified: enriched
+    rows (activity readout with client-ticked elapsed — 1 s tick only while
+    something is live — compact usage via the cockpit's own formatter),
+    needs-you sub-line with inline allow/deny (buttons disable on click,
+    pruned by the next snapshot), armed two-click stop, per-row
+    quick-prompt expando, grid-act errors on a dismissible header line
+    (picker-open errors keep the onboarding slot, routed via a live ref),
+    sr-only polite needs-you announcement, stable-order sort with the
+    needs-you group first (longest-stalled first — their stalled
+    lastActivity is the wait clock). One structural addition: each session
+    renders as a `.fleet-item` wrapper (row + sub-lines) so the row's
+    stretched click-overlay never covers sub-line controls. New
+    `fleet.e2e.ts` (7 tests): activity live+clears, usage lands, allow
+    runs the tool observed in the session tab, deny doesn't, armed stop
+    interrupts, quick prompt echoes in the session, ordering holds while
+    working and jumps only on needs-you; axe scan with the permission row
+    visible is clean. Tiers: 337 / 94 (unchanged, web-only step) / 45.
+    `assertAxeClean` is deliberately a copy from app.e2e.ts (importing it
+    would re-register that suite's tests) — dedupe when testing helpers
+    get their own module.
   - Goal: the fleet page shows each session's live state and carries the three
     acts — needs-you rows answerable in place — in the enriched-row shape,
     stable-ordered with needs-you first.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2810,7 +2810,18 @@ server sends no timers.
     holds its place while another works (no jumping); the axe scan of the
     cockpit with a permission row visible has no serious/critical hits.
 
-- [ ] **Step M.4 — Phone width**
+- [x] **Step M.4 — Phone width**
+  - Status 2026-07-24: ✅ done, on `feat/cockpit-m` (after rebasing the
+    branch over Phase E's merged PR #7 — zero conflicts, the
+    distinct-anchor shared-file discipline held). Own additive media
+    block: sub-lines lose the desktop indent, the permission detail takes
+    a full-width ellipsized line with the allow/deny pair wrapping beneath
+    at ≥40px, stop/prompt-toggle at .fleet-end's 36px parity, the
+    quick-prompt input at the 16px iOS no-zoom floor. One phone test in
+    fleet.e2e.ts (390×844 touch context): activity + permission + usage
+    all visible with noSideScroll clean, thumb targets measured ≥40px,
+    deny and quick-prompt by tap land in the session tab, axe clean.
+    Tiers 357 / 94 / 46 green.
   - Goal: at ≤640 px the cockpit rows fold without side-scroll — the glance
     set survives, targets stay ≥40 px, the second-line controls remain usable.
   - Build: additive media-query CSS for the new row elements (the existing

--- a/PLAN.md
+++ b/PLAN.md
@@ -2674,7 +2674,17 @@ exact rule (per-turn tokens summed, cost taken cumulative — the same numbers
 the in-session bar shows); elapsed time ticks client-side from `since`, the
 server sends no timers.
 
-- [ ] **Step M.1 — Live cockpit state on the wire (registry-derived, additive SessionMeta)**
+- [x] **Step M.1 — Live cockpit state on the wire (registry-derived, additive SessionMeta)**
+  - Status 2026-07-24: ✅ done as specified, on `feat/cockpit-m`. One
+    placement delta: the deterministic per-transition pins (activity
+    since-reset, queue stickiness, detail cap, summary copies/absence, the
+    `foldUsage` cost-taken rule — unobservable through the costless mock)
+    landed as Tier-1 additions to the existing in-process
+    `registry.test.ts` (its Q.3 pattern), with `fleet-cockpit.itest.ts`
+    keeping the over-the-socket proof (activity across a real mock turn,
+    `dangerous` permission surface + in-session answer clears, usage folded
+    across two turns, stable `createdAt`). Tier 1 330 / Tier 2 89 green,
+    typecheck clean.
   - Goal: a fleet watcher's snapshot says what each session is DOING — current
     activity + since-when, the pending-permission queue, session usage totals,
     and creation time — derived entirely in the registry.

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -190,6 +190,10 @@ const CLIENT: ClientByType = {
   watch_sessions: { type: "watch_sessions" },
   rename: { type: "rename", sessionId: "s1", name: "renamed" },
   end_session: { type: "end_session", sessionId: "s1" },
+  // M.2: the cockpit's sessionId-addressed grid acts (the end_session precedent).
+  answer_permission: { type: "answer_permission", sessionId: "s1", id: "p1", allow: true },
+  interrupt_session: { type: "interrupt_session", sessionId: "s1" },
+  prompt_session: { type: "prompt_session", sessionId: "s1", text: "run the tests" },
   refresh_agents: { type: "refresh_agents" },
   fs_list: { type: "fs_list", id: "f1" },
   fs_read: { type: "fs_read", id: "f2", path: "src/app.ts" },
@@ -257,6 +261,36 @@ test("Q.2 nested shapes carry their exact field names", () => {
     ACTIONS.map((a) => a.kind),
     ["prompt", "tool", "state"],
   );
+});
+
+// M.1: the cockpit's enriched fleet row — every Phase M optional field
+// populated. Pinned as its OWN fixture so SESSION_META above stays minimal
+// and keeps proving the new fields are optional (an old daemon's row still
+// typechecks and round-trips).
+const COCKPIT_META: SessionMeta = {
+  ...SESSION_META,
+  createdAt: 1_719_999_000_000,
+  activity: { label: "Bash", since: 1_720_000_000_500 },
+  permissions: [{ id: "p1", tool: "Bash", detail: "rm -rf build" }],
+  usage: { inputTokens: 1200, outputTokens: 300, costUsd: 0.05 },
+};
+
+test("M.1 the enriched fleet row: exact key set, pure JSON", () => {
+  assert.deepEqual(Object.keys(COCKPIT_META).sort(), [
+    "activity",
+    "agent",
+    "createdAt",
+    "cwd",
+    "lastActivity",
+    "model",
+    "name",
+    "permissions",
+    "sessionId",
+    "status",
+    "usage",
+    "viewports",
+  ]);
+  assert.deepEqual(JSON.parse(JSON.stringify(COCKPIT_META)), COCKPIT_META);
 });
 
 test("Q.2 load-bearing frames keep their exact shape (a rename fails here loudly)", () => {

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -449,6 +449,17 @@ export type ClientMsg =
   // the fleet, and kick any attached viewports back to mission control. Usable
   // from a session viewport or a fleet watcher (#11).
   | { type: "end_session"; sessionId: string }
+  // Phase M cockpit acts (M.2) — sessionId-addressed like end_session, so a
+  // fleet watcher can act on a session without attaching. Acting from the
+  // grid grants nothing a local viewport couldn't do by attaching; the two
+  // acts that DRIVE the model (answer_permission's allow path,
+  // prompt_session) are refused on a REMOTE (relay) connection when the
+  // session's credential can't ride the paid relay — the R.4i gate, same
+  // rule as attach. interrupt_session stays ungated, like end_session
+  // (teardown, not model use). Unknown session ids answer with an `error`.
+  | { type: "answer_permission"; sessionId: string; id: string; allow: boolean }
+  | { type: "interrupt_session"; sessionId: string }
+  | { type: "prompt_session"; sessionId: string; text: string }
   // Re-probe local model servers and re-send the `agents` hello (N.3). The
   // onboarding picker sends this on a slow interval while open, so the
   // "start your local server and it appears here" promise is live — no

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -361,6 +361,24 @@ export type SessionMeta = {
   status: "idle" | "working" | "permission";
   lastActivity: number;
   viewports: number;
+  // Phase M cockpit state (all optional/additive — old clients strip them,
+  // R.4h). Derived by the registry from the broadcast stream itself, so every
+  // agent carries them with no adapter cooperation (M.1).
+  // When the session was created — the cockpit's stable sort key (M.3).
+  createdAt?: number;
+  // What the session is doing RIGHT NOW ("thinking", a tool name, "! <cmd>");
+  // `since` is when that label started, so the client ticks elapsed time
+  // locally. Absent when idle. Engine-derived text — the fleet renders it as
+  // inert plain text only, never markdown (the trusted-shell rule).
+  activity?: { label: string; since: number };
+  // The pending-permission queue, oldest first — what the session is blocked
+  // on. Lives exactly as long as the 4.6 status hold: cleared when the stream
+  // moves off "permission". Same inert-text trust rule as `activity`.
+  permissions?: { id: string; tool: string; detail: string }[];
+  // Session-total usage, folded under the status bar's exact rule (T2.6):
+  // per-turn tokens SUMMED; costUsd TAKEN (it arrives session-cumulative),
+  // never summed.
+  usage?: { inputTokens: number; outputTokens: number; costUsd?: number };
 };
 
 /**

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -231,6 +231,13 @@ const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, 
   }
 };
 
+// What a remote (relay) connection is told when a cockpit act would drive a
+// subscription-backed session (M.2) — the same reasoning as the attach gate's
+// refusal (R.4i), phrased for an action instead of an attach.
+const RELAY_GATE_REFUSAL =
+  "This session runs on a subscription login, which can't be driven over the relay. " +
+  "Use an API key to drive an agent remotely.";
+
 // Agents the browser is allowed to name at onboarding (P.4). A create message
 // naming anything else falls back to the daemon default rather than erroring.
 const OFFERABLE = new Set(ADAPTER_AGENTS);
@@ -506,6 +513,60 @@ export function openConnection(
           log.info(`end_session → ${msg.sessionId}`);
         }
         break;
+      // ---- Cockpit acts (M.2): sessionId-addressed like end_session, so a
+      // fleet watcher acts without attaching. answer_permission and
+      // prompt_session DRIVE the model, so a remote (relay) connection gets
+      // the same R.4i gate attach applies; interrupt_session stays ungated
+      // like end_session. Unknown ids error, never crash.
+      case "answer_permission": {
+        if (
+          typeof msg.sessionId !== "string" ||
+          typeof msg.id !== "string" ||
+          typeof msg.allow !== "boolean"
+        ) {
+          break;
+        }
+        const target = registry.get(msg.sessionId);
+        if (!target) {
+          sendError(`no such session: ${msg.sessionId}`);
+          break;
+        }
+        if (remote && !allowedOverRelay(target.kind)) {
+          sendError(RELAY_GATE_REFUSAL);
+          break;
+        }
+        registry.answerPermission(msg.sessionId, msg.id, msg.allow);
+        log.info(`answer_permission → session ${msg.sessionId} (${msg.allow ? "allow" : "deny"})`);
+        break;
+      }
+      case "interrupt_session":
+        if (typeof msg.sessionId === "string") {
+          if (registry.interruptSession(msg.sessionId)) {
+            log.info(`interrupt_session → ${msg.sessionId}`);
+          } else {
+            sendError(`no such session: ${msg.sessionId}`);
+          }
+        }
+        break;
+      case "prompt_session": {
+        if (typeof msg.sessionId !== "string" || typeof msg.text !== "string") break;
+        const text = msg.text.trim();
+        // The frame cap already bounds a message; this bounds what one grid
+        // dispatch may push into a model turn.
+        if (!text || text.length > 100_000) break;
+        const target = registry.get(msg.sessionId);
+        if (!target) {
+          sendError(`no such session: ${msg.sessionId}`);
+          break;
+        }
+        if (remote && !allowedOverRelay(target.kind)) {
+          sendError(RELAY_GATE_REFUSAL);
+          break;
+        }
+        registry.promptSession(msg.sessionId, text);
+        log.info(`prompt_session → session ${msg.sessionId}`);
+        break;
+      }
       case "interrupt":
         entry?.session.interrupt();
         break;

--- a/server/sessions/fleet-acts.test.ts
+++ b/server/sessions/fleet-acts.test.ts
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WireMsg } from "../protocol";
+import { SessionRegistry } from "./registry";
+import { openConnection, type Connection } from "./connection";
+import type { Backend } from "../adapters";
+
+// M.2: the cockpit acts' input validation and the R.4i relay gate, in-process
+// (openConnection driven directly, `remote` flag in hand — the one axis the
+// Tier-2 socket harness can't reach without a full relay rig). The real
+// over-the-socket round-trips live in fleet-cockpit.itest.ts.
+
+const dir = () => mkdtempSync(path.join(os.tmpdir(), "genui-fleet-"));
+// live:false → the inert MockSession; `kind` is what the gate reads.
+const SUB: Backend = { agent: "codex", kind: "subscription", live: false };
+const NONE: Backend = { agent: "claude-code", kind: "none", live: false };
+
+function conn(reg: SessionRegistry, remote: boolean) {
+  const seen: WireMsg[] = [];
+  const c = openConnection(reg, (m) => seen.push(m), "test", undefined, remote);
+  return { c, seen };
+}
+const send = (c: Connection, msg: unknown) => c.handleMessage(JSON.stringify(msg));
+const errors = (seen: WireMsg[]) =>
+  seen.filter((m) => m.type === "error").map((m) => (m as { message: string }).message);
+
+test("M.2 remote gate: prompt_session and answer_permission are refused on a subscription session", () => {
+  const reg = new SessionRegistry(SUB);
+  const e = reg.create({ cwd: dir() });
+  const { c, seen } = conn(reg, true);
+
+  send(c, { type: "prompt_session", sessionId: e.id, text: "hi" });
+  send(c, { type: "answer_permission", sessionId: e.id, id: "p1", allow: true });
+
+  assert.equal(errors(seen).length, 2);
+  assert.ok(errors(seen).every((m) => m.includes("subscription")));
+  assert.ok(
+    !e.buffer.some((m) => m.type === "user_prompt"),
+    "the refused prompt never reached the session stream",
+  );
+  reg.end(e.id);
+});
+
+test("M.2 remote gate: interrupt_session stays ungated (teardown, like end_session)", () => {
+  const reg = new SessionRegistry(SUB);
+  const e = reg.create({ cwd: dir() });
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "interrupt_session", sessionId: e.id });
+  assert.equal(errors(seen).length, 0);
+  reg.end(e.id);
+});
+
+test("M.2 local connections are never gated — a subscription session takes a grid prompt", () => {
+  const reg = new SessionRegistry(SUB);
+  const e = reg.create({ cwd: dir() });
+  const { c, seen } = conn(reg, false);
+  send(c, { type: "prompt_session", sessionId: e.id, text: "hi" });
+  assert.equal(errors(seen).length, 0);
+  assert.ok(e.buffer.some((m) => m.type === "user_prompt"));
+  reg.end(e.id);
+});
+
+test("M.2 unknown session ids answer with an error; malformed acts are silently ignored", () => {
+  const reg = new SessionRegistry(NONE);
+  const { c, seen } = conn(reg, false);
+  send(c, { type: "prompt_session", sessionId: "nope", text: "x" });
+  send(c, { type: "interrupt_session", sessionId: "nope" });
+  send(c, { type: "answer_permission", sessionId: "nope", id: "p", allow: false });
+  assert.equal(errors(seen).length, 3);
+  assert.ok(errors(seen).every((m) => m.includes("no such session")));
+
+  // Malformed fields: the repo's malformed-input convention — ignored, no
+  // crash, no error spam (same posture as rename/permission_response).
+  const before = seen.length;
+  send(c, { type: "prompt_session", sessionId: 5, text: 7 });
+  send(c, { type: "prompt_session" });
+  send(c, { type: "answer_permission", sessionId: "x" });
+  send(c, { type: "interrupt_session" });
+  assert.equal(seen.length, before, "nothing emitted for malformed acts");
+});
+
+test("M.2 an empty or whitespace grid prompt is ignored, like the in-session prompt path", () => {
+  const reg = new SessionRegistry(NONE);
+  const e = reg.create({ cwd: dir() });
+  const { c, seen } = conn(reg, false);
+  send(c, { type: "prompt_session", sessionId: e.id, text: "   \n " });
+  assert.equal(errors(seen).length, 0);
+  assert.ok(!e.buffer.some((m) => m.type === "user_prompt"));
+  reg.end(e.id);
+});
+
+test("M.2 answer_permission drops ONLY the answered id from the queue, immediately", () => {
+  const reg = new SessionRegistry(NONE);
+  const e = reg.create({ cwd: dir() });
+  reg.broadcast(e, { type: "permission_request", tool: "Bash", detail: "a", id: "p1" });
+  reg.broadcast(e, { type: "permission_request", tool: "Write", detail: "b", id: "p2" });
+  const { c } = conn(reg, false);
+  send(c, { type: "answer_permission", sessionId: e.id, id: "p1", allow: true });
+  assert.deepEqual(
+    e.permissions.map((p) => p.id),
+    ["p2"],
+    "the concurrently pending request stays visible",
+  );
+  reg.end(e.id);
+});

--- a/server/sessions/fleet-cockpit.itest.ts
+++ b/server/sessions/fleet-cockpit.itest.ts
@@ -127,3 +127,107 @@ test("usage folds across turns: tokens sum, and no cost is invented", async () =
   w.close();
   client.close();
 });
+
+// ---- M.2: acting from the grid — the sessionId-addressed acts over the real
+// socket. (The remote/relay gate is pinned in-process in fleet-acts.test.ts,
+// where the `remote` flag is directly in hand.)
+
+test("grid allow: a watcher's answer_permission lets the tool run", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+  client.send({ type: "prompt", text: "do something dangerous" });
+  const held = await w.waitFor(
+    (m) => (row(m, sessionId)?.permissions?.length ?? 0) > 0,
+    "pending permission on the row",
+  );
+  const perm = row(held, sessionId)!.permissions![0];
+
+  w.send({ type: "answer_permission", sessionId, id: perm.id, allow: true });
+
+  const tool = (await client.waitFor(
+    (m) => m.type === "tool_use" && (m as Any).name === "Bash",
+    "the allowed tool runs in the session",
+    20_000,
+  )) as Any;
+  assert.ok(tool.detail.includes("rm -rf"), "the mock's dangerous command ran");
+  await client.type("turn_end", 20_000);
+  await w.waitFor(
+    (m) => {
+      const s = row(m, sessionId);
+      return !!s && !s.permissions;
+    },
+    "the row's queue cleared",
+    20_000,
+  );
+  w.close();
+  client.close();
+});
+
+test("grid deny: the command does not run and the turn ends honestly", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+  client.send({ type: "prompt", text: "do something dangerous" });
+  const held = await w.waitFor(
+    (m) => (row(m, sessionId)?.permissions?.length ?? 0) > 0,
+    "pending permission on the row",
+  );
+  const perm = row(held, sessionId)!.permissions![0];
+
+  const from = client.mark();
+  w.send({ type: "answer_permission", sessionId, id: perm.id, allow: false });
+  await client.type("turn_end", 20_000);
+  assert.ok(
+    !client.received.slice(from).some((m) => m.type === "tool_use"),
+    "denied — no tool ran",
+  );
+  w.close();
+  client.close();
+});
+
+test("grid interrupt halts the turn; the session stays warm for the next prompt", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+  client.send({ type: "prompt", text: "a long turn to interrupt" });
+  await w.waitFor((m) => row(m, sessionId)?.status === "working", "working on the row");
+
+  w.send({ type: "interrupt_session", sessionId });
+  await client.type("turn_end", 20_000);
+
+  client.send({ type: "prompt", text: "still alive?" });
+  await client.type("turn_end", 20_000);
+  w.close();
+  client.close();
+});
+
+test("prompt_session dispatches a turn from the grid", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+  w.send({ type: "prompt_session", sessionId, text: "dispatched from the cockpit" });
+  const echo = (await client.waitFor(
+    (m) => m.type === "user_prompt",
+    "the echoed command strip",
+  )) as Any;
+  assert.equal(echo.text, "dispatched from the cockpit");
+  await client.type("turn_end", 20_000);
+  w.close();
+  client.close();
+});
+
+test("unknown-session acts error; malformed acts are ignored; the daemon survives", async () => {
+  const w = await watcher();
+  w.send({ type: "prompt_session", sessionId: "nope", text: "x" });
+  await w.waitFor(
+    (m) => m.type === "error" && (m as Any).message.includes("no such session"),
+    "error for the unknown prompt target",
+  );
+  w.send({ type: "answer_permission", sessionId: "nope", id: "p", allow: true });
+  await w.waitFor((m) => m.type === "error", "error for the unknown answer target");
+  w.send({ type: "interrupt_session", sessionId: "nope" });
+  await w.waitFor((m) => m.type === "error", "error for the unknown interrupt target");
+
+  w.sendRaw(JSON.stringify({ type: "prompt_session", sessionId: 5, text: 7 }));
+  w.sendRaw(JSON.stringify({ type: "answer_permission" }));
+  w.send({ type: "ping" });
+  await w.type("pong");
+  w.close();
+});

--- a/server/sessions/fleet-cockpit.itest.ts
+++ b/server/sessions/fleet-cockpit.itest.ts
@@ -1,0 +1,129 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { SessionMeta, WireMsg } from "../protocol";
+import { startDaemon, createSession, TestClient, type Daemon } from "../testing/itest-harness";
+
+// Phase M.1, Tier-2: the cockpit metadata a fleet watcher's `sessions`
+// snapshots carry — activity, the pending-permission queue, folded usage,
+// createdAt — observed over the real socket against the real daemon
+// (mock-forced), end to end through the registry's notify/coalesce path.
+// The deterministic per-transition pins live in registry.test.ts (Tier 1).
+
+type Any = WireMsg & Record<string, any>;
+
+let d: Daemon;
+before(async () => {
+  d = await startDaemon({ SESSION_IDLE_TIMEOUT_MS: "30000" });
+});
+after(async () => {
+  await d.stop();
+});
+
+async function watcher(): Promise<TestClient> {
+  const w = new TestClient(d.port);
+  await w.opened();
+  await w.type("agents");
+  w.send({ type: "watch_sessions" });
+  await w.type("sessions");
+  return w;
+}
+
+const row = (m: WireMsg, id: string): SessionMeta | undefined =>
+  m.type === "sessions"
+    ? ((m as Any).sessions as SessionMeta[]).find((s) => s.sessionId === id)
+    : undefined;
+
+test("activity appears while a turn works and clears at idle; createdAt is stable", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+  const first = row(w.received.at(-1) as WireMsg, sessionId);
+  assert.ok(first, "the watcher's first snapshot lists the session");
+  const created = first.createdAt;
+  assert.ok(typeof created === "number" && created > 0, "createdAt on the first snapshot");
+
+  client.send({ type: "prompt", text: "hello cockpit" });
+  const working = await w.waitFor(
+    (m) => !!row(m, sessionId)?.activity,
+    "a snapshot carrying activity",
+  );
+  const act = row(working, sessionId)!.activity!;
+  assert.ok(act.label.length > 0, "activity has a label");
+  assert.ok(act.since > 0, "activity has a start time");
+
+  const idle = await w.waitFor(
+    (m) => row(m, sessionId)?.status === "idle",
+    "the turn-end snapshot",
+    20_000,
+  );
+  const r = row(idle, sessionId)!;
+  assert.equal(r.activity, undefined, "activity cleared at idle");
+  assert.equal(r.createdAt, created, "createdAt stable across snapshots");
+  w.close();
+  client.close();
+});
+
+test("a dangerous prompt surfaces the pending permission; the in-session answer clears it", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+
+  client.send({ type: "prompt", text: "do something dangerous" });
+  const held = await w.waitFor(
+    (m) => (row(m, sessionId)?.permissions?.length ?? 0) > 0,
+    "a snapshot with the pending permission",
+  );
+  const r = row(held, sessionId)!;
+  assert.equal(r.status, "permission");
+  assert.equal(r.permissions![0].tool, "Bash");
+  assert.ok(r.permissions![0].detail.includes("rm -rf"), "the row names WHAT it wants");
+
+  // Answer over the existing in-session path; the queue must clear with the hold.
+  const req = (await client.type("permission_request")) as Any;
+  assert.equal(req.id, r.permissions![0].id, "the row carries the real request id");
+  client.send({ type: "permission_response", id: req.id, allow: true });
+
+  const moved = await w.waitFor(
+    (m) => {
+      const s = row(m, sessionId);
+      return !!s && s.status !== "permission" && !s.permissions;
+    },
+    "the post-answer snapshot with the queue cleared",
+    20_000,
+  );
+  assert.ok(moved);
+  w.close();
+  client.close();
+});
+
+test("usage folds across turns: tokens sum, and no cost is invented", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  const w = await watcher();
+
+  client.send({ type: "prompt", text: "first turn" });
+  const u1 = (await client.type("usage")) as Any;
+  await client.type("turn_end");
+  const s1 = await w.waitFor(
+    (m) => row(m, sessionId)?.status === "idle" && !!row(m, sessionId)?.usage,
+    "first idle snapshot with usage",
+    20_000,
+  );
+  const t1 = row(s1, sessionId)!.usage!;
+  assert.equal(t1.inputTokens, u1.inputTokens);
+  assert.equal(t1.outputTokens, u1.outputTokens);
+  assert.equal(t1.costUsd, undefined, "the mock reports no cost; none is invented");
+
+  client.send({ type: "prompt", text: "second turn" });
+  const u2 = (await client.type("usage")) as Any;
+  await client.type("turn_end");
+  const s2 = await w.waitFor(
+    (m) =>
+      row(m, sessionId)?.status === "idle" &&
+      (row(m, sessionId)?.usage?.inputTokens ?? 0) > t1.inputTokens,
+    "second idle snapshot with the folded total",
+    20_000,
+  );
+  const t2 = row(s2, sessionId)!.usage!;
+  assert.equal(t2.inputTokens, u1.inputTokens + u2.inputTokens, "tokens SUM across turns");
+  assert.equal(t2.outputTokens, u1.outputTokens + u2.outputTokens);
+  w.close();
+  client.close();
+});

--- a/server/sessions/registry.test.ts
+++ b/server/sessions/registry.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { resolveCwd, SessionRegistry } from "./registry";
+import { foldUsage, resolveCwd, SessionRegistry } from "./registry";
 import type { Backend } from "../adapters";
 import type { WireMsg } from "../protocol";
 
@@ -144,5 +144,111 @@ test("Q.3 canResume on a small (un-evicted) buffer: seq 0 replays from the very 
   const seen: number[] = [];
   reg.attach(entry, (m) => seen.push(m.seq!), 0);
   assert.deepEqual(seen, [1, 2, 3, 4, 5]);
+  reg.end(entry.id);
+});
+
+// ---- Phase M.1: cockpit metadata derived in broadcast() --------------------
+// Driven in-process like the Q.3 ring tests above — broadcast() by hand,
+// entry state inspected directly, so every transition is deterministic. The
+// over-the-socket proof (real daemon, real watcher, mock pacing) is
+// fleet-cockpit.itest.ts.
+
+test("M.1 foldUsage sums per-turn tokens", () => {
+  const first = foldUsage(undefined, { inputTokens: 100, outputTokens: 10 });
+  assert.deepEqual(first, { inputTokens: 100, outputTokens: 10 });
+  assert.deepEqual(foldUsage(first, { inputTokens: 50, outputTokens: 5 }), {
+    inputTokens: 150,
+    outputTokens: 15,
+  });
+});
+
+test("M.1 foldUsage TAKES costUsd (session-cumulative), never sums it", () => {
+  const first = foldUsage(undefined, { inputTokens: 1, outputTokens: 1, costUsd: 0.1 });
+  const second = foldUsage(first, { inputTokens: 1, outputTokens: 1, costUsd: 0.25 });
+  assert.equal(second.costUsd, 0.25, "the cumulative figure replaces, not adds");
+  const later = foldUsage(second, { inputTokens: 1, outputTokens: 1 });
+  assert.equal(later.costUsd, 0.25, "a report without cost keeps the last one");
+});
+
+test("M.1 foldUsage invents no cost when none was ever reported", () => {
+  const folded = foldUsage(foldUsage(undefined, { inputTokens: 1, outputTokens: 1 }), {
+    inputTokens: 1,
+    outputTokens: 1,
+  });
+  assert.ok(!("costUsd" in folded), "absent cost stays absent — never a stand-in");
+});
+
+test("M.1 activity follows the status stream; since resets only on a label CHANGE; idle clears", () => {
+  const { reg, entry } = freshSession();
+  reg.broadcast(entry, { type: "status", state: "thinking" });
+  assert.equal(entry.activity?.label, "thinking");
+  const since = entry.activity!.since;
+  reg.broadcast(entry, { type: "status", state: "thinking" }); // re-announced, same label
+  assert.equal(entry.activity!.since, since, "identical label keeps its elapsed time");
+  reg.broadcast(entry, { type: "status", state: "tool", label: "Bash" });
+  assert.equal(entry.activity?.label, "Bash");
+  reg.broadcast(entry, { type: "text_delta", text: "x" });
+  assert.equal(entry.activity?.label, "Bash", "text streaming keeps the label — RenderZone parity");
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.activity, undefined, "cleared at idle");
+  reg.end(entry.id);
+});
+
+test("M.1 bang activity: first line only, capped, cleared at bang_end", () => {
+  const { reg, entry } = freshSession();
+  reg.broadcast(entry, { type: "bang_start", command: "echo hi\nrm -rf /", id: "b1" });
+  assert.equal(entry.activity?.label, "! echo hi");
+  reg.broadcast(entry, { type: "bang_start", command: "x".repeat(200), id: "b2" });
+  assert.equal(entry.activity!.label.length, "! ".length + 80);
+  reg.broadcast(entry, { type: "bang_end", id: "b2", exitCode: 0 });
+  assert.equal(entry.activity, undefined);
+  reg.end(entry.id);
+});
+
+test("M.1 the permission queue lives exactly as long as the 4.6 hold", () => {
+  const { reg, entry } = freshSession();
+  reg.broadcast(entry, { type: "permission_request", tool: "Bash", detail: "rm -rf x", id: "p1" });
+  assert.equal(entry.status, "permission");
+  assert.deepEqual(entry.permissions, [{ id: "p1", tool: "Bash", detail: "rm -rf x" }]);
+  // A second concurrent request stacks, oldest first — no clear.
+  reg.broadcast(entry, { type: "permission_request", tool: "Write", detail: "f.txt", id: "p2" });
+  assert.deepEqual(
+    entry.permissions.map((p) => p.id),
+    ["p1", "p2"],
+  );
+  // The stream moving off the hold clears the queue (status-stickiness rule).
+  reg.broadcast(entry, { type: "tool_use", name: "Bash", detail: "rm -rf x", id: "t1" });
+  assert.equal(entry.status, "working");
+  assert.deepEqual(entry.permissions, []);
+  reg.end(entry.id);
+});
+
+test("M.1 permission detail is capped for the snapshot", () => {
+  const { reg, entry } = freshSession();
+  reg.broadcast(entry, {
+    type: "permission_request",
+    tool: "Bash",
+    detail: "y".repeat(500),
+    id: "p1",
+  });
+  assert.equal(entry.permissions[0].detail.length, 200);
+  reg.end(entry.id);
+});
+
+test("M.1 summary(): cockpit fields are absent when empty, present as COPIES when set", () => {
+  const { reg, entry } = freshSession();
+  let meta = reg.summary().find((s) => s.sessionId === entry.id)!;
+  assert.equal(typeof meta.createdAt, "number");
+  assert.ok(!("activity" in meta) && !("permissions" in meta) && !("usage" in meta));
+
+  reg.broadcast(entry, { type: "status", state: "tool", label: "Bash" });
+  reg.broadcast(entry, { type: "usage", inputTokens: 10, outputTokens: 2 });
+  reg.broadcast(entry, { type: "permission_request", tool: "Bash", detail: "d", id: "p1" });
+  meta = reg.summary().find((s) => s.sessionId === entry.id)!;
+  assert.equal(meta.activity?.label, "Bash");
+  assert.deepEqual(meta.usage, { inputTokens: 10, outputTokens: 2 });
+  assert.deepEqual(meta.permissions, [{ id: "p1", tool: "Bash", detail: "d" }]);
+  meta.permissions![0].detail = "mutated";
+  assert.equal(entry.permissions[0].detail, "d", "snapshot rows are copies, not aliases");
   reg.end(entry.id);
 });

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -80,7 +80,33 @@ export type SessionEntry = {
   // When the last `!` command started — the burst throttle in connection.ts
   // (each bang costs a model turn, so bursts burn tokens).
   lastBangAt?: number;
+  // Phase M cockpit metadata (M.1), derived in broadcast() the same way
+  // `status` is: when the session was created (the cockpit's stable sort
+  // key), what it's doing right now, the pending-permission queue (lives as
+  // long as the 4.6 permission hold), and folded session usage.
+  createdAt: number;
+  activity?: { label: string; since: number };
+  permissions: { id: string; tool: string; detail: string }[];
+  usage?: { inputTokens: number; outputTokens: number; costUsd?: number };
 };
+
+/**
+ * Fold one per-turn `usage` report into the session total — the status bar's
+ * exact rule (T2.6, Shell.tsx): tokens are per-turn and SUM; costUsd arrives
+ * session-cumulative and is TAKEN, never summed (a later report without a
+ * cost keeps the last one). Exported for the Tier-1 pin.
+ */
+export function foldUsage(
+  prev: SessionEntry["usage"],
+  msg: { inputTokens: number; outputTokens: number; costUsd?: number },
+): NonNullable<SessionEntry["usage"]> {
+  const costUsd = msg.costUsd ?? prev?.costUsd;
+  return {
+    inputTokens: (prev?.inputTokens ?? 0) + msg.inputTokens,
+    outputTokens: (prev?.outputTokens ?? 0) + msg.outputTokens,
+    ...(costUsd !== undefined ? { costUsd } : {}),
+  };
+}
 
 /**
  * Sessions decoupled from connections (Step 4.2). A session outlives any
@@ -135,6 +161,8 @@ export class SessionRegistry {
       name: path.basename(dir) || dir,
       status: "idle",
       lastActivity: Date.now(),
+      createdAt: Date.now(),
+      permissions: [],
     };
     session.onMessage((msg) => this.broadcast(entry, msg));
     this.entries.set(id, entry);
@@ -177,6 +205,8 @@ export class SessionRegistry {
     // cooperation needed. Terminal states first; a permission hold sticks
     // until the turn moves again (4.6).
     const prev = entry.status;
+    const prevActivity = entry.activity?.label;
+    const prevPending = entry.permissions.length;
     if (msg.type === "turn_end" || msg.type === "error" || msg.type === "bang_end") {
       entry.status = "idle";
     } else if (msg.type === "permission_request") {
@@ -184,7 +214,46 @@ export class SessionRegistry {
     } else {
       entry.status = "working";
     }
-    if (entry.status !== prev) this.notifyWatchers();
+    // Cockpit metadata (M.1), same stream-derivation idea. Activity: what
+    // the session is doing right now — `since` resets only when the label
+    // CHANGES, so a re-announced identical status keeps its elapsed time.
+    // The in-session status line persists through text streaming until
+    // turn_end (RenderZone), so holding the last label here is faithful.
+    if (msg.type === "status") {
+      const label = msg.state === "tool" ? (msg.label ?? "tool") : "thinking";
+      if (prevActivity !== label) entry.activity = { label, since: Date.now() };
+    } else if (msg.type === "bang_start") {
+      // First line only, capped — a pasted script must not bloat snapshots.
+      entry.activity = {
+        label: `! ${msg.command.split("\n", 1)[0].slice(0, 80)}`,
+        since: Date.now(),
+      };
+    } else if (entry.status === "idle") {
+      entry.activity = undefined;
+    }
+    // The pending-permission queue lives exactly as long as the 4.6 hold:
+    // cleared the moment the stream moves off "permission". (A second
+    // concurrently-pending request that outlives the first answer re-surfaces
+    // only via its own timeout — the documented v1 honesty bound, the same
+    // one the status dot already has.)
+    if (msg.type === "permission_request") {
+      entry.permissions.push({
+        id: msg.id,
+        tool: msg.tool,
+        detail: msg.detail.slice(0, 200),
+      });
+    } else if (prev === "permission") {
+      entry.permissions = [];
+    }
+    if (msg.type === "usage") entry.usage = foldUsage(entry.usage, msg);
+    if (
+      entry.status !== prev ||
+      entry.activity?.label !== prevActivity ||
+      entry.permissions.length !== prevPending ||
+      msg.type === "usage"
+    ) {
+      this.notifyWatchers();
+    }
     for (const viewport of entry.viewports) viewport(msg);
   }
 
@@ -266,6 +335,15 @@ export class SessionRegistry {
         status: e.status,
         lastActivity: e.lastActivity,
         viewports: e.viewports.size,
+        createdAt: e.createdAt,
+        // Copies, and absent-when-empty (M.1): a watcher's serialized
+        // snapshot must not alias entry state, and old clients strip fields
+        // they don't know rather than seeing empty placeholders.
+        ...(e.activity ? { activity: { ...e.activity } } : {}),
+        ...(e.permissions.length
+          ? { permissions: e.permissions.map((p) => ({ ...p })) }
+          : {}),
+        ...(e.usage ? { usage: { ...e.usage } } : {}),
       }))
       .sort((a, b) => b.lastActivity - a.lastActivity);
   }

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -366,6 +366,44 @@ export class SessionRegistry {
     return true;
   }
 
+  // ---- Cockpit acts (M.2): sessionId-addressed, usable from a fleet watcher
+  // without attaching. Each returns false for an unknown session — the caller
+  // turns that into an error reply, never a crash. The relay gate for the
+  // acts that drive the model lives in connection.ts, beside its attach twin.
+
+  /** Answer a session's pending permission from the grid. The answered id is
+   *  dropped from the queue immediately (honest feedback before the stream
+   *  moves — the allowed tool may take a moment to start); a concurrently
+   *  pending second request stays visible. A stale id is a no-op at the
+   *  adapter, exactly as on the in-session path. */
+  answerPermission(id: string, permissionId: string, allow: boolean): boolean {
+    const entry = this.entries.get(id);
+    if (!entry) return false;
+    entry.session.resolvePermission(permissionId, allow);
+    const before = entry.permissions.length;
+    entry.permissions = entry.permissions.filter((p) => p.id !== permissionId);
+    if (entry.permissions.length !== before) this.notifyWatchers();
+    return true;
+  }
+
+  /** Halt a session's in-flight turn from the grid; the session stays warm. */
+  interruptSession(id: string): boolean {
+    const entry = this.entries.get(id);
+    if (!entry) return false;
+    entry.session.interrupt();
+    return true;
+  }
+
+  /** Dispatch a user turn to a session from the grid — the `prompt` case's
+   *  exact semantics (echo through the stream, then push), addressed by id. */
+  promptSession(id: string, text: string): boolean {
+    const entry = this.entries.get(id);
+    if (!entry) return false;
+    this.broadcast(entry, { type: "user_prompt", text });
+    entry.session.pushPrompt(text);
+    return true;
+  }
+
   /** Push a fresh snapshot to every watcher, coalescing bursts. */
   private notifyWatchers() {
     if (this.watchers.size === 0 || this.notifyTimer) return;

--- a/server/testing/fleet.e2e.ts
+++ b/server/testing/fleet.e2e.ts
@@ -155,6 +155,58 @@ test("ordering: rows hold creation order while working; needs-you surfaces to th
   await second.close();
 });
 
+// ---- M.4: phone width — the same cockpit, folded clean and thumb-sized ----
+
+const noSideScroll = async (p: Page) => {
+  const over = await p.evaluate(
+    () => document.documentElement.scrollWidth - document.documentElement.clientWidth,
+  );
+  assert.ok(over <= 1, `page scrolls sideways by ${over}px`);
+};
+
+test("phone: glance set visible with no side-scroll; permission and prompt act by thumb", async () => {
+  const phoneCtx = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 3,
+    isMobile: true,
+    hasTouch: true,
+  });
+  const phone = await phoneCtx.newPage();
+  await phone.goto(`${base}/`);
+  await phone.waitForSelector(".fleet-row");
+
+  // Park a permission hold on session 1 — with its usage from the earlier
+  // turns, the row is at its richest: activity + permission + usage at once.
+  await say(session, "do something dangerous");
+  await phone.waitForSelector(".fleet-perm", { timeout: 15_000 });
+  await phone.waitForSelector(".fleet-activity", { timeout: 15_000 });
+  assert.ok(await phone.locator(".fleet-usage").count(), "usage stays visible on phone");
+  await noSideScroll(phone);
+
+  // Thumb targets: the answer pair is ≥40px tall (the R.4l standard).
+  for (const sel of [".fleet-perm-allow", ".fleet-perm-deny"]) {
+    const box = await phone.locator(sel).boundingBox();
+    assert.ok(box && box.height >= 40, `${sel} is ${box?.height ?? 0}px tall — needs ≥40`);
+  }
+  await assertAxeClean(phone, "phone cockpit with a pending permission");
+
+  // Deny by thumb; the hold clears everywhere.
+  await phone.locator(".fleet-perm-deny").tap();
+  await session.waitForSelector("text=I won't run that command", { timeout: 30_000 });
+  await phone.waitForSelector(".fleet-perm", { state: "detached", timeout: 15_000 });
+  await allIdle(2);
+
+  // Quick prompt by thumb: the first row (creation order → session 1, the
+  // tab we're watching) takes a dispatched turn; still no side pan.
+  await phone.locator(".fleet-prompt-toggle").first().tap();
+  await phone.locator(".fleet-prompt-input").fill("phone cockpit prompt");
+  await phone.keyboard.press("Enter");
+  await session.waitForSelector("text=phone cockpit prompt", { timeout: 15_000 });
+  await noSideScroll(phone);
+  await allIdle(2);
+  await phoneCtx.close();
+});
+
 // ---- axe (copy of app.e2e.ts's assertAxeClean — a shared testing helper
 // would force importing that whole suite, which would re-register its tests;
 // dedupe when the helpers move to their own module) ------------------------

--- a/server/testing/fleet.e2e.ts
+++ b/server/testing/fleet.e2e.ts
@@ -1,0 +1,196 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { chromium, type Browser, type Page } from "playwright-core";
+import axe from "axe-core";
+import { startDaemon, type Daemon } from "./itest-harness";
+
+// Phase M (M.3), Tier-3: the cockpit — mission control's enriched rows and
+// grid acts, driven in a real browser against the real daemon (mock-forced).
+// Two tabs throughout: a session tab (the acted-on session's transcript is
+// the proof an act really landed) and the fleet tab (the cockpit under test).
+
+const CHROME = process.env.CHROME_BIN ?? "/usr/bin/google-chrome";
+
+let d: Daemon;
+let browser: Browser;
+let session: Page; // the first session's transcript tab
+let fleet: Page; // mission control
+let sessionId: string;
+let base: string;
+
+before(async () => {
+  d = await startDaemon({ SESSION_IDLE_TIMEOUT_MS: "300000" });
+  base = `http://127.0.0.1:${d.port}`;
+  browser = await chromium.launch({ executablePath: CHROME });
+
+  // First run: "/" opens straight into the picker; picking creates session 1.
+  session = await browser.newPage();
+  await session.goto(`${base}/`);
+  await session.locator(".onb-agent", { hasText: "Claude Code" }).click();
+  await session.waitForURL(/\/s\/[\w-]+/);
+  sessionId = new URL(session.url()).pathname.split("/").pop()!;
+
+  fleet = await browser.newPage();
+  await fleet.goto(`${base}/`);
+  await fleet.waitForSelector(".fleet-row");
+});
+after(async () => {
+  await browser?.close();
+  await d?.stop();
+});
+
+/** Type a prompt into a session tab's real prompt box. */
+async function say(p: Page, text: string) {
+  await p.locator("textarea").click();
+  await p.keyboard.type(text);
+  await p.keyboard.press("Enter");
+}
+
+/** The fleet-wide idle oracle: every row idle, nothing mid-turn. */
+async function allIdle(rows: number) {
+  await fleet.waitForFunction(
+    (n) => document.querySelectorAll(".fleet-status-idle").length === n,
+    rows,
+    { timeout: 30_000 },
+  );
+}
+
+test("the row shows live activity while a turn works, then clears to idle", async () => {
+  await say(session, "give me a quick overview");
+  const activity = await fleet.waitForSelector(".fleet-activity", { timeout: 15_000 });
+  assert.match((await activity.innerText()) ?? "", /[✳⚙!] ?.* · \d+[smh]/u);
+  // Activity clears when the turn ends — the row is honest at idle.
+  await fleet.waitForSelector(".fleet-activity", { state: "detached", timeout: 30_000 });
+  await allIdle(1);
+});
+
+test("session usage lands on the row after the turn (tokens, no invented cost)", async () => {
+  const usage = await fleet.waitForSelector(".fleet-usage", { timeout: 15_000 });
+  const text = (await usage.innerText()) ?? "";
+  assert.match(text, /tok/, "token total on the row");
+  assert.ok(!text.includes("$"), "the mock reports no cost — none shown");
+});
+
+test("needs-you: the row names WHAT it wants; allow from the grid runs the tool; axe-clean", async () => {
+  await say(session, "do something dangerous");
+  await fleet.waitForSelector(".fleet-perm", { timeout: 15_000 });
+  const detail = await fleet.locator(".fleet-perm-detail").innerText();
+  assert.match(detail, /Bash/);
+  assert.match(detail, /rm -rf/);
+  assert.equal(await fleet.locator(".fleet-status-permission").innerText(), "needs you");
+
+  // The C.2 discipline: the cockpit's new surface scans clean WITH the
+  // permission line (its most content-rich state) on screen.
+  await assertAxeClean(fleet, "cockpit with a pending permission");
+
+  await fleet.locator(".fleet-perm-allow").click();
+  // The allowed tool really ran — observed in the session tab's transcript.
+  await session.waitForSelector("text=Cache cleared and the service restarted", {
+    timeout: 30_000,
+  });
+  await fleet.waitForSelector(".fleet-perm", { state: "detached", timeout: 15_000 });
+  await allIdle(1);
+});
+
+test("deny from the grid: the command does not run", async () => {
+  await say(session, "do something dangerous");
+  await fleet.waitForSelector(".fleet-perm", { timeout: 15_000 });
+  await fleet.locator(".fleet-perm-deny").click();
+  await session.waitForSelector("text=I won't run that command", { timeout: 30_000 });
+  await fleet.waitForSelector(".fleet-perm", { state: "detached", timeout: 15_000 });
+  await allIdle(1);
+});
+
+test("the armed stop interrupts a working turn from the grid", async () => {
+  await say(session, "tell me about this project");
+  const stop = await fleet.waitForSelector(".fleet-stop", { timeout: 15_000 });
+  await stop.click();
+  assert.equal(await fleet.locator(".fleet-stop").innerText(), "stop?", "first click arms");
+  await fleet.locator(".fleet-stop").click();
+  // Interrupt = turn over, session warm: the stop control unmounts with the
+  // working state, well before the mock turn's natural several-second run.
+  await fleet.waitForSelector(".fleet-stop", { state: "detached", timeout: 10_000 });
+  await allIdle(1);
+});
+
+test("quick prompt: a turn dispatched from the grid lands in the session", async () => {
+  await fleet.locator(".fleet-prompt-toggle").click();
+  await fleet.locator(".fleet-prompt-input").fill("quick hello from the cockpit");
+  await fleet.keyboard.press("Enter");
+  // The dispatched turn echoes as the session's command strip (server
+  // broadcast — the same user_prompt every viewport paints).
+  await session.waitForSelector("text=quick hello from the cockpit", { timeout: 15_000 });
+  await fleet.waitForSelector(".fleet-prompt-input", { state: "detached" });
+  await allIdle(1);
+});
+
+test("ordering: rows hold creation order while working; needs-you surfaces to the top", async () => {
+  // Session 2 via the fleet's own picker path.
+  const second = await browser.newPage();
+  await second.goto(`${base}/?new=1`);
+  await second.locator(".onb-agent", { hasText: "Claude Code" }).click();
+  await second.waitForURL(/\/s\/[\w-]+/);
+  const secondId = new URL(second.url()).pathname.split("/").pop()!;
+  assert.notEqual(secondId, sessionId);
+
+  const firstRowId = () => fleet.locator(".fleet-item").first().locator(".fleet-id").innerText();
+  await fleet.waitForFunction(() => document.querySelectorAll(".fleet-item").length === 2);
+  assert.equal(await firstRowId(), sessionId, "creation order: the older session leads");
+
+  // A working turn must NOT reorder the grid (the recency sort is retired).
+  await say(second, "summarize the repo");
+  await fleet.waitForSelector(".fleet-activity", { timeout: 15_000 });
+  assert.equal(await firstRowId(), sessionId, "rows hold their place while one works");
+  await allIdle(2);
+
+  // A permission hold DOES surface — the top group is the act-here zone.
+  await say(second, "do something dangerous");
+  await fleet.waitForSelector(".fleet-perm", { timeout: 15_000 });
+  assert.equal(await firstRowId(), secondId, "needs-you jumps to the top group");
+
+  await fleet.locator(".fleet-perm-deny").click();
+  await fleet.waitForSelector(".fleet-perm", { state: "detached", timeout: 15_000 });
+  await allIdle(2);
+  assert.equal(await firstRowId(), sessionId, "answered → back to creation order");
+  await second.close();
+});
+
+// ---- axe (copy of app.e2e.ts's assertAxeClean — a shared testing helper
+// would force importing that whole suite, which would re-register its tests;
+// dedupe when the helpers move to their own module) ------------------------
+
+const AXE_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"];
+const AXE_EXCEPTIONS: { rule: string; why: string }[] = [];
+
+type AxeViolation = { id: string; impact: string; nodes: unknown[]; help: string };
+type AxePage = { axe: { run: (ctx: Document, opts: unknown) => Promise<{ violations: AxeViolation[] }> } };
+
+async function assertAxeClean(p: Page, label: string): Promise<void> {
+  // Settle animations to their end state first (the C.2 fleet-rise flake).
+  await p.addStyleTag({
+    content:
+      "*, *::before, *::after { animation-duration: 0s !important; " +
+      "animation-delay: 0s !important; transition-duration: 0s !important; }",
+  });
+  await p.addScriptTag({ content: axe.source });
+  const violations = await p.evaluate(
+    async ([tags, exceptions]) => {
+      const rules: Record<string, { enabled: boolean }> = {};
+      for (const r of exceptions as string[]) rules[r] = { enabled: false };
+      const res = await (window as unknown as AxePage).axe.run(document, {
+        resultTypes: ["violations"],
+        runOnly: { type: "tag", values: tags },
+        rules,
+      });
+      return res.violations
+        .filter((v) => v.impact === "serious" || v.impact === "critical")
+        .map((v) => ({ id: v.id, impact: v.impact, help: v.help, count: v.nodes.length }));
+    },
+    [AXE_TAGS, AXE_EXCEPTIONS.map((e) => e.rule)] as const,
+  );
+  assert.deepEqual(
+    violations,
+    [],
+    `axe serious/critical violations on ${label}: ${JSON.stringify(violations, null, 2)}`,
+  );
+}

--- a/server/testing/fleet.e2e.ts
+++ b/server/testing/fleet.e2e.ts
@@ -155,6 +155,29 @@ test("ordering: rows hold creation order while working; needs-you surfaces to th
   await second.close();
 });
 
+test("M.5: the fleet tab itself signals needs-you (title count), and rows show viewport counts", async () => {
+  // Viewport counts: session 1 has its transcript tab open → ⧉ 1.
+  assert.match(
+    await fleet.locator(".fleet-item").first().locator(".fleet-viewports").innerText(),
+    /⧉ \d+/,
+  );
+  assert.equal(await fleet.title(), "Mirafold — sessions");
+
+  await say(session, "do something dangerous");
+  await fleet.waitForSelector(".fleet-perm", { timeout: 15_000 });
+  // The title rides a React effect (post-paint) — poll, don't sample.
+  await fleet.waitForFunction(() => document.title === "⚠ 1 needs you — Mirafold", undefined, {
+    timeout: 5_000,
+  });
+
+  await fleet.locator(".fleet-perm-deny").click();
+  await fleet.waitForSelector(".fleet-perm", { state: "detached", timeout: 15_000 });
+  await allIdle(2);
+  await fleet.waitForFunction(() => document.title === "Mirafold — sessions", undefined, {
+    timeout: 5_000,
+  });
+});
+
 // ---- M.4: phone width — the same cockpit, folded clean and thumb-sized ----
 
 const noSideScroll = async (p: Page) => {

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentInfo, SessionMeta } from "@protocol";
 import { Onboarding } from "./Onboarding";
 import { ConnectDevice } from "./ConnectDevice";
@@ -6,10 +6,12 @@ import { SocketClient } from "../ws";
 import { tildify } from "../tildify";
 import { useArmedConfirm } from "../use-armed-confirm";
 
-// 4.6 Mission control: the root page is an ambient supervision surface —
-// every live session in the registry with name, cwd, coarse status, and last
-// activity, each row dropping into its transcript at /s/<id>. This is shell
-// UI end to end: agent output can never paint here.
+// 4.6 Mission control, grown into the Phase M cockpit: every live session in
+// the registry with name, cwd, live activity, pending permission, and usage —
+// and the grid acts on sessions (answer a permission, interrupt, dispatch a
+// prompt) without entering them. This is shell UI end to end: agent output
+// can never paint here, and every engine-derived string (activity label,
+// permission detail) renders as inert plain text — never markdown.
 
 function ago(ts: number): string {
   const s = Math.max(0, Math.floor((Date.now() - ts) / 1000));
@@ -20,7 +22,45 @@ function ago(ts: number): string {
   return `${Math.floor(s / 86400)}d ago`;
 }
 
+/** Elapsed-time readout beside the activity label ("14s", "2m", "1h"). */
+function elapsed(since: number): string {
+  const s = Math.max(0, Math.floor((Date.now() - since) / 1000));
+  if (s < 60) return `${s}s`;
+  if (s < 3600) return `${Math.floor(s / 60)}m`;
+  return `${Math.floor(s / 3600)}h`;
+}
+
+/** Compact token count ("870", "12.3k", "1.2M") — the cockpit's own small
+ *  formatter; StatusBar's display is its own (never imported across). */
+function fmtTokens(n: number): string {
+  if (n < 1000) return `${n}`;
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(1).replace(/\.0$/, "")}M`;
+}
+
+/** The activity line, glyph-prefixed like the in-session status line:
+ *  "✳ thinking", "⚙ Bash", and a bang label ("! cmd") kept as-is. */
+function activityText(a: NonNullable<SessionMeta["activity"]>): string {
+  const head = a.label === "thinking" ? "✳ thinking" : a.label.startsWith("! ") ? a.label : `⚙ ${a.label}`;
+  return `${head} · ${elapsed(a.since)}`;
+}
+
 const STATUS_LABEL = { idle: "idle", working: "working", permission: "needs you" } as const;
+
+/** Cockpit ordering (Kyle's call, Phase M): rows hold a stable creation
+ *  order so eyes can park on a session; the one exception is sessions
+ *  awaiting permission, which surface to a top group — longest-stalled
+ *  first (their stream is blocked, so lastActivity is when they stalled).
+ *  `createdAt` is optional on the wire (old daemon); absent → the wire
+ *  order holds (the sort is stable). */
+function cockpitOrder(sessions: SessionMeta[]): SessionMeta[] {
+  const rank = (s: SessionMeta) => (s.status === "permission" ? 0 : 1);
+  return [...sessions].sort(
+    (a, b) =>
+      rank(a) - rank(b) ||
+      (rank(a) === 0 ? a.lastActivity - b.lastActivity : (a.createdAt ?? 0) - (b.createdAt ?? 0)),
+  );
+}
 
 export function FleetView() {
   const [sessions, setSessions] = useState<SessionMeta[] | null>(null);
@@ -35,12 +75,22 @@ export function FleetView() {
   // button opens in a fresh tab (2026-07-20, Kyle).
   const [showNew, setShowNew] = useState(() => new URLSearchParams(location.search).has("new"));
   const [onbError, setOnbError] = useState<string | null>(null);
+  // A fleet ACT's error reply (unknown session, relay gate) — a dismissible
+  // header line, kept apart from the onboarding card's error slot (M.3).
+  const [actionError, setActionError] = useState<string | null>(null);
   const [renaming, setRenaming] = useState<string | null>(null);
   // SessionId whose "end" button is armed (first click); a second click
-  // ends it (#11).
+  // ends it (#11). The stop (interrupt) button gets the same two-click arm.
   const endConfirm = useArmedConfirm<string>();
   const confirmEnd = endConfirm.armed;
-  const [, setTick] = useState(0); // re-render so the "ago" labels stay honest
+  const stopConfirm = useArmedConfirm<string>();
+  const confirmStop = stopConfirm.armed;
+  // Permission ids already answered from the grid — buttons disable
+  // instantly; the next snapshot (queue dropped server-side) prunes them.
+  const [answered, setAnswered] = useState<ReadonlySet<string>>(new Set());
+  // SessionId whose quick-prompt line is open (one at a time).
+  const [promptFor, setPromptFor] = useState<string | null>(null);
+  const [, setTick] = useState(0); // re-render so ago/elapsed labels stay honest
 
   const socket = useMemo(() => {
     const s = new SocketClient();
@@ -48,30 +98,55 @@ export function FleetView() {
     return s;
   }, []);
 
+  // The socket's message handler lives for the socket's life; it reads the
+  // picker's openness through this ref so error ROUTING follows the live
+  // value (picker open → its card; otherwise → the header line).
+  const showNewRef = useRef(false);
+
   useEffect(() => {
     const offMsg = socket.onMessage((m) => {
-      if (m.type === "sessions") setSessions(m.sessions);
-      else if (m.type === "agents") {
+      if (m.type === "sessions") {
+        setSessions(m.sessions);
+        // Answered ids leave the set once the server's queue no longer
+        // carries them — the set stays bounded to what's actually pending.
+        setAnswered((prev) => {
+          const pending = new Set(
+            m.sessions.flatMap((s) => (s.permissions ?? []).map((p) => p.id)),
+          );
+          const kept = [...prev].filter((id) => pending.has(id));
+          return kept.length === prev.size ? prev : new Set(kept);
+        });
+      } else if (m.type === "agents") {
         setAgents(m.agents);
         setDaemon({ cwd: m.cwd, home: m.home, relay: m.relay });
       } else if (m.type === "session_created") {
         // The create issued from the onboarding card below: enter the session.
         location.assign(`/s/${m.sessionId}`);
       } else if (m.type === "error") {
-        setOnbError(m.message);
+        // While the picker is open its card owns errors (a refused create);
+        // otherwise the reply belongs to a grid act — the header line (M.3).
+        if (showNewRef.current) setOnbError(m.message);
+        else setActionError(m.message);
       }
     });
     const offOpen = socket.onOpen(() => setConnected(true));
     const offClose = socket.onClose(() => setConnected(false));
-    const timer = setInterval(() => setTick((t) => t + 1), 30_000);
     return () => {
       offMsg();
       offOpen();
       offClose();
-      clearInterval(timer);
       socket.close();
     };
   }, [socket]);
+
+  // Ago labels are honest at 30s; the second-resolution elapsed readout wants
+  // a 1s tick — but only while something is actually active, so an idle
+  // fleet page stays quiet.
+  const hasLive = (sessions ?? []).some((s) => s.activity || s.status === "working");
+  useEffect(() => {
+    const timer = setInterval(() => setTick((t) => t + 1), hasLive ? 1000 : 30_000);
+    return () => clearInterval(timer);
+  }, [hasLive]);
 
   useEffect(() => {
     document.title = "Mirafold — sessions";
@@ -87,8 +162,22 @@ export function FleetView() {
     if (name.trim()) socket.send({ type: "rename", sessionId: id, name });
   };
 
+  const answerPermission = (sessionId: string, id: string, allow: boolean) => {
+    socket.send({ type: "answer_permission", sessionId, id, allow });
+    setAnswered((prev) => new Set([...prev, id]));
+  };
+
+  const sendQuickPrompt = (sessionId: string, text: string) => {
+    if (text.trim()) socket.send({ type: "prompt_session", sessionId, text });
+    setPromptFor(null);
+  };
+
   // First run (no sessions yet) opens straight into "choose your agent".
   const onboarding = showNew || (sessions !== null && sessions.length === 0);
+  showNewRef.current = onboarding;
+
+  const ordered = cockpitOrder(sessions ?? []);
+  const needsYou = ordered.filter((s) => s.status === "permission").length;
 
   return (
     <div className="fleet">
@@ -130,90 +219,209 @@ export function FleetView() {
             + new session
           </button>
         </header>
+        {/* Screen-reader pulse for the cockpit's "act here" state (M.3). */}
+        <span className="sr-only" aria-live="polite">
+          {needsYou > 0
+            ? `${needsYou} session${needsYou === 1 ? " needs" : "s need"} your permission`
+            : ""}
+        </span>
+        {actionError && (
+          <div className="fleet-error" role="alert">
+            <span className="fleet-error-text">{actionError}</span>
+            <button
+              className="fleet-error-dismiss"
+              aria-label="Dismiss this error"
+              onClick={() => setActionError(null)}
+            >
+              ✕
+            </button>
+          </div>
+        )}
         <div className="fleet-list">
-          {(sessions ?? []).map((s) => {
+          {ordered.map((s) => {
+            const perm = s.permissions?.[0];
+            const morePerms = (s.permissions?.length ?? 0) - 1;
             return (
-              // A.3b: the row is a plain container, NOT an anchor — buttons
-              // inside a link are invalid HTML and made screen readers read the
-              // whole row (id, status, "end") as one link label. The session
-              // NAME is the link; its stretched overlay (.fleet-link::after)
-              // keeps click-anywhere-to-open for mouse users, and the real
-              // controls ride above the overlay.
-              // The cwd stays OFF the row (an on-row column was tried
-              // 2026-07-22 and re-removed the same day as clutter — Kyle):
-              // desktop gets it on hover here; phone gets it in the settings
-              // card's Session section, one tap inside.
-              <div key={s.sessionId} className="fleet-row" title={tildify(s.cwd, daemon.home)}>
-                <span className={`fleet-dot fleet-dot-${s.status}`} title={STATUS_LABEL[s.status]} />
-                {renaming === s.sessionId ? (
-                  <input
-                    className="fleet-rename"
-                    defaultValue={s.name}
-                    autoFocus
-                    spellCheck={false}
-                    onBlur={(e) => commitRename(s.sessionId, e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") commitRename(s.sessionId, e.currentTarget.value);
-                      else if (e.key === "Escape") setRenaming(null);
-                    }}
-                  />
-                ) : (
-                  <span className="fleet-name">
-                    <a className="fleet-link" href={`/s/${s.sessionId}`}>
-                      {s.name}
-                    </a>
-                    <button
-                      className="fleet-edit"
-                      title="Rename this session"
-                      aria-label={`Rename session ${s.name}`}
-                      onClick={() => setRenaming(s.sessionId)}
-                    >
-                      ✎
-                    </button>
+              // A wrapper per session (M.3): the classic row plus its
+              // cockpit sub-lines — the pending-permission line and the
+              // quick-prompt line — so the row's stretched click-overlay
+              // (.fleet-link::after, bounded by .fleet-row's position)
+              // never covers the sub-line controls.
+              <div key={s.sessionId} className="fleet-item">
+                {/* A.3b: the row is a plain container, NOT an anchor — buttons
+                    inside a link are invalid HTML and made screen readers read the
+                    whole row (id, status, "end") as one link label. The session
+                    NAME is the link; its stretched overlay (.fleet-link::after)
+                    keeps click-anywhere-to-open for mouse users, and the real
+                    controls ride above the overlay.
+                    The cwd stays OFF the row (an on-row column was tried
+                    2026-07-22 and re-removed the same day as clutter — Kyle):
+                    desktop gets it on hover here; phone gets it in the settings
+                    card's Session section, one tap inside. */}
+                <div className="fleet-row" title={tildify(s.cwd, daemon.home)}>
+                  <span className={`fleet-dot fleet-dot-${s.status}`} title={STATUS_LABEL[s.status]} />
+                  {renaming === s.sessionId ? (
+                    <input
+                      className="fleet-rename"
+                      defaultValue={s.name}
+                      autoFocus
+                      spellCheck={false}
+                      onBlur={(e) => commitRename(s.sessionId, e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") commitRename(s.sessionId, e.currentTarget.value);
+                        else if (e.key === "Escape") setRenaming(null);
+                      }}
+                    />
+                  ) : (
+                    <span className="fleet-name">
+                      <a className="fleet-link" href={`/s/${s.sessionId}`}>
+                        {s.name}
+                      </a>
+                      <button
+                        className="fleet-edit"
+                        title="Rename this session"
+                        aria-label={`Rename session ${s.name}`}
+                        onClick={() => setRenaming(s.sessionId)}
+                      >
+                        ✎
+                      </button>
+                    </span>
+                  )}
+                  {/* Agent before model, matching the in-session status bar (2026-07-17, Kyle);
+                      model only when known, like the bar (2026-07-23). */}
+                  <span className="fleet-agent">{s.agent}</span>
+                  {s.model && (
+                    <span className="fleet-model" title="model">
+                      {s.model}
+                    </span>
+                  )}
+                  {s.activity && (
+                    <span className="fleet-activity" title="current activity">
+                      {activityText(s.activity)}
+                    </span>
+                  )}
+                  <span className="fleet-spacer" />
+                  {s.usage && (
+                    <span className="fleet-usage" title="session tokens · cost">
+                      {fmtTokens(s.usage.inputTokens + s.usage.outputTokens)} tok
+                      {s.usage.costUsd !== undefined ? ` · $${s.usage.costUsd.toFixed(2)}` : ""}
+                    </span>
+                  )}
+                  <span className="fleet-id" title="session id">
+                    {s.sessionId}
                   </span>
-                )}
-                {/* Agent before model, matching the in-session status bar (2026-07-17, Kyle);
-                    model only when known, like the bar (2026-07-23). */}
-                <span className="fleet-agent">{s.agent}</span>
-                {s.model && (
-                  <span className="fleet-model" title="model">
-                    {s.model}
+                  <span className="fleet-sep" aria-hidden="true">
+                    —
                   </span>
-                )}
-                <span className="fleet-spacer" />
-                <span className="fleet-id" title="session id">
-                  {s.sessionId}
-                </span>
-                <span className="fleet-sep" aria-hidden="true">
-                  —
-                </span>
-                <span className={`fleet-status fleet-status-${s.status}`}>
-                  {STATUS_LABEL[s.status]}
-                </span>
-                <span className="fleet-ago">{ago(s.lastActivity)}</span>
-                <button
-                  className={"fleet-end" + (confirmEnd === s.sessionId ? " fleet-end-armed" : "")}
-                  title={
-                    confirmEnd === s.sessionId
-                      ? "Click again to end this session"
-                      : "End this session"
-                  }
-                  aria-label={
-                    confirmEnd === s.sessionId
-                      ? `Click again to end session ${s.name}`
-                      : `End session ${s.name}`
-                  }
-                  onClick={() => {
-                    if (confirmEnd === s.sessionId) {
-                      socket.send({ type: "end_session", sessionId: s.sessionId });
-                      endConfirm.disarm();
-                    } else {
-                      endConfirm.arm(s.sessionId);
+                  <span className={`fleet-status fleet-status-${s.status}`}>
+                    {STATUS_LABEL[s.status]}
+                  </span>
+                  <span className="fleet-ago">{ago(s.lastActivity)}</span>
+                  <button
+                    className={
+                      "fleet-prompt-toggle" + (promptFor === s.sessionId ? " fleet-prompt-toggle-open" : "")
                     }
-                  }}
-                >
-                  {confirmEnd === s.sessionId ? "end?" : "end"}
-                </button>
+                    title="Send a prompt to this session"
+                    aria-label={`Send a prompt to session ${s.name}`}
+                    aria-expanded={promptFor === s.sessionId}
+                    onClick={() => setPromptFor(promptFor === s.sessionId ? null : s.sessionId)}
+                  >
+                    ❯
+                  </button>
+                  {s.status === "working" && (
+                    <button
+                      className={"fleet-stop" + (confirmStop === s.sessionId ? " fleet-stop-armed" : "")}
+                      title={
+                        confirmStop === s.sessionId
+                          ? "Click again to interrupt this turn"
+                          : "Interrupt this turn (the session stays warm)"
+                      }
+                      aria-label={
+                        confirmStop === s.sessionId
+                          ? `Click again to interrupt session ${s.name}`
+                          : `Interrupt session ${s.name}`
+                      }
+                      onClick={() => {
+                        if (confirmStop === s.sessionId) {
+                          socket.send({ type: "interrupt_session", sessionId: s.sessionId });
+                          stopConfirm.disarm();
+                        } else {
+                          stopConfirm.arm(s.sessionId);
+                        }
+                      }}
+                    >
+                      {confirmStop === s.sessionId ? "stop?" : "stop"}
+                    </button>
+                  )}
+                  <button
+                    className={"fleet-end" + (confirmEnd === s.sessionId ? " fleet-end-armed" : "")}
+                    title={
+                      confirmEnd === s.sessionId
+                        ? "Click again to end this session"
+                        : "End this session"
+                    }
+                    aria-label={
+                      confirmEnd === s.sessionId
+                        ? `Click again to end session ${s.name}`
+                        : `End session ${s.name}`
+                    }
+                    onClick={() => {
+                      if (confirmEnd === s.sessionId) {
+                        socket.send({ type: "end_session", sessionId: s.sessionId });
+                        endConfirm.disarm();
+                      } else {
+                        endConfirm.arm(s.sessionId);
+                      }
+                    }}
+                  >
+                    {confirmEnd === s.sessionId ? "end?" : "end"}
+                  </button>
+                </div>
+                {perm && (
+                  // The "act here" line (M.3): WHAT the session wants, inert
+                  // plain text, answerable in place. Oldest first, exactly
+                  // like the in-session permission bar.
+                  <div className="fleet-perm">
+                    <span className="fleet-perm-detail" title={`${perm.tool} · ${perm.detail}`}>
+                      {perm.tool} · {perm.detail}
+                    </span>
+                    {morePerms > 0 && <span className="fleet-perm-more">+{morePerms} more</span>}
+                    <button
+                      className="fleet-perm-allow"
+                      disabled={answered.has(perm.id)}
+                      aria-label={`Allow ${perm.tool} in session ${s.name}`}
+                      onClick={() => answerPermission(s.sessionId, perm.id, true)}
+                    >
+                      allow
+                    </button>
+                    <button
+                      className="fleet-perm-deny"
+                      disabled={answered.has(perm.id)}
+                      aria-label={`Deny ${perm.tool} in session ${s.name}`}
+                      onClick={() => answerPermission(s.sessionId, perm.id, false)}
+                    >
+                      deny
+                    </button>
+                  </div>
+                )}
+                {promptFor === s.sessionId && (
+                  <div className="fleet-prompt">
+                    <span className="glyph" aria-hidden="true">
+                      ❯
+                    </span>
+                    <input
+                      className="fleet-prompt-input"
+                      autoFocus
+                      spellCheck={false}
+                      placeholder="send a prompt to this session…"
+                      aria-label={`Prompt for session ${s.name}`}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") sendQuickPrompt(s.sessionId, e.currentTarget.value);
+                        else if (e.key === "Escape") setPromptFor(null);
+                      }}
+                    />
+                  </div>
+                )}
               </div>
             );
           })}

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -5,6 +5,7 @@ import { ConnectDevice } from "./ConnectDevice";
 import { SocketClient } from "../ws";
 import { tildify } from "../tildify";
 import { useArmedConfirm } from "../use-armed-confirm";
+import { paintTabStatus } from "../tab-status";
 
 // 4.6 Mission control, grown into the Phase M cockpit: every live session in
 // the registry with name, cwd, live activity, pending permission, and usage —
@@ -148,9 +149,19 @@ export function FleetView() {
     return () => clearInterval(timer);
   }, [hasLive]);
 
+  // M.5: the fleet TAB is a cockpit signal too — the same badge grammar as a
+  // session tab (amber = something needs you, blue = fleet busy), title
+  // carrying the needs-you count. paintTabStatus draws the favicon; the
+  // fleet's own title overwrites its session wording.
+  const needsYou = (sessions ?? []).filter((s) => s.status === "permission").length;
+  const fleetBusy = (sessions ?? []).some((s) => s.status === "working");
   useEffect(() => {
-    document.title = "Mirafold — sessions";
-  }, []);
+    paintTabStatus(needsYou > 0 ? "permission" : fleetBusy ? "busy" : "idle");
+    document.title =
+      needsYou > 0
+        ? `⚠ ${needsYou} need${needsYou === 1 ? "s" : ""} you — Mirafold`
+        : "Mirafold — sessions";
+  }, [needsYou, fleetBusy]);
 
   // Stable identity: Onboarding keys its poll interval on this prop, so a
   // fresh arrow each render would restart the 3s timer instead of letting
@@ -177,7 +188,6 @@ export function FleetView() {
   showNewRef.current = onboarding;
 
   const ordered = cockpitOrder(sessions ?? []);
-  const needsYou = ordered.filter((s) => s.status === "permission").length;
 
   return (
     <div className="fleet">
@@ -317,6 +327,11 @@ export function FleetView() {
                     {STATUS_LABEL[s.status]}
                   </span>
                   <span className="fleet-ago">{ago(s.lastActivity)}</span>
+                  {/* M.5: who's watching — 0 is the interesting number (an
+                      unwatched session still working for you). */}
+                  <span className="fleet-viewports" title="open viewports">
+                    ⧉ {s.viewports}
+                  </span>
                   <button
                     className={
                       "fleet-prompt-toggle" + (promptFor === s.sessionId ? " fleet-prompt-toggle-open" : "")

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3138,3 +3138,205 @@ html {
     display: none;
   }
 }
+
+/* ---- Phase M cockpit (M.3): the enriched fleet rows -----------------------
+   All additive — the classic .fleet-row styling above is untouched. Each
+   session renders as a .fleet-item: the row plus its cockpit sub-lines
+   (pending permission, quick prompt). */
+
+.fleet-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+/* The live "what it's doing" readout (✳ thinking · 14s / ⚙ Bash · 2m).
+   Ellipsized: a bang label carries the command's first line. */
+.fleet-activity {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78em;
+  color: var(--info);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 30ch;
+}
+
+/* Session-total tokens · cost, dim like the id cluster it sits beside. */
+.fleet-usage {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78em;
+  color: var(--fg-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+/* Row controls added by the cockpit ride above the stretched row-link
+   overlay, exactly like .fleet-edit/.fleet-end. */
+.fleet-stop,
+.fleet-prompt-toggle {
+  position: relative;
+  z-index: 1;
+}
+
+/* Interrupt: the end button's shape, warn-toned — it halts a turn, it
+   doesn't kill the session. Two-click armed (stop → stop?). */
+.fleet-stop {
+  flex-shrink: 0;
+  margin-left: 2px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.74em;
+  color: var(--fg-faint);
+  background: none;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+
+.fleet-stop:hover {
+  color: var(--warn-fg);
+  border-color: var(--warn-border-2);
+}
+
+.fleet-stop-armed,
+.fleet-stop-armed:hover {
+  color: var(--warn-fg);
+  border-color: var(--warn-border-2);
+  background: var(--warn-bg);
+}
+
+/* The per-row quick-prompt toggle (❯). */
+.fleet-prompt-toggle {
+  flex-shrink: 0;
+  margin-left: 2px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.74em;
+  color: var(--fg-faint);
+  background: none;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 3px 8px;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.fleet-prompt-toggle:hover,
+.fleet-prompt-toggle-open {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
+/* The "act here" sub-line: what the session is blocked on, answerable in
+   place. Warn-tinted like the in-session permission bar's family; the
+   detail is engine text, rendered inert and ellipsized. */
+.fleet-perm {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-left: 24px;
+  padding: 7px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
+  background: var(--warn-bg);
+  border: 1px solid var(--warn-border);
+  border-radius: 8px;
+  animation: rise 0.16s ease-out both;
+}
+
+.fleet-perm-detail {
+  color: var(--warn-fg);
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.fleet-perm-more {
+  color: var(--fg-faint);
+  flex-shrink: 0;
+}
+
+.fleet-perm-allow,
+.fleet-perm-deny {
+  flex-shrink: 0;
+  font-family: inherit;
+  font-size: 0.92em;
+  color: var(--fg-dim);
+  background: none;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 3px 10px;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease;
+}
+
+.fleet-perm-allow:hover:enabled {
+  color: var(--accent);
+  border-color: var(--border-hover);
+}
+
+.fleet-perm-deny:hover:enabled {
+  color: var(--error);
+  border-color: var(--err-border-strong);
+}
+
+.fleet-perm-allow:disabled,
+.fleet-perm-deny:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+/* The quick-prompt sub-line: one input, Enter sends, Escape closes. */
+.fleet-prompt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-left: 24px;
+  animation: rise 0.16s ease-out both;
+}
+
+.fleet-prompt-input {
+  flex: 1;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  color: var(--fg);
+  background: var(--bg-inset);
+  border: 1px solid var(--border-hover);
+  border-radius: 6px;
+  padding: 6px 10px;
+  outline: none;
+}
+
+/* A grid act's error reply (unknown session, relay gate) — dismissible,
+   above the list, never inside the onboarding card's slot. */
+.fleet-error {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  padding: 8px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82em;
+  color: var(--error);
+  background: var(--err-bg);
+  border: 1px solid var(--err-border-strong);
+  border-radius: 8px;
+}
+
+.fleet-error-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.fleet-error-dismiss {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 1em;
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3386,3 +3386,20 @@ html {
     font-size: 16px;
   }
 }
+
+/* ---- Phase M cockpit (M.5): viewport count -------------------------------- */
+
+.fleet-viewports {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.78em;
+  color: var(--fg-faint);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+@media (max-width: 640px) {
+  /* Plumbing column — steps back on phone like .fleet-id above. */
+  .fleet-viewports {
+    display: none;
+  }
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3340,3 +3340,49 @@ html {
   padding: 0 4px;
   font-size: 1em;
 }
+
+/* ---- Phase M cockpit (M.4): phone-width folding ---------------------------
+   Own additive block. The sub-lines lose their desktop indent (a 390px
+   canvas has no room to spend on hierarchy), the activity readout
+   ellipsizes harder, and every act control is thumb-sized. */
+
+@media (max-width: 640px) {
+  .fleet-activity {
+    max-width: 34vw;
+  }
+
+  .fleet-perm,
+  .fleet-prompt {
+    margin-left: 0;
+  }
+
+  /* Detail on its own full-width (still one ellipsized line), the
+     allow/deny pair wrapping beneath it at thumb size. */
+  .fleet-perm {
+    flex-wrap: wrap;
+    row-gap: 6px;
+  }
+
+  .fleet-perm-detail {
+    flex: 1 1 100%;
+  }
+
+  .fleet-perm-allow,
+  .fleet-perm-deny {
+    min-height: 40px;
+    padding: 5px 16px;
+  }
+
+  /* .fleet-end's phone sizing, matched. */
+  .fleet-stop,
+  .fleet-prompt-toggle {
+    min-height: 36px;
+    padding: 5px 12px;
+  }
+
+  /* 16px = the iOS no-auto-zoom threshold (see the rule at the top of the
+     phone block above) — anything focusable must never go below it. */
+  .fleet-prompt-input {
+    font-size: 16px;
+  }
+}


### PR DESCRIPTION
Grows FleetView into the cockpit per the locked 2026-07-24 design (PLAN.md Phase M, all five steps checked off with dated notes):

- **M.1** additive `SessionMeta` live state (activity, permission queue, usage, createdAt), derived in the registry — agent-neutral, riding the existing `watch_sessions` snapshot path.
- **M.2** grid acts: `answer_permission` / `interrupt_session` / `prompt_session` (end_session precedent), R.4i relay gate on the model-driving acts.
- **M.3** the enriched rows: inline allow/deny, armed stop, quick prompt, stable order with needs-you first.
- **M.4** phone-width folding (≥40px thumb targets, 16px input floor, noSideScroll clean).
- **M.5** fleet tab needs-you badge/title + row viewport counts.

All tiers green: **357 / 94 / 47** (new: `fleet-acts.test.ts`, `fleet-cockpit.itest.ts`, `fleet.e2e.ts`). Shared files touched additively at anchors clear of Phase E — rebased over PR #7 with zero conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)