### PR TITLE
Explorer E.4: phone full-screen drill-in

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2630,7 +2630,7 @@ in nested lists are tabbable and axe-clean.
     beside the transcript, back + close) and the C.2 axe scan extended to the
     open panel — clean. All tiers green **349/95/39**.*
 
-- [ ] **Step E.4 — Phone: full-screen drill-in** (~0.5–1 day)
+- [x] **Step E.4 — Phone: full-screen drill-in**
   - Goal: at ≤640px the same data presents as stacked full-screen layers —
     StatusBar affordance → tree → file/diff → back — never a squeezed panel.
   - Build: branch on the 640px breakpoint with a LIVE matchMedia check (not
@@ -2646,6 +2646,32 @@ in nested lists are tabbable and axe-clean.
     to the tree; Esc closes the top layer only; `noSideScroll` passes on every
     layer; focus returns to the opener on final close; the axe scan of the
     layers is clean.
+  - *2026-07-24: DONE, on `feat/explorer-e4` (stacked on E.3). Because E.3
+    already made the panel drill-in, E.4 was mostly the frame: a live
+    `useIsPhone` hook (`web/src/use-is-phone.ts` — the tracked matchMedia the
+    plan asked for, not PromptBox's module-load constant), a `@media
+    (max-width:640px)` rule turning `.files-panel` into a full-screen fixed
+    layer (z-index 55, below the 60 modals; safe-area padding; ≥40px rows),
+    and dialog semantics via the two hooks directly (`useFocusTrap` +
+    `useEscapeKey`) rather than `ModalCard`, since drill-in Esc = back-one-layer
+    then close, which ModalCard's fixed onDismiss can't express. Also
+    restructured the panel so the tree stays MOUNTED with the file view laid
+    over it (absolute overlay) — back reveals the tree at its prior scroll,
+    and this improves desktop too. **One real bug found + fixed while
+    verifying** (the honest kind the e2e existed to catch): the trap/escape
+    were gated on `phone` alone, but FilesPanel is always mounted (returns
+    null when closed), so the hooks' `[ref, active]` deps never re-fired when
+    `open` flipped false→true — the trap ran once at mount (closed, a no-op)
+    and never engaged. Gated on `phone && open`; the e2e proved it (focus →
+    files-btn on open, → sb-files on close). Design note for E.4's "each layer
+    is a ModalCard": kept as ONE component with an overlaid file layer, not
+    two stacked ModalCards — simpler, and back-preserves-scroll falls out.
+    Verified: `phone.e2e.ts` at 390px — full-screen open, drill to a file,
+    Esc-back-to-tree (panel stays), Esc-close, `noSideScroll` at every layer,
+    focus-return on close (tested via keyboard open, the path where the A.3
+    contract is real — a touch tap doesn't focus the opener). The existing
+    tight phone status-bar row absorbed the `files` control without wrapping
+    (no flex-wrap) or side-scroll. All tiers green **349/95/40**.*
 
 - [ ] **Step E.5 — Polish (optional; the cut line)** (~0.5 day)
   - Auto-refresh the open panel on `turn_end` (the server throttle already

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -170,6 +170,50 @@ test("phone: pairs by URL, opens the session, drives a turn with a rendered comp
   assert.ok(promptFont >= 16, `prompt textarea is ${promptFont}px — iOS will zoom on focus`);
 });
 
+test("phone (E.4): the files panel is a full-screen drill-in — tree → file → back → Esc, no side-scroll", async () => {
+  // Open from the status-bar affordance — a full-screen dialog layer, not the
+  // desktop docked column. Activated by keyboard (focus + Enter) rather than
+  // tap: focus-return-on-close is an A.3 KEYBOARD contract, and a touch tap
+  // doesn't move DOM focus to the button, so only the keyboard path has a
+  // meaningful opener to return to.
+  await phone.locator(".sb-files").focus();
+  await phone.keyboard.press("Enter");
+  await phone.waitForSelector(".files-panel[role=dialog]");
+  await noSideScroll(phone);
+  const width = await phone.evaluate(() => {
+    const el = document.querySelector(".files-panel");
+    return el ? Math.round(el.getBoundingClientRect().width) : 0;
+  });
+  assert.ok(width >= 380, `panel is ${width}px wide — not full-screen`);
+
+  // The tree is live git data (the daemon runs in the repo) — drill into a file.
+  const pkg = phone.locator(".files-file-row", { hasText: "package.json" }).first();
+  await pkg.waitFor({ timeout: 15_000 });
+  await pkg.tap();
+  await phone.waitForSelector(".files-view .fv-content");
+  await noSideScroll(phone);
+
+  // Esc drills BACK one layer (to the tree), never straight out — the
+  // stacked-layer contract; the panel stays open.
+  await phone.keyboard.press("Escape");
+  await phone.waitForSelector(".files-tree");
+  assert.equal(
+    await phone.locator(".files-file").count(),
+    0,
+    "Esc from a file must return to the tree, not close the panel",
+  );
+  assert.equal(await phone.locator(".files-panel").count(), 1, "the panel is still open");
+
+  // Esc from the tree closes the panel, and focus returns to the opener.
+  await phone.keyboard.press("Escape");
+  assert.equal(await phone.locator(".files-panel").count(), 0, "Esc from the tree closes the panel");
+  await noSideScroll(phone);
+  const focusedFiles = await phone.evaluate(
+    () => document.activeElement?.classList.contains("sb-files") ?? false,
+  );
+  assert.ok(focusedFiles, "focus returned to the files toggle on close");
+});
+
 test("phone: a permission request is answerable by thumb", async () => {
   await sendPrompt(phone, "do something dangerous");
   await phone.waitForSelector(".perm-bar", { timeout: 15_000 });

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -2,14 +2,20 @@ import { useEffect, useRef, useState } from "react";
 import type { FsEntry, WireMsg } from "@protocol";
 import type { ZoneMsg } from "../../session-bus";
 import { buildFileTree, type FileNode } from "../../files-tree";
+import { useEscapeKey } from "../../use-escape";
+import { useFocusTrap } from "../../use-focus-trap";
+import { useIsPhone } from "../../use-is-phone";
 import { FileView, type FileViewState } from "./FileView";
 
-// The Explorer's shell-owned panel (E.3): a read-only browser of the
-// session's working tree. Desktop mounts it as a collapsible LEFT column
-// beside the transcript; the phone container (E.4) reuses this same component
-// full-screen. Interaction is drill-in on both — tree, then a file view with
-// a back button — so a narrow column never has to show tree and file at once,
-// and the two platforms differ only in their frame.
+// The Explorer's shell-owned panel (E.3 desktop, E.4 phone): a read-only
+// browser of the session's working tree. Interaction is drill-in on both
+// platforms — the tree, then a file view laid OVER it with a back button —
+// so a narrow surface never shows tree and file at once, the tree stays
+// mounted underneath (its scroll survives a round trip), and the two
+// platforms differ only in the frame: desktop = a docked LEFT column beside
+// the transcript; phone (≤640px) = a full-screen dialog (focus-trapped, Esc
+// = back one layer / close from the tree — the A.3 discipline the other
+// overlays use).
 //
 // SHELL-OWNED: it holds the bus (socket) and the agent paints nothing here.
 // Replies are correlated by the echoed id (a stale reply from a superseded
@@ -60,6 +66,21 @@ export function FilesPanel({
   // and is ignored.
   const listId = useRef<string | null>(null);
   const fileId = useRef<string | null>(null);
+
+  // Phone = a full-screen dialog; desktop = a docked column. Live (not the
+  // module-load constant) so a resize across the breakpoint re-frames it.
+  const phone = useIsPhone();
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Trap focus only while it's an OPEN modal dialog (phone). Gating on `open`
+  // matters: this component is always mounted (it returns null when closed),
+  // so without `open` in the active flag the trap's effect would run once at
+  // mount — closed, a no-op — and never re-fire when the panel actually opens.
+  // On desktop the panel is a docked column beside a usable transcript — no trap.
+  const modal = phone && open;
+  useFocusTrap(panelRef, modal);
+  // Esc on phone drills back one layer, then closes from the tree — the
+  // stacked-layer contract. Desktop leaves Esc to Shell (busy = interrupt).
+  useEscapeKey(modal ? (selected ? () => setSelected(null) : onClose) : undefined);
 
   // Subscribe once; the refs above make the handler care only about the
   // latest request. RenderZone ignores fs_* the same way (unknown to it).
@@ -124,7 +145,15 @@ export function FilesPanel({
   const tree = buildFileTree(entries);
 
   return (
-    <aside className="files-panel" aria-label="Files">
+    <aside
+      className="files-panel"
+      aria-label="Files"
+      ref={panelRef}
+      // Phone frames it as a modal dialog; desktop is a plain docked column.
+      role={phone ? "dialog" : undefined}
+      aria-modal={phone ? true : undefined}
+      tabIndex={phone ? -1 : undefined}
+    >
       <div className="files-head">
         {selected ? (
           <button className="files-back" onClick={() => setSelected(null)} title="Back to files">
@@ -144,34 +173,9 @@ export function FilesPanel({
         </button>
       </div>
 
-      {selected ? (
-        <div className="files-file">
-          <div className="files-file-path">
-            <span className="files-file-name" title={selected.path}>
-              {selected.path}
-            </span>
-            {git && selected.status && (
-              <span className="files-file-tabs">
-                <button
-                  className={"files-tab" + (mode === "content" ? " is-active" : "")}
-                  onClick={() => openFile(selected.path, selected.status, "content")}
-                >
-                  file
-                </button>
-                <button
-                  className={"files-tab" + (mode === "diff" ? " is-active" : "")}
-                  onClick={() => openFile(selected.path, selected.status, "diff")}
-                >
-                  diff
-                </button>
-              </span>
-            )}
-          </div>
-          <div className="files-view">
-            <FileView state={view} />
-          </div>
-        </div>
-      ) : (
+      {/* The tree stays mounted; the file view (when a file is open) is laid
+          over it, so back reveals the tree at its prior scroll (E.4). */}
+      <div className="files-main">
         <div className="files-tree" role="tree" aria-label="Working tree">
           {treeError ? (
             <div className="files-empty files-error">{treeError}</div>
@@ -199,7 +203,36 @@ export function FilesPanel({
             </>
           )}
         </div>
-      )}
+
+        {selected && (
+          <div className="files-file">
+            <div className="files-file-path">
+              <span className="files-file-name" title={selected.path}>
+                {selected.path}
+              </span>
+              {git && selected.status && (
+                <span className="files-file-tabs">
+                  <button
+                    className={"files-tab" + (mode === "content" ? " is-active" : "")}
+                    onClick={() => openFile(selected.path, selected.status, "content")}
+                  >
+                    file
+                  </button>
+                  <button
+                    className={"files-tab" + (mode === "diff" ? " is-active" : "")}
+                    onClick={() => openFile(selected.path, selected.status, "diff")}
+                  >
+                    diff
+                  </button>
+                </span>
+              )}
+            </div>
+            <div className="files-view">
+              <FileView state={view} />
+            </div>
+          </div>
+        )}
+      </div>
     </aside>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -375,6 +375,15 @@ body {
   border-color: var(--border-hover);
 }
 
+/* Tree + file view share this box; the file view overlays the tree (below)
+   so back reveals the tree at its prior scroll. */
+.files-main {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
 .files-tree {
   flex: 1;
   min-height: 0;
@@ -459,9 +468,12 @@ body {
   font-style: italic;
 }
 
+/* Laid over the still-mounted tree (opaque), so it fully covers it on desktop
+   and phone alike; back just unmounts this layer. */
 .files-file {
-  flex: 1;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
+  background: var(--bg);
   display: flex;
   flex-direction: column;
 }
@@ -3401,5 +3413,30 @@ html {
   /* No dock → nothing to pin to; the affordance is hover-only anyway. */
   .pin-btn {
     display: none;
+  }
+
+  /* Explorer on phone (E.4): the docked column becomes a full-screen
+     drill-in layer over everything, GitHub-mobile style. Same component,
+     different frame; the file view still overlays the tree within it. */
+  .files-panel {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    max-width: none;
+    z-index: 55; /* above the transcript + status bar, below the 60 modals */
+    border-right: none;
+    background: var(--bg);
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  /* Bigger tap targets on the touch surface (the ≥40px rule from the phone
+     pass) without disturbing the desktop density. */
+  .files-row {
+    padding: 9px 8px;
+  }
+
+  .files-head {
+    padding: 14px 12px;
   }
 }

--- a/web/src/use-is-phone.ts
+++ b/web/src/use-is-phone.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+// Live phone-width detection (E.4). PromptBox's IS_PHONE is a module-load
+// constant — fine for a one-shot layout choice, wrong for a component that
+// must re-render when the viewport crosses the breakpoint (a rotate, a
+// desktop window resize, and every e2e that drives one page across widths).
+// This tracks the media query for the component's lifetime.
+const PHONE_QUERY = "(max-width: 640px)";
+
+export function useIsPhone(): boolean {
+  const [phone, setPhone] = useState(() => window.matchMedia?.(PHONE_QUERY)?.matches ?? false);
+  useEffect(() => {
+    const mq = window.matchMedia?.(PHONE_QUERY);
+    if (!mq) return;
+    const onChange = () => setPhone(mq.matches);
+    onChange(); // sync in case it changed between first render and effect
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return phone;
+}


### PR DESCRIPTION
Step E.4 of PLAN.md Phase E — Explorer. **Stacked on #9 (E.3)** — merge that first, then this retargets to main.

- At ≤640px the docked column becomes a full-screen dialog layer (fixed inset:0, z-index 55, safe-area padding, ≥40px rows). New `useIsPhone` hook — the tracked matchMedia the plan asked for, not PromptBox's module-load constant.
- Dialog semantics via `useFocusTrap` + `useEscapeKey` directly (drill-in Esc = back-one-layer then close, which ModalCard's fixed `onDismiss` can't express). Panel restructured so the tree stays mounted with the file view overlaid — back preserves scroll (improves desktop too).
- **Real bug fixed while verifying**: the trap/escape were gated on `phone` alone, but FilesPanel is always mounted (returns null when closed), so the hooks' `[ref, active]` deps never re-fired when `open` flipped false→true — the trap ran once at mount (closed, no-op) and never engaged. Gated on `phone && open`; the e2e proves it.
- `phone.e2e.ts` at 390px: full-screen open, drill to a file, Esc-back-to-tree (panel stays), Esc-close, `noSideScroll` on every layer, focus-return on keyboard open (the path where the A.3 contract is real). The tight phone status-bar absorbed the `files` control without wrapping or side-scroll.
- All tiers green: 349 / 95 / 40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)