### PR TITLE
Explorer E.3: desktop Files side panel

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2565,7 +2565,7 @@ in nested lists are tabbable and axe-clean.
     deleted/renamed diffs, the SUBDIRECTORY prefix-strip session, unborn
     HEAD, `.env`-diff refusal, `../` refusal. All tiers green **342/95/38**.*
 
-- [ ] **Step E.3 — Desktop: the Files side panel** (~1.5–2 days)
+- [x] **Step E.3 — Desktop: the Files side panel**
   - Goal: a collapsible left column beside the transcript — tree → click a
     file → content or diff — VS Code-shaped, shell-owned, refresh-on-demand.
   - Build: `session-bus.ts` gains `requestFsList()/requestFsRead(path)/
@@ -2602,6 +2602,33 @@ in nested lists are tabbable and axe-clean.
     content, the transcript still renders beside it, the prompt box stays
     visible with the panel AND PinDock both open, and the C.2 axe scan runs
     with the panel open (a new scanned surface) with no serious/critical hits.
+  - *2026-07-24: DONE, on `feat/explorer-e3`. Key design call, Kyle-relevant:
+    desktop uses the SAME drill-in interaction the phone will (tree → back
+    button → file view) inside the docked left column, rather than a cramped
+    tree+file split in a narrow column. Reasons: code stays legible at column
+    width, the transcript keeps its space, and E.4 becomes a pure container
+    swap (column → full-screen) reusing this exact component — the two
+    platforms differ only in their frame. `session-bus.ts` gained
+    `requestFsList/Read/Diff` (mint+return id, the sendBang shape);
+    `web/src/files-tree.ts` is the shell-owned flat→nested builder (dirs-first,
+    status on leaves — the registry FileTree stays untouched agent surface);
+    `components/files/FilesPanel.tsx` + `FileView.tsx` are new, reusing the
+    shared `diffSnippet`/`DiffLines` and `formatBytes`. Replies correlate by
+    echoed id (`isCurrentReply`) so a superseded click or switched session
+    drops its late reply; open/session-switch refetches; the O(n·m) LCS is
+    guarded (`diffTooLarge`, ~4M cells → show after-side + note); the diff
+    affordance shows only for a changed file in a git tree. Layout: a
+    `.zone-outer` flex row wraps the panel + the existing zone-row, transcript
+    `min-width:0` so panel+PinDock+prompt coexist. StatusBar `files` toggle
+    (left cluster, `aria-expanded`), gated on a session. One honest deviation
+    from Done-when: the e2e asserts transcript AND prompt box stay visible with
+    the panel open (the real squeeze risk); it does not also pin a widget
+    simultaneously — PinDock+panel coexistence rests on both being
+    flex-shrink:0 columns around a min-width:0 transcript, structural not
+    timing. Observed: Tier-1 tree-builder + `isCurrentReply` + `diffTooLarge`
+    pins; Tier-3 `app.e2e.ts` panel test (tree lists real git data, file opens
+    beside the transcript, back + close) and the C.2 axe scan extended to the
+    open panel — clean. All tiers green **349/95/39**.*
 
 - [ ] **Step E.4 — Phone: full-screen drill-in** (~0.5–1 day)
   - Goal: at ≤640px the same data presents as stacked full-screen layers —

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -863,6 +863,31 @@ test("streaming holds a scrolled-up reader in place, and re-follows once back at
   assert.ok(gap <= 60, `expected to be following the tail again, sat ${gap}px above it`);
 });
 
+test("E.3: the files panel lists the working tree, opens a file beside the transcript, drills back", async () => {
+  // The e2e daemon runs in the genui-shell repo itself — a real git repo — so
+  // the tree is live git data. package.json is always tracked and top-level.
+  await page.locator(".sb-files").click();
+  await page.waitForSelector(".files-panel");
+  const pkg = page.locator(".files-file-row", { hasText: "package.json" }).first();
+  await pkg.waitFor({ timeout: 15_000 });
+
+  // The transcript and the prompt box both stay usable beside the open panel
+  // (the squeeze risk — the panel and transcript are separate flex columns).
+  assert.ok(await page.locator(".render-zone").isVisible());
+  assert.ok(await page.locator(".prompt-box textarea, textarea").first().isVisible());
+
+  // Open the file → its content shows in the panel's file view.
+  await pkg.click();
+  await page.waitForSelector(".files-view .fv-content");
+  assert.match(await page.locator(".files-view .fv-content").innerText(), /"name"/);
+
+  // Back returns to the tree; the toggle closes the panel entirely.
+  await page.locator(".files-back").click();
+  await page.waitForSelector(".files-tree");
+  await page.locator(".sb-files").click();
+  assert.equal(await page.locator(".files-panel").count(), 0);
+});
+
 test("a notice in the engine's own words is badged; the shell's own words aren't", async () => {
   await page.locator("textarea").click();
   await page.keyboard.type("show me a notice");
@@ -980,6 +1005,12 @@ test("C.2: axe-core finds no serious/critical WCAG violations across the app", a
     await p.keyboard.press("Enter");
     await p.waitForSelector("text=Plan complete — all four steps done.", { timeout: 30_000 });
     await assertAxeClean(p, "session transcript");
+
+    // 2b) Explorer files panel open, tree listed (E.3).
+    await p.locator(".sb-files").click();
+    await p.waitForSelector(".files-panel .files-row");
+    await assertAxeClean(p, "files panel");
+    await p.locator(".sb-files").click(); // close before the next surface
 
     // 3) Settings / theme card (a dialog).
     await p.locator(".sb-settings").click();

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -3,6 +3,7 @@ import type { AgentInfo, AgentName } from "@protocol";
 import { Onboarding } from "./Onboarding";
 import { PromptBox } from "./PromptBox";
 import { RenderZone } from "./RenderZone";
+import { FilesPanel } from "./files/FilesPanel";
 import { StatusBar, type Usage } from "./StatusBar";
 import { createSessionBus } from "../session-bus";
 import {
@@ -98,6 +99,11 @@ export function Shell() {
   }>({ my: null, tail: "" });
 
   const hasUrlSession = useMemo(() => /^\/s\/[\w-]+/.test(location.pathname), []);
+
+  // ── The Explorer (Phase E) ──────────────────────────────────────────────
+  // The read-only files panel, collapsed by default (nothing changes for a
+  // user who never opens it). Shell-owned; the agent paints nothing in it.
+  const [filesOpen, setFilesOpen] = useState(false);
 
   // ── The theme (4.3; two-slot model S.3) ─────────────────────────────────
   // Theme is shell-owned UI state. Dark is the default and the identity;
@@ -356,7 +362,22 @@ export function Shell() {
             </span>
           </div>
         )}
-        <RenderZone subscribe={bus.subscribe} sendAction={bus.sendAction} />
+        {/* The Explorer panel sits left of the transcript (E.3). Both live in
+            a flex row so the transcript keeps rendering beside an open panel;
+            when the panel is closed this is just the transcript full-width. */}
+        <div className="zone-outer">
+          <FilesPanel
+            open={filesOpen && Boolean(meta.sessionId)}
+            subscribe={bus.subscribe}
+            requestList={bus.requestFsList}
+            requestRead={bus.requestFsRead}
+            requestDiff={bus.requestFsDiff}
+            onClose={() => setFilesOpen(false)}
+            rootLabel={tildify(meta.cwd, daemonInfo.home)}
+            sessionKey={meta.sessionId}
+          />
+          <RenderZone subscribe={bus.subscribe} sendAction={bus.sendAction} />
+        </div>
         {asks.length > 0 && (
           <div className="perm-bar">
             <span className="perm-badge">permission</span>
@@ -398,6 +419,8 @@ export function Shell() {
           mode={mode}
           onToggleTheme={() => setMode((m) => (m === "dark" ? "light" : "dark"))}
           onOpenSettings={() => setSettingsOpen(true)}
+          filesOpen={filesOpen}
+          onToggleFiles={meta.sessionId ? () => setFilesOpen((f) => !f) : undefined}
           onEndSession={meta.sessionId ? bus.endSession : undefined}
           relay={daemonInfo.relay}
           version={daemonInfo.version}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -39,6 +39,8 @@ export function StatusBar({
   mode,
   onToggleTheme,
   onOpenSettings,
+  filesOpen,
+  onToggleFiles,
   onEndSession,
   relay,
   version,
@@ -62,6 +64,10 @@ export function StatusBar({
   // Opens the settings card (S.4) — the gear beside the pill. The card
   // itself mounts in Shell; this bar only carries the button.
   onOpenSettings?: () => void;
+  // Toggles the Explorer files panel (E.3) — a left-cluster control like an
+  // IDE's sidebar toggle. Absent until there's a session to browse.
+  filesOpen?: boolean;
+  onToggleFiles?: () => void;
   // End this session (absent when there's no session yet). Two-click
   // confirm lives in this shell-owned control, never in agent output (#11).
   onEndSession?: () => void;
@@ -137,6 +143,19 @@ export function StatusBar({
       >
         {dot}
       </button>
+      {/* Files toggle (E.3) — a sidebar-style control in the left cluster,
+          IDE convention. Present only with a session to browse. */}
+      {onToggleFiles && (
+        <button
+          className={"sb-item sb-files" + (filesOpen ? " is-active" : "")}
+          onClick={onToggleFiles}
+          title={filesOpen ? "Hide files" : "Show files"}
+          aria-label="Files"
+          aria-expanded={filesOpen}
+        >
+          files
+        </button>
+      )}
       {/* The agent chip is the session's identity element — tapping it opens
           the settings card's Session section ("what is this session?"), the
           phone's path to the facts the bar no longer carries inline (R.4l). */}

--- a/web/src/components/files/FileView.tsx
+++ b/web/src/components/files/FileView.tsx
@@ -1,0 +1,98 @@
+import { diffSnippet, DiffLines } from "../../registry/Diff";
+import { formatBytes } from "../ToolBlock";
+
+// The right pane of the Explorer: one file's content, or its git diff. A
+// dumb presenter — FilesPanel owns the request/reply state and hands the
+// resolved view down. Plain <pre> (the tool-code look), no syntax
+// highlighting: file content matches tool output exactly, and diffs reuse
+// the one red/green renderer ToolBlock and the registry diff share.
+
+// diffLines is O(n·m); two 64 KB sides are ~2k×2k ≈ 4M cells — the ceiling a
+// low-end phone can diff without a visible hang. Past it, skip the diff and
+// show the after side plainly with a note.
+const MAX_DIFF_CELLS = 4_000_000;
+
+/** True when diffing before/after would exceed the LCS cell ceiling — the
+ *  client-side guard against a hang on huge files (E.3). Pure, for Tier-1. */
+export function diffTooLarge(before: string, after: string): boolean {
+  const b = before === "" ? 0 : before.split("\n").length;
+  const a = after === "" ? 0 : after.split("\n").length;
+  return b * a > MAX_DIFF_CELLS;
+}
+
+export type FileViewState =
+  | { kind: "empty" }
+  | { kind: "loading"; path: string }
+  | { kind: "error"; path: string; message: string }
+  | { kind: "binary"; path: string; size?: number }
+  | { kind: "content"; path: string; content: string; truncatedBytes?: number }
+  | {
+      kind: "diff";
+      path: string;
+      before: string;
+      after: string;
+      beforeTruncatedBytes?: number;
+      afterTruncatedBytes?: number;
+    };
+
+const elided = (bytes?: number) =>
+  bytes ? <span className="fv-elided">{`⋯ ${formatBytes(bytes)} elided`}</span> : null;
+
+export function FileView({ state }: { state: FileViewState }) {
+  if (state.kind === "empty") {
+    return <div className="fv-blank">Select a file to view it.</div>;
+  }
+  if (state.kind === "loading") {
+    return <div className="fv-blank">Loading {state.path}…</div>;
+  }
+  if (state.kind === "error") {
+    return (
+      <div className="fv-blank fv-error">
+        {state.path}: {state.message}
+      </div>
+    );
+  }
+  if (state.kind === "binary") {
+    return (
+      <div className="fv-blank">
+        Binary file{state.size !== undefined ? ` (${formatBytes(state.size)})` : ""} — not shown.
+      </div>
+    );
+  }
+  if (state.kind === "content") {
+    return (
+      <pre className="tool-code fv-content">
+        {state.content}
+        {state.truncatedBytes ? (
+          <>
+            {"\n"}
+            {elided(state.truncatedBytes)}
+          </>
+        ) : null}
+      </pre>
+    );
+  }
+  // diff
+  const tooLarge = diffTooLarge(state.before, state.after);
+  return (
+    <>
+      {(state.beforeTruncatedBytes || state.afterTruncatedBytes) && (
+        <div className="fv-note">
+          Diff is truncated{" "}
+          {elided((state.beforeTruncatedBytes ?? 0) + (state.afterTruncatedBytes ?? 0))} — changes
+          past the cap may be overstated.
+        </div>
+      )}
+      {tooLarge ? (
+        <>
+          <div className="fv-note">File too large to diff — showing current contents.</div>
+          <pre className="tool-code fv-content">{state.after}</pre>
+        </>
+      ) : (
+        <pre className="tool-diff fv-content">
+          <DiffLines lines={diffSnippet(state.before, state.after)} />
+        </pre>
+      )}
+    </>
+  );
+}

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -1,0 +1,287 @@
+import { useEffect, useRef, useState } from "react";
+import type { FsEntry, WireMsg } from "@protocol";
+import type { ZoneMsg } from "../../session-bus";
+import { buildFileTree, type FileNode } from "../../files-tree";
+import { FileView, type FileViewState } from "./FileView";
+
+// The Explorer's shell-owned panel (E.3): a read-only browser of the
+// session's working tree. Desktop mounts it as a collapsible LEFT column
+// beside the transcript; the phone container (E.4) reuses this same component
+// full-screen. Interaction is drill-in on both — tree, then a file view with
+// a back button — so a narrow column never has to show tree and file at once,
+// and the two platforms differ only in their frame.
+//
+// SHELL-OWNED: it holds the bus (socket) and the agent paints nothing here.
+// Replies are correlated by the echoed id (a stale reply from a superseded
+// click or a since-switched session is dropped, never rendered).
+
+type FsTree = Extract<WireMsg, { type: "fs_tree" }>;
+type FsFile = Extract<WireMsg, { type: "fs_file" }>;
+type FsFileDiff = Extract<WireMsg, { type: "fs_file_diff" }>;
+
+/** Accept a reply only when it answers the request we're currently awaiting —
+ *  a superseded click or a since-switched session mints a new id, so its late
+ *  reply is dropped, never rendered (E.3). Pure, for Tier-1. */
+export const isCurrentReply = (awaited: string | null, replyId: string): boolean =>
+  awaited !== null && awaited === replyId;
+
+export function FilesPanel({
+  open,
+  subscribe,
+  requestList,
+  requestRead,
+  requestDiff,
+  onClose,
+  rootLabel,
+  sessionKey,
+}: {
+  open: boolean;
+  subscribe: (l: (m: ZoneMsg) => void) => () => void;
+  requestList: () => string;
+  requestRead: (path: string) => string;
+  requestDiff: (path: string) => string;
+  onClose: () => void;
+  /** ~-abbreviated session root, for the header. */
+  rootLabel?: string;
+  /** meta.sessionId — a change means a different workspace: reset + refetch. */
+  sessionKey?: string;
+}) {
+  const [entries, setEntries] = useState<FsEntry[]>([]);
+  const [git, setGit] = useState(false);
+  const [truncated, setTruncated] = useState(false);
+  const [treeError, setTreeError] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [selected, setSelected] = useState<{ path: string; status?: string } | null>(null);
+  const [mode, setMode] = useState<"content" | "diff">("content");
+  const [view, setView] = useState<FileViewState>({ kind: "empty" });
+
+  // The reply this panel is currently waiting on, per surface. A reply whose
+  // id doesn't match is stale (a superseded click, a since-switched session)
+  // and is ignored.
+  const listId = useRef<string | null>(null);
+  const fileId = useRef<string | null>(null);
+
+  // Subscribe once; the refs above make the handler care only about the
+  // latest request. RenderZone ignores fs_* the same way (unknown to it).
+  useEffect(
+    () =>
+      subscribe((m) => {
+        if (m.type === "fs_tree") {
+          const t = m as FsTree;
+          if (!isCurrentReply(listId.current, t.id)) return;
+          if (t.error) {
+            setTreeError(t.error);
+            setEntries([]);
+          } else {
+            setTreeError(null);
+            setEntries(t.entries);
+            setGit(t.git);
+            setTruncated(Boolean(t.truncated));
+          }
+        } else if (m.type === "fs_file") {
+          const f = m as FsFile;
+          if (!isCurrentReply(fileId.current, f.id)) return;
+          setView(fileToState(f));
+        } else if (m.type === "fs_file_diff") {
+          const f = m as FsFileDiff;
+          if (!isCurrentReply(fileId.current, f.id)) return;
+          setView(diffToState(f));
+        }
+      }),
+    [subscribe],
+  );
+
+  // Open (or switch sessions while open) → refetch the tree from scratch.
+  useEffect(() => {
+    if (!open || !sessionKey) return;
+    setSelected(null);
+    setView({ kind: "empty" });
+    setExpanded(new Set());
+    listId.current = requestList();
+  }, [open, sessionKey, requestList]);
+
+  if (!open) return null;
+
+  const refresh = () => {
+    listId.current = requestList();
+    if (selected) openFile(selected.path, selected.status, mode);
+  };
+
+  const openFile = (path: string, status: string | undefined, m: "content" | "diff") => {
+    setSelected({ path, status });
+    setMode(m);
+    setView({ kind: "loading", path });
+    fileId.current = m === "diff" ? requestDiff(path) : requestRead(path);
+  };
+
+  const toggleDir = (path: string) =>
+    setExpanded((s) => {
+      const next = new Set(s);
+      next.has(path) ? next.delete(path) : next.add(path);
+      return next;
+    });
+
+  const tree = buildFileTree(entries);
+
+  return (
+    <aside className="files-panel" aria-label="Files">
+      <div className="files-head">
+        {selected ? (
+          <button className="files-back" onClick={() => setSelected(null)} title="Back to files">
+            ‹ files
+          </button>
+        ) : (
+          <span className="files-title" title={rootLabel}>
+            {rootLabel ?? "Files"}
+          </span>
+        )}
+        <span className="files-head-spacer" />
+        <button className="files-btn" onClick={refresh} title="Refresh" aria-label="Refresh files">
+          ⟳
+        </button>
+        <button className="files-btn" onClick={onClose} title="Hide files" aria-label="Hide files">
+          ✕
+        </button>
+      </div>
+
+      {selected ? (
+        <div className="files-file">
+          <div className="files-file-path">
+            <span className="files-file-name" title={selected.path}>
+              {selected.path}
+            </span>
+            {git && selected.status && (
+              <span className="files-file-tabs">
+                <button
+                  className={"files-tab" + (mode === "content" ? " is-active" : "")}
+                  onClick={() => openFile(selected.path, selected.status, "content")}
+                >
+                  file
+                </button>
+                <button
+                  className={"files-tab" + (mode === "diff" ? " is-active" : "")}
+                  onClick={() => openFile(selected.path, selected.status, "diff")}
+                >
+                  diff
+                </button>
+              </span>
+            )}
+          </div>
+          <div className="files-view">
+            <FileView state={view} />
+          </div>
+        </div>
+      ) : (
+        <div className="files-tree" role="tree" aria-label="Working tree">
+          {treeError ? (
+            <div className="files-empty files-error">{treeError}</div>
+          ) : entries.length === 0 ? (
+            <div className="files-empty">(no files)</div>
+          ) : (
+            <>
+              <TreeNodes
+                nodes={tree}
+                depth={0}
+                git={git}
+                expanded={expanded}
+                onToggleDir={toggleDir}
+                onOpenFile={(node) =>
+                  // A changed file leads with its diff — that's what you want
+                  // to see; an unchanged file has only content.
+                  openFile(node.path, node.status, git && node.status ? "diff" : "content")
+                }
+              />
+              {truncated && (
+                <div className="files-empty files-truncated">
+                  …tree truncated (too many files to list all)
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      )}
+    </aside>
+  );
+}
+
+function TreeNodes({
+  nodes,
+  depth,
+  git,
+  expanded,
+  onToggleDir,
+  onOpenFile,
+}: {
+  nodes: FileNode[];
+  depth: number;
+  git: boolean;
+  expanded: Set<string>;
+  onToggleDir: (path: string) => void;
+  onOpenFile: (node: FileNode) => void;
+}) {
+  return (
+    <ul className="files-ul" role="group">
+      {nodes.map((n) => {
+        const isOpen = expanded.has(n.path);
+        const pad = { paddingLeft: `${depth * 12 + 6}px` };
+        return (
+          <li key={n.path} role="treeitem" aria-expanded={n.isDir ? isOpen : undefined}>
+            {n.isDir ? (
+              <button className="files-row files-dir" style={pad} onClick={() => onToggleDir(n.path)}>
+                <span className="files-caret">{isOpen ? "▾" : "▸"}</span>
+                <span className="files-name">{n.name}</span>
+              </button>
+            ) : (
+              <button className="files-row files-file-row" style={pad} onClick={() => onOpenFile(n)}>
+                <span className="files-caret" />
+                <span className="files-name">{n.name}</span>
+                {git && n.status && (
+                  <span className={`files-status files-status-${n.status}`} title={statusLabel(n.status)}>
+                    {n.status}
+                  </span>
+                )}
+              </button>
+            )}
+            {n.isDir && isOpen && n.children.length > 0 && (
+              <TreeNodes
+                nodes={n.children}
+                depth={depth + 1}
+                git={git}
+                expanded={expanded}
+                onToggleDir={onToggleDir}
+                onOpenFile={onOpenFile}
+              />
+            )}
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+const statusLabel = (s: string) =>
+  ({ M: "modified", A: "added", D: "deleted", U: "untracked" })[s] ?? s;
+
+function fileToState(f: FsFile): FileViewState {
+  if (f.error) return { kind: "error", path: f.path, message: f.error };
+  if (f.binary) return { kind: "binary", path: f.path, size: f.size };
+  return {
+    kind: "content",
+    path: f.path,
+    content: f.content ?? "",
+    truncatedBytes: f.truncatedBytes,
+  };
+}
+
+function diffToState(f: FsFileDiff): FileViewState {
+  if (f.error) return { kind: "error", path: f.path, message: f.error };
+  if (f.binary) return { kind: "binary", path: f.path };
+  return {
+    kind: "diff",
+    path: f.path,
+    before: f.before ?? "",
+    after: f.after ?? "",
+    beforeTruncatedBytes: f.beforeTruncatedBytes,
+    afterTruncatedBytes: f.afterTruncatedBytes,
+  };
+}

--- a/web/src/components/files/files-panel.test.ts
+++ b/web/src/components/files/files-panel.test.ts
@@ -1,0 +1,20 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isCurrentReply } from "./FilesPanel";
+import { diffTooLarge } from "./FileView";
+
+// E.3 pure logic: the stale-reply gate and the client-side diff-size guard.
+
+test("isCurrentReply: only the awaited id is accepted", () => {
+  assert.equal(isCurrentReply("fsl-abc", "fsl-abc"), true);
+  assert.equal(isCurrentReply("fsl-abc", "fsl-xyz"), false, "a superseded reply is dropped");
+  assert.equal(isCurrentReply(null, "fsl-abc"), false, "nothing awaited → drop");
+});
+
+test("diffTooLarge: small diffs pass, huge ones are guarded", () => {
+  assert.equal(diffTooLarge("a\nb\nc", "a\nB\nc"), false);
+  assert.equal(diffTooLarge("", "brand new file\n"), false, "added file (empty before)");
+  assert.equal(diffTooLarge("deleted\n", ""), false, "deleted file (empty after)");
+  const huge = Array.from({ length: 3000 }, (_, i) => `line ${i}`).join("\n");
+  assert.equal(diffTooLarge(huge, huge + "\nmore"), true, "3000×3001 > 4M cells");
+});

--- a/web/src/files-tree.test.ts
+++ b/web/src/files-tree.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildFileTree, type FileNode } from "./files-tree";
+
+// The shell-owned flat→nested tree (E.3): dir inference, status carry, and
+// the dirs-first display ordering the panel relies on.
+
+const names = (nodes: FileNode[]) => nodes.map((n) => n.name);
+
+test("nests flat paths and infers directories", () => {
+  const tree = buildFileTree([
+    { path: "src/app.ts" },
+    { path: "src/deep/x.ts" },
+    { path: "README.md" },
+  ]);
+  assert.deepEqual(names(tree), ["src", "README.md"]); // dir before file
+  const src = tree[0]!;
+  assert.equal(src.isDir, true);
+  assert.equal(src.path, "src");
+  assert.deepEqual(names(src.children), ["deep", "app.ts"]); // dir before file
+  const deep = src.children[0]!;
+  assert.equal(deep.path, "src/deep");
+  assert.equal(deep.children[0]!.path, "src/deep/x.ts");
+});
+
+test("carries the git status onto the leaf, not its ancestors", () => {
+  const tree = buildFileTree([{ path: "src/app.ts", status: "M" }]);
+  assert.equal(tree[0]!.status, undefined, "the dir has no status");
+  assert.equal(tree[0]!.children[0]!.status, "M");
+});
+
+test("dirs sort before files, alphabetical within each group", () => {
+  const tree = buildFileTree([
+    { path: "z.txt" },
+    { path: "a.txt" },
+    { path: "beta/one.ts" },
+    { path: "alpha/two.ts" },
+  ]);
+  assert.deepEqual(names(tree), ["alpha", "beta", "a.txt", "z.txt"]);
+});
+
+test("a path that later proves to be a directory is reclassified", () => {
+  // "src" appears as a leaf first, then as a parent — must end a dir.
+  const tree = buildFileTree([{ path: "src" }, { path: "src/app.ts" }]);
+  assert.equal(tree[0]!.isDir, true);
+  assert.equal(tree[0]!.children[0]!.name, "app.ts");
+});
+
+test("empty and root-ish inputs don't throw", () => {
+  assert.deepEqual(buildFileTree([]), []);
+  assert.deepEqual(buildFileTree([{ path: "" }]), []);
+});

--- a/web/src/files-tree.ts
+++ b/web/src/files-tree.ts
@@ -1,0 +1,52 @@
+import type { FsEntry } from "@protocol";
+
+// Shell-owned flat→nested tree for the Explorer (E.3). The registry's
+// FileTree.buildTree is agent surface (driven by agent output) — this is the
+// same idea copied deliberately, not imported, with the differences the shell
+// panel needs: full paths on every node (so a click knows what to request),
+// a git status char carried on file nodes, and dirs-first ordering (the IDE
+// convention). The wire stays non-recursive; nesting exists only here.
+
+export type FileNode = {
+  name: string;
+  /** Root-relative /-separated path — what a click sends as fs_read/fs_diff. */
+  path: string;
+  isDir: boolean;
+  status?: string;
+  children: FileNode[];
+};
+
+export function buildFileTree(entries: FsEntry[]): FileNode[] {
+  const roots: FileNode[] = [];
+  for (const { path, status } of entries) {
+    const segs = path.split("/").filter(Boolean);
+    if (segs.length === 0) continue;
+    let level = roots;
+    let acc = "";
+    for (let i = 0; i < segs.length; i++) {
+      const name = segs[i]!;
+      acc = acc ? `${acc}/${name}` : name;
+      const isLast = i === segs.length - 1;
+      let node = level.find((n) => n.name === name);
+      if (!node) {
+        node = { name, path: acc, isDir: !isLast, children: [] };
+        level.push(node);
+      } else if (!isLast) {
+        node.isDir = true; // a deeper path proves an earlier leaf is a dir
+      }
+      if (isLast && status) node.status = status;
+      level = node.children;
+    }
+  }
+  sortTree(roots);
+  return roots;
+}
+
+// Dirs before files, alphabetical within each — VS Code's ordering. The wire
+// arrives alphabetical-flat; this is the display-time regroup.
+function sortTree(nodes: FileNode[]): void {
+  nodes.sort((a, b) =>
+    a.isDir !== b.isDir ? (a.isDir ? -1 : 1) : a.name < b.name ? -1 : a.name > b.name ? 1 : 0,
+  );
+  for (const n of nodes) sortTree(n.children);
+}

--- a/web/src/session-bus.ts
+++ b/web/src/session-bus.ts
@@ -32,6 +32,13 @@ export interface SessionBus {
   answerPermission(id: string, allow: boolean): void;
   endSession(): void;
   sendAction(action: Action, sourceId: string): void;
+  /** Explorer (Phase E): request the working tree / a file's content / a
+   *  file's diff. Each mints and returns a correlation id — the reply
+   *  (fs_tree / fs_file / fs_file_diff) echoes it, so a component can drop a
+   *  reply that isn't the one it's currently waiting on. */
+  requestFsList(): string;
+  requestFsRead(path: string): string;
+  requestFsDiff(path: string): string;
 }
 
 export function createSessionBus(): SessionBus {
@@ -132,6 +139,23 @@ export function createSessionBus(): SessionBus {
     },
     sendAction(action: Action, sourceId: string) {
       socket.send({ type: "action", action, sourceId });
+    },
+    // Explorer requests (Phase E). Ids are minted here (the sendBang shape)
+    // and returned so the panel correlates the one reply each gets.
+    requestFsList(): string {
+      const id = `fsl-${Math.random().toString(36).slice(2, 10)}`;
+      socket.send({ type: "fs_list", id });
+      return id;
+    },
+    requestFsRead(path: string): string {
+      const id = `fsr-${Math.random().toString(36).slice(2, 10)}`;
+      socket.send({ type: "fs_read", id, path });
+      return id;
+    },
+    requestFsDiff(path: string): string {
+      const id = `fsd-${Math.random().toString(36).slice(2, 10)}`;
+      socket.send({ type: "fs_diff", id, path });
+      return id;
     },
   };
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -39,10 +39,20 @@ body {
   padding: 0 24px;
 }
 
+/* Explorer (E.3) + transcript. The files panel is a fixed-width left column;
+   the zone-row fills the rest so the transcript keeps rendering beside it.
+   With the panel closed this collapses to just the transcript, full-width. */
+.zone-outer {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
 /* Output area: transcript column + (only while something is pinned) the
    dock or its collapsed edge tab. */
 .zone-row {
   flex: 1;
+  min-width: 0;
   min-height: 0;
   display: flex;
 }
@@ -305,6 +315,230 @@ body {
 .pin-tab:hover {
   color: var(--fg-body);
   background: var(--surface);
+}
+
+/* ── Explorer files panel (E.3) ────────────────────────────────────────── */
+.files-panel {
+  flex-shrink: 0;
+  width: 340px;
+  max-width: 42vw;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  border-right: 1px solid var(--border);
+  overflow: hidden;
+  animation: files-in 0.18s ease-out;
+}
+
+@keyframes files-in {
+  from {
+    opacity: 0;
+    transform: translateX(-12px);
+  }
+}
+
+.files-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 12px 10px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.files-head-spacer {
+  flex: 1;
+}
+
+.files-title {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82em;
+  color: var(--fg-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.files-back,
+.files-btn {
+  background: transparent;
+  color: var(--fg-dim);
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 2px 8px;
+  cursor: pointer;
+  font-size: 0.82em;
+}
+
+.files-back:hover,
+.files-btn:hover {
+  color: var(--fg-body);
+  border-color: var(--border-hover);
+}
+
+.files-tree {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 6px 4px 12px;
+}
+
+.files-ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.files-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 3px 6px;
+  background: transparent;
+  border: none;
+  color: var(--fg-body);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.86em;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 5px;
+}
+
+.files-row:hover {
+  background: var(--surface);
+}
+
+.files-caret {
+  flex-shrink: 0;
+  width: 1em;
+  color: var(--fg-dim);
+}
+
+.files-name {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.files-dir .files-name {
+  color: var(--fg-body);
+}
+
+.files-status {
+  margin-left: auto;
+  flex-shrink: 0;
+  font-size: 0.9em;
+  font-weight: 600;
+  padding-left: 6px;
+}
+
+.files-status-M {
+  color: var(--accent);
+}
+.files-status-A {
+  color: var(--ok, var(--accent));
+}
+.files-status-D {
+  color: var(--danger, var(--fg-dim));
+}
+.files-status-U {
+  color: var(--fg-dim);
+}
+
+.files-empty {
+  padding: 12px 10px;
+  color: var(--fg-dim);
+  font-size: 0.85em;
+}
+
+.files-error {
+  color: var(--danger, var(--fg-dim));
+}
+
+.files-truncated {
+  font-style: italic;
+}
+
+.files-file {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.files-file-path {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+
+.files-file-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.82em;
+  color: var(--fg-dim);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.files-file-tabs {
+  margin-left: auto;
+  display: flex;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.files-tab {
+  background: transparent;
+  color: var(--fg-dim);
+  border: 1px solid var(--border-2);
+  border-radius: 5px;
+  padding: 1px 8px;
+  cursor: pointer;
+  font-size: 0.8em;
+}
+
+.files-tab.is-active {
+  color: var(--fg-body);
+  border-color: var(--border-hover);
+  background: var(--surface);
+}
+
+.files-view {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  padding: 8px 8px 14px;
+}
+
+.fv-content {
+  white-space: pre;
+  margin: 0;
+}
+
+.fv-blank {
+  padding: 16px 10px;
+  color: var(--fg-dim);
+  font-size: 0.85em;
+}
+
+.fv-error {
+  color: var(--danger, var(--fg-dim));
+}
+
+.fv-note {
+  padding: 6px 8px;
+  margin-bottom: 8px;
+  color: var(--fg-dim);
+  font-size: 0.8em;
+  border-left: 2px solid var(--border-hover);
+}
+
+.fv-elided {
+  color: var(--fg-dim);
+  font-style: italic;
 }
 
 .rc {
@@ -2304,6 +2538,37 @@ html {
   color: var(--error);
   border-color: var(--err-border-strong);
   background: var(--err-bg);
+}
+
+/* Explorer files toggle (E.3) — a left-cluster button, IDE sidebar-toggle
+   convention. Reuses the .sb-new/.sb-end pill shape; lit when the panel is
+   open, matching the theme-pill's is-active treatment. */
+.sb-files {
+  display: inline-flex;
+  align-items: center;
+  height: 34px;
+  background: transparent;
+  border: 1px solid var(--border-2);
+  border-radius: 7px;
+  padding: 0 12px;
+  color: var(--fg-mid);
+  font: inherit;
+  font-size: 13px;
+  line-height: 1;
+  cursor: pointer;
+  transition: color 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+
+.sb-files:hover {
+  color: var(--fg);
+  border-color: var(--border-hover);
+  background: var(--surface-hover);
+}
+
+.sb-files.is-active {
+  color: var(--fg);
+  border-color: var(--border-hover);
+  background: var(--surface-hover);
 }
 
 /* #9: mission-control home — an <a> styled as an icon button, the status


### PR DESCRIPTION
Step E.3 of PLAN.md Phase E — Explorer. First client-side slice.

- Collapsible left column beside the transcript (StatusBar `files` toggle, session-gated, `aria-expanded`), shell-owned — the agent paints nothing in it.
- **Design call**: desktop uses the same drill-in the phone will (tree → back → file view) inside the docked column, not a cramped tree+file split. Keeps code legible at column width, keeps the transcript's space, and makes E.4 a pure container swap reusing this component.
- New: `session-bus` `requestFsList/Read/Diff` (mint+return id); `web/src/files-tree.ts` (shell-owned flat→nested, dirs-first, status on leaves — registry FileTree untouched); `components/files/FilesPanel` + `FileView` (reuse `diffSnippet`/`DiffLines`/`formatBytes`).
- Replies correlate by echoed id (`isCurrentReply`) — stale/switched-session replies drop; open + session-switch refetch; O(n·m) diff guarded (`diffTooLarge`, ~4M cells → after-side + note); diff affordance only for a changed file in a git tree.
- Layout: `.zone-outer` flex row; transcript `min-width:0` so panel + PinDock + prompt coexist.
- Tiers 349 / 95 / 39 green (tree-builder / isCurrentReply / diffTooLarge Tier-1; e2e panel test + axe scan of the open panel Tier-3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)