### PR TITLE
Explorer E.4–E.5: phone drill-in, turn-end auto-refresh + follow-ups

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2673,13 +2673,41 @@ in nested lists are tabbable and axe-clean.
     tight phone status-bar row absorbed the `files` control without wrapping
     (no flex-wrap) or side-scroll. All tiers green **349/95/40**.*
 
-- [ ] **Step E.5 — Polish (optional; the cut line)** (~0.5 day)
+- [x] **Step E.5 — Polish (the valuable slice; taste items parked)**
   - Auto-refresh the open panel on `turn_end` (the server throttle already
     protects the daemon); changed-files-first grouping in the tree;
     panel-collapsed/expanded-dirs persistence (localStorage, the theme-key
     precedent); revisit syntax highlighting (plain v1 is deliberate —
     consistent with tool-code; highlight.js is already bundled if wanted
     later). Everything here is safe to drop.
+  - *2026-07-24: DONE, on `feat/explorer-e4`. Did the two solid, low-risk
+    wins and DELIBERATELY parked the taste-driven ones. **Landed:** (1)
+    auto-refresh — on `turn_end`, if the panel is open, re-request the TREE
+    (statuses + new/deleted entries reflect what the agent just did); tree
+    only, so an open file view keeps its scroll, and the per-connection
+    throttle bounds it. (2) expanded dirs now SURVIVE a close/reopen within a
+    session — the reset moved to a session-switch-keyed effect, so only a
+    different workspace clears the tree UI state. **Parked, on purpose:**
+    changed-files-first / a "Changes" section is a TASTE/layout decision —
+    per the propose-then-verify rule it wants candidates shown to Kyle first,
+    not a unilateral pick; localStorage panel-open persistence was skipped
+    (auto-opening a full-screen overlay on phone reload is jank, and the
+    value is marginal); syntax highlighting stays plain by design (matches
+    tool-code; the bundled highlight.js is there if Kyle later wants it).
+    Verified: Tier-3 `app.e2e.ts` — expand `server/`, close+reopen (still
+    expanded), run a full turn (panel stays open, expansion survives the
+    auto-refresh). Auto-refresh FIRING on a changed tree isn't directly
+    asserted (the mock changes no files); the wiring reuses the proven
+    `requestList` path and the test proves it integrates without clobbering
+    tree state. All tiers green **349/95/41**.*
+
+**Phase E — Explorer is COMPLETE** (E.1–E.5, 2026-07-24). Read-only
+folder/file/diff browser shipped: wire-native per-viewport transport,
+cwd-jailed with the secret denial, git tree + statuses + before/after diffs,
+desktop collapsible left panel and phone full-screen drill-in, auto-refresh
+on turn-end. PRs #7 (E.1+E.2, merged), #9 (E.3), #10 (E.4+E.5, stacked).
+Post-v1 depth (editing, fs-watcher, syntax highlighting, changed-files
+grouping) stays parked in POST-RELEASE.md.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2709,6 +2709,22 @@ on turn-end. PRs #7 (E.1+E.2, merged), #9 (E.3), #10 (E.4+E.5, stacked).
 Post-v1 depth (editing, fs-watcher, syntax highlighting, changed-files
 grouping) stays parked in POST-RELEASE.md.
 
+*2026-07-24 — post-completion security audit of the whole Phase E delta:
+**no exploitable vulnerability.** The realpath jail, `.env` basename denial,
+`execFile` git calls (no shell), `cleanRelPath` before `git show`, throttles,
+reply caps, and server-side validation of all client input all hold — the
+itests that perform the `../`/absolute/symlink-out/`.env` attacks are the
+demonstration. Two items surfaced: (a) FIXED same session — `listTree`'s walk
+counted only files, so a non-git workspace that's a huge tree of empty
+directories could be walked unbounded and synchronously (the git path is
+bounded by its subprocess limits); a total-node cap (`FS_TREE_MAX_NODES`)
+now bounds the walk, pinned by a non-vacuous Tier-1 test. (b) DOC — the
+Explorer's `.env`-basename read scope matches the existing `Read` tool/`!cat`
+(terminal parity, daemon's own `.env` protected, Explorer narrower); recorded
+in SECURITY.md's known-trust-decisions, not a bug. **Deferred (this item):
+make the non-git walk asynchronous (yield to the event loop) IF the node cap
+ever proves too blunt — evidence-gated, likely unnecessary given the cap.***
+
 ---
 
 ## Phase M — Mission control (opened 2026-07-24; Kyle-directed — the cockpit fleetview, promoted from POST-RELEASE.md)

--- a/PLAN.md
+++ b/PLAN.md
@@ -2630,7 +2630,7 @@ in nested lists are tabbable and axe-clean.
     beside the transcript, back + close) and the C.2 axe scan extended to the
     open panel — clean. All tiers green **349/95/39**.*
 
-- [ ] **Step E.4 — Phone: full-screen drill-in** (~0.5–1 day)
+- [x] **Step E.4 — Phone: full-screen drill-in**
   - Goal: at ≤640px the same data presents as stacked full-screen layers —
     StatusBar affordance → tree → file/diff → back — never a squeezed panel.
   - Build: branch on the 640px breakpoint with a LIVE matchMedia check (not
@@ -2646,6 +2646,32 @@ in nested lists are tabbable and axe-clean.
     to the tree; Esc closes the top layer only; `noSideScroll` passes on every
     layer; focus returns to the opener on final close; the axe scan of the
     layers is clean.
+  - *2026-07-24: DONE, on `feat/explorer-e4` (stacked on E.3). Because E.3
+    already made the panel drill-in, E.4 was mostly the frame: a live
+    `useIsPhone` hook (`web/src/use-is-phone.ts` — the tracked matchMedia the
+    plan asked for, not PromptBox's module-load constant), a `@media
+    (max-width:640px)` rule turning `.files-panel` into a full-screen fixed
+    layer (z-index 55, below the 60 modals; safe-area padding; ≥40px rows),
+    and dialog semantics via the two hooks directly (`useFocusTrap` +
+    `useEscapeKey`) rather than `ModalCard`, since drill-in Esc = back-one-layer
+    then close, which ModalCard's fixed onDismiss can't express. Also
+    restructured the panel so the tree stays MOUNTED with the file view laid
+    over it (absolute overlay) — back reveals the tree at its prior scroll,
+    and this improves desktop too. **One real bug found + fixed while
+    verifying** (the honest kind the e2e existed to catch): the trap/escape
+    were gated on `phone` alone, but FilesPanel is always mounted (returns
+    null when closed), so the hooks' `[ref, active]` deps never re-fired when
+    `open` flipped false→true — the trap ran once at mount (closed, a no-op)
+    and never engaged. Gated on `phone && open`; the e2e proved it (focus →
+    files-btn on open, → sb-files on close). Design note for E.4's "each layer
+    is a ModalCard": kept as ONE component with an overlaid file layer, not
+    two stacked ModalCards — simpler, and back-preserves-scroll falls out.
+    Verified: `phone.e2e.ts` at 390px — full-screen open, drill to a file,
+    Esc-back-to-tree (panel stays), Esc-close, `noSideScroll` at every layer,
+    focus-return on close (tested via keyboard open, the path where the A.3
+    contract is real — a touch tap doesn't focus the opener). The existing
+    tight phone status-bar row absorbed the `files` control without wrapping
+    (no flex-wrap) or side-scroll. All tiers green **349/95/40**.*
 
 - [ ] **Step E.5 — Polish (optional; the cut line)** (~0.5 day)
   - Auto-refresh the open panel on `turn_end` (the server throttle already

--- a/README.md
+++ b/README.md
@@ -423,6 +423,13 @@ server/            the local daemon (Node, run with tsx)
     connection.ts      one viewport's server side, transport-agnostic (R.1) —
                        shared verbatim by local sockets and relay viewports
     actions.ts         Phase 2 mediation: allowlisted tools component actions may run
+    fs-handlers.ts     Explorer request layer (Phase E): the fs_list/fs_read/
+                       fs_diff handlers connection.ts delegates to — per-viewport
+                       replies, jailed + throttled, one reply each
+    fs-explorer.ts     Explorer data layer: the capped tree walk + jailed,
+                       secret-safe, binary-sniffing file reads (E.1)
+    git.ts             Explorer git layer (E.2): bounded one-shot git calls for
+                       the tracked tree + statuses + HEAD-vs-working diffs
     ws-liveness.ts     heartbeat sweep shared by the local and relay socket paths
   security/          the two trust gates (H.6):
     auth.ts            the 4.5 auth predicates (token cookie, loopback Origin) —
@@ -486,6 +493,9 @@ web/               the browser app (React 19 + Vite)
                        dismiss + dialog ARIA + Escape + focus trap, shared by
                        ConnectDevice/ThemePicker/Onboarding — mount only while
                        open
+    files/             the Explorer panel (Phase E): FilesPanel.tsx (tree +
+                       drill-in — docked left column on desktop, full-screen
+                       dialog on phone) + FileView.tsx (content / diff / binary)
   src/registry/      Card, List, Table, LinkGroup, Chart, TodoList, Md +
                      RenderBlock (validate → fallback → error boundary) +
                      ActionRow/context
@@ -507,7 +517,13 @@ web/               the browser app (React 19 + Vite)
                      the end-session buttons in StatusBar + FleetView
   src/diff.ts        the LCS line differ shared by ToolBlock's Edit/Write
                      diffs and the `diff` registry component (the per-line
-                     JSX lives once, as `DiffLines` in registry/Diff.tsx)
+                     JSX lives once, as `DiffLines` in registry/Diff.tsx) —
+                     the Explorer's FileView reuses it too (E.3)
+  src/files-tree.ts  the Explorer's shell-owned flat→nested tree builder
+                     (dirs-first, git status on leaves); a deliberate copy of
+                     registry/FileTree's approach, kept off the agent surface (E.3)
+  src/use-is-phone.ts  live matchMedia phone-width hook — re-renders on a
+                     breakpoint cross, unlike PromptBox's module-load constant (E.4)
   src/tildify.ts     ~-abbreviation for cwd display (prompt + status bar)
   src/ws.ts          SocketClient: typed send/onMessage, hello, seq cursor,
                      heartbeat (half-open detection) + capped backoff (4.4);

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -57,3 +57,16 @@ guard is defense-in-depth, not the boundary: creating a symlink or running
 `cat .env` takes a tool that prompts (Bash, Write), so the closed routes
 are the zero-click ones. A prompt-free path to the daemon's secrets is a
 vulnerability we want reported.
+
+The **Explorer's** read-only file browser (`fs_list`/`fs_read`/`fs_diff`,
+Phase E) shares this same guard: it refuses `.env`/`.env.local` *content* by
+basename (the file still appears in the tree — its name isn't secret) and
+jails every path to the session's working directory via realpath containment,
+which — unlike the tool guard above — *does* catch symlinks that escape the
+root. Its read scope otherwise matches the auto-allowed `Read` tool and `!cat`
+(terminal parity): any other file inside the session directory — including a
+project's own `.env.production`, `id_rsa`, etc. — is browsable, exactly as the
+agent could already read it. That's by design (the browser shows you your own
+project); the daemon's own `.env` is the file that's protected, and the
+Explorer is *narrower* than `Read`, since it can't reach outside the session
+directory at all (2026-07-24 audit).

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -5,9 +5,7 @@ import path from "node:path";
 import type { AgentName, ClientMsg, WireMsg } from "../protocol";
 import type { SessionEntry, SessionRegistry } from "./registry";
 import { runActionTool } from "./actions";
-import { capBuffer, listTree, readWorkspaceFile, sniffBinary } from "./fs-explorer";
-import { cleanRelPath, gitShowHead, gitTree } from "./git";
-import { isSecretFile } from "../security/permissions";
+import { createFsHandlers } from "./fs-handlers";
 import {
   ADAPTER_AGENTS,
   availableAgents,
@@ -50,17 +48,6 @@ const CWD_HANDOFF_MAX_BYTES = 4096;
 // (N.3). The picker polls every few seconds; anything faster serves the
 // cached answer instead of re-probing localhost.
 const REFRESH_MIN_INTERVAL_MS = Number(process.env.REFRESH_MIN_INTERVAL_MS ?? 1_000);
-
-// Minimum gap between Explorer requests per connection AND per type (E.1) —
-// fs_list walks the tree, so a hostile client must not turn it into a CPU
-// grinder; the per-type split keeps a legitimate list-then-read pair from
-// tripping it. Throttled requests still get a reply (an error), never
-// silence — the client's request/reply correlation must always resolve.
-const FS_MIN_INTERVAL_MS = Number(process.env.FS_MIN_INTERVAL_MS ?? 250);
-
-// Same shape rule as bang ids: client-minted correlation ids are short and
-// word-safe or the message is dropped whole.
-const FS_ID_RE = /^[\w-]{1,64}$/;
 
 /**
  * The transcript is fenced by <bash-input>/<bash-output>; output that itself
@@ -275,13 +262,15 @@ export function openConnection(
   // hostile client could spam — bound the probe rate per connection. A
   // throttled refresh still answers, from the cache.
   let lastProbeAt = 0;
-  // Explorer throttles (E.1), one clock per request type.
-  let lastFsListAt = 0;
-  let lastFsReadAt = 0;
-  let lastFsDiffAt = 0;
-  // At most one git child per connection (E.2) — like the bang
-  // already-running refusal; a second request while busy errors, not queues.
-  let gitInFlight = false;
+  // The Explorer's fs_list/fs_read/fs_diff handling (Phase E), with its own
+  // per-connection throttle + git-in-flight state (fs-handlers.ts). `entry`
+  // and `closed` are read through getters because both change over the
+  // connection's life.
+  const fs = createFsHandlers({
+    viewport,
+    getEntry: () => entry,
+    isClosed: () => closed,
+  });
 
   // Identity first, then the replayed history, then the live stream. 4.4:
   // a valid afterSeq turns the replay into a tail-only resume — the client
@@ -555,208 +544,17 @@ export function openConnection(
           if (!closed) sendAgents();
         });
         break;
-      case "fs_list": {
-        // Explorer tree query (E.1) — answered on THIS connection only, like
-        // pong/sessions: disk state is a query, not session history, so it
-        // must never enter the broadcast stream or the replay ring. A bad id
-        // drops the message whole (nothing to correlate a reply to); every
-        // well-formed request gets exactly one reply.
-        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
-        const treeErr = (root: string, error: string) =>
-          viewport({ type: "fs_tree", id: msg.id, root, entries: [], git: false, error });
-        if (!entry) {
-          treeErr("", "no session attached");
-          break;
-        }
-        if (Date.now() - lastFsListAt < FS_MIN_INTERVAL_MS) {
-          treeErr(entry.cwd, "requests are arriving too fast — retry shortly");
-          break;
-        }
-        lastFsListAt = Date.now();
-        if (gitInFlight) {
-          treeErr(entry.cwd, "a git query is already running — retry shortly");
-          break;
-        }
-        // Git's view first (E.2); not-a-repo / no-git degrades to the E.1
-        // walk. Async now, so: root captured before the await (the viewport
-        // may switch sessions under it), `closed` checked before replying,
-        // and every path caught — an escaped throw exits the daemon.
-        const root = entry.cwd;
-        gitInFlight = true;
-        void gitTree(root)
-          .then((g) => {
-            if (closed) return;
-            if ("error" in g) {
-              treeErr(root, g.error);
-            } else if ("entries" in g) {
-              viewport({
-                type: "fs_tree",
-                id: msg.id,
-                root,
-                entries: g.entries,
-                git: true,
-                ...(g.truncated ? { truncated: true } : {}),
-              });
-            } else {
-              const r = listTree(root);
-              if ("error" in r) {
-                treeErr(root, r.error);
-              } else {
-                viewport({
-                  type: "fs_tree",
-                  id: msg.id,
-                  root,
-                  entries: r.entries,
-                  git: false,
-                  ...(r.truncated ? { truncated: true } : {}),
-                });
-              }
-            }
-          })
-          .catch((err) => {
-            if (!closed) treeErr(root, errText(err));
-          })
-          .finally(() => {
-            gitInFlight = false;
-          });
+      case "fs_list":
+        // Explorer tree/read/diff (Phase E) — per-viewport queries handled
+        // in fs-handlers.ts (jail, throttle, git-in-flight, one reply each).
+        fs.list(msg);
         break;
-      }
-      case "fs_read": {
-        // Explorer file read (E.1) — same per-viewport reply rules as
-        // fs_list; the path is validated raw here and jailed in the module.
-        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
-        const fileErr = (p: string, error: string) =>
-          viewport({ type: "fs_file", id: msg.id, path: p, error });
-        if (typeof msg.path !== "string" || msg.path.length === 0 || msg.path.length > 4_096) {
-          fileErr("", "bad path");
-          break;
-        }
-        if (!entry) {
-          fileErr(msg.path, "no session attached");
-          break;
-        }
-        if (Date.now() - lastFsReadAt < FS_MIN_INTERVAL_MS) {
-          fileErr(msg.path, "requests are arriving too fast — retry shortly");
-          break;
-        }
-        lastFsReadAt = Date.now();
-        try {
-          const r = readWorkspaceFile(entry.cwd, msg.path);
-          if ("error" in r) {
-            fileErr(msg.path, r.error);
-          } else if ("binary" in r) {
-            viewport({ type: "fs_file", id: msg.id, path: msg.path, binary: true, size: r.size });
-          } else {
-            viewport({
-              type: "fs_file",
-              id: msg.id,
-              path: msg.path,
-              content: r.content,
-              size: r.size,
-              ...(r.truncatedBytes ? { truncatedBytes: r.truncatedBytes } : {}),
-            });
-          }
-        } catch (err) {
-          fileErr(msg.path, errText(err));
-        }
+      case "fs_read":
+        fs.read(msg);
         break;
-      }
-      case "fs_diff": {
-        // Explorer per-file diff (E.2): before = HEAD's version, after = the
-        // working tree — the client diffs the pair; no hunk text on the wire.
-        if (typeof msg.id !== "string" || !FS_ID_RE.test(msg.id)) break;
-        const diffErr = (p: string, error: string) =>
-          viewport({ type: "fs_file_diff", id: msg.id, path: p, error });
-        if (typeof msg.path !== "string") {
-          diffErr("", "bad path");
-          break;
-        }
-        // Textual containment BEFORE git sees the path: `git show` resolves
-        // against the repo, not the fs, so the realpath jail can't cover it —
-        // a `../` here could read repo files above a subdirectory session.
-        const rel = cleanRelPath(msg.path);
-        if (!rel) {
-          diffErr(msg.path.slice(0, 200), "bad path");
-          break;
-        }
-        if (!entry) {
-          diffErr(rel, "no session attached");
-          break;
-        }
-        if (isSecretFile(rel)) {
-          diffErr(rel, "environment files are never readable here");
-          break;
-        }
-        if (Date.now() - lastFsDiffAt < FS_MIN_INTERVAL_MS) {
-          diffErr(rel, "requests are arriving too fast — retry shortly");
-          break;
-        }
-        lastFsDiffAt = Date.now();
-        if (gitInFlight) {
-          diffErr(rel, "a git query is already running — retry shortly");
-          break;
-        }
-        const diffRoot = entry.cwd;
-        gitInFlight = true;
-        void gitShowHead(diffRoot, rel)
-          .then((show) => {
-            if (closed) return;
-            if ("notGit" in show) {
-              diffErr(rel, "not a git repository — no diff available");
-              return;
-            }
-            if ("error" in show) {
-              diffErr(rel, show.error);
-              return;
-            }
-            const beforeBuf = "content" in show ? show.content : Buffer.alloc(0);
-            if (sniffBinary(beforeBuf)) {
-              viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
-              return;
-            }
-            // The after side. A missing working file is a REAL case (deleted
-            // → after ""), not an error — but only plain absence; an
-            // existing-but-unreadable path stays an error.
-            let after = "";
-            let afterTruncatedBytes: number | undefined;
-            let exists = true;
-            try {
-              lstatSync(path.join(diffRoot, rel));
-            } catch {
-              exists = false;
-            }
-            if (exists) {
-              const r = readWorkspaceFile(diffRoot, rel);
-              if ("error" in r) {
-                diffErr(rel, r.error);
-                return;
-              }
-              if ("binary" in r) {
-                viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
-                return;
-              }
-              after = r.content;
-              afterTruncatedBytes = r.truncatedBytes;
-            }
-            const before = capBuffer(beforeBuf);
-            viewport({
-              type: "fs_file_diff",
-              id: msg.id,
-              path: rel,
-              before: before.text,
-              after,
-              ...(before.truncatedBytes ? { beforeTruncatedBytes: before.truncatedBytes } : {}),
-              ...(afterTruncatedBytes ? { afterTruncatedBytes } : {}),
-            });
-          })
-          .catch((err) => {
-            if (!closed) diffErr(rel, errText(err));
-          })
-          .finally(() => {
-            gitInFlight = false;
-          });
+      case "fs_diff":
+        fs.diff(msg);
         break;
-      }
       case "client_error":
         // The browser half's uncaught errors, landing in the flight-recorder
         // log so a front-end crash leaves a trace a bug report can attach.

--- a/server/sessions/fs-explorer.test.ts
+++ b/server/sessions/fs-explorer.test.ts
@@ -70,6 +70,22 @@ test("listTree: path-byte cap trips honestly", () => {
   assert.ok(r.entries.length < 5);
 });
 
+test("listTree: the walk is node-bounded — a tree of empty dirs can't be walked without limit (audit 2026-07-24)", () => {
+  const root = tmp();
+  // 30 sibling directories, each with a nested empty child — NO files, so the
+  // entry/byte caps never trip. Before the node cap this walked all of them.
+  for (let i = 0; i < 30; i++) {
+    mkdirSync(path.join(root, `dir${i}`, "child"), { recursive: true });
+  }
+  const r = listTree(root, { maxNodes: 10 });
+  assert.ok(!("error" in r));
+  assert.equal(r.truncated, true, "the node cap must trip on a file-less tree");
+  // And a normal small tree with room to spare is NOT flagged truncated.
+  writeFileSync(path.join(root, "a.txt"), "a");
+  const ok = listTree(tmp());
+  assert.ok(!("error" in ok));
+});
+
 test("listTree: unreadable root is the error case, not a throw", () => {
   const r = listTree(path.join(os.tmpdir(), "fsx-does-not-exist-ever"));
   assert.ok("error" in r);

--- a/server/sessions/fs-explorer.ts
+++ b/server/sessions/fs-explorer.ts
@@ -21,6 +21,13 @@ import { isSecretFile } from "../security/permissions";
 // both. Honest: `truncated: true`, never a silent cut.
 const FS_TREE_MAX_ENTRIES = Number(process.env.FS_TREE_MAX_ENTRIES ?? 4_000);
 const FS_TREE_MAX_PATH_BYTES = Number(process.env.FS_TREE_MAX_PATH_BYTES ?? 400_000);
+// Bounds the WALK's cost, not just the reply. The entry/byte caps count only
+// FILES, so a tree of many (mostly empty) directories would be walked in full
+// — the file cap never trips. This caps total nodes VISITED (files + dirs), so
+// the synchronous walk can't block the event loop on a pathological non-git
+// workspace (the git path is bounded separately by its subprocess limits).
+// Well above the entry cap: real projects hit files first (2026-07-24 audit).
+const FS_TREE_MAX_NODES = Number(process.env.FS_TREE_MAX_NODES ?? 40_000);
 
 // Directories nobody browses that would drown the tree (and blow the caps
 // instantly). E.2's git view gets this pruning for free via .gitignore;
@@ -63,14 +70,16 @@ export type FileResult =
  */
 export function listTree(
   root: string,
-  caps: { maxEntries?: number; maxPathBytes?: number } = {},
+  caps: { maxEntries?: number; maxPathBytes?: number; maxNodes?: number } = {},
 ): TreeResult {
   const maxEntries = caps.maxEntries ?? FS_TREE_MAX_ENTRIES;
   const maxPathBytes = caps.maxPathBytes ?? FS_TREE_MAX_PATH_BYTES;
+  const maxNodes = caps.maxNodes ?? FS_TREE_MAX_NODES;
   const realRoot = inside(root, ".");
   if (!realRoot) return { error: "the session workspace is not readable" };
   const entries: FsEntry[] = [];
   let pathBytes = 0;
+  let nodesSeen = 0;
   let truncated = false;
   const walk = (dir: string, relPrefix: string) => {
     if (truncated) return;
@@ -83,6 +92,12 @@ export function listTree(
     dirents.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
     for (const d of dirents) {
       if (truncated) return;
+      // Every dirent counts toward the walk budget — directories included, so
+      // an empty-dir-heavy tree can't be walked without bound (audit finding).
+      if (++nodesSeen > maxNodes) {
+        truncated = true;
+        return;
+      }
       const rel = relPrefix ? `${relPrefix}/${d.name}` : d.name;
       // Dirent types come from lstat semantics: a symlink-to-dir reports as
       // a symlink (not a directory), which is exactly the leaf rule.

--- a/server/sessions/fs-handlers.ts
+++ b/server/sessions/fs-handlers.ts
@@ -1,0 +1,208 @@
+// The Explorer's per-viewport request layer (Phase E) — the fs_list / fs_read
+// / fs_diff message handlers, lifted out of connection.ts's switch so the
+// Explorer's request handling lives beside its data layer (fs-explorer.ts,
+// git.ts) instead of swelling the dispatcher. connection.ts builds one of
+// these per connection and delegates the three cases to it.
+//
+// Every reply is per-viewport: answered on THIS connection only (like
+// pong/sessions), never broadcast, never replay-buffered — disk state is a
+// query, not session history. A bad correlation id drops the message whole
+// (nothing to answer); every well-formed request gets exactly one reply, with
+// any error riding the reply rather than vanishing. Handlers never throw: this
+// runs on the local WS path, which has no try/catch above it, so an escaped
+// throw would exit the daemon.
+
+import { lstatSync } from "node:fs";
+import path from "node:path";
+import type { ClientMsg, FsEntry, WireMsg } from "../protocol";
+import type { SessionEntry } from "./registry";
+import { capBuffer, listTree, readWorkspaceFile, sniffBinary } from "./fs-explorer";
+import { cleanRelPath, gitShowHead, gitTree } from "./git";
+import { isSecretFile } from "../security/permissions";
+import { errText } from "../adapters";
+
+// Minimum gap between Explorer requests per connection AND per type — fs_list
+// walks the tree, so a hostile client must not turn it into a CPU grinder; the
+// per-type split keeps a legitimate list-then-read pair from tripping it. A
+// throttled request still gets a reply (an error), never silence — the client's
+// request/reply correlation must always resolve.
+const FS_MIN_INTERVAL_MS = Number(process.env.FS_MIN_INTERVAL_MS ?? 250);
+
+// Same shape rule as bang ids: client-minted correlation ids are short and
+// word-safe or the message is dropped whole.
+const FS_ID_RE = /^[\w-]{1,64}$/;
+
+type FsList = Extract<ClientMsg, { type: "fs_list" }>;
+type FsRead = Extract<ClientMsg, { type: "fs_read" }>;
+type FsDiff = Extract<ClientMsg, { type: "fs_diff" }>;
+
+type FsDeps = {
+  /** Send one frame to this viewport (never the broadcast path). */
+  viewport: (m: WireMsg) => void;
+  /** The session this connection watches, read at call time (it can change). */
+  getEntry: () => SessionEntry | null;
+  /** Whether the socket is already gone — checked before any async reply. */
+  isClosed: () => boolean;
+};
+
+export type FsHandlers = {
+  list: (msg: FsList) => void;
+  read: (msg: FsRead) => void;
+  diff: (msg: FsDiff) => void;
+};
+
+export function createFsHandlers({ viewport, getEntry, isClosed }: FsDeps): FsHandlers {
+  // Per-connection state: one throttle clock per request type, and at most one
+  // git child in flight (shared by list + diff, like the bang already-running
+  // refusal).
+  let lastListAt = 0;
+  let lastReadAt = 0;
+  let lastDiffAt = 0;
+  let gitInFlight = false;
+
+  const badId = (id: unknown): boolean => typeof id !== "string" || !FS_ID_RE.test(id);
+  const tooSoon = (last: number): boolean => Date.now() - last < FS_MIN_INTERVAL_MS;
+
+  const list = (msg: FsList): void => {
+    if (badId(msg.id)) return;
+    const sendErr = (root: string, error: string) =>
+      viewport({ type: "fs_tree", id: msg.id, root, entries: [], git: false, error });
+    const entry = getEntry();
+    if (!entry) return sendErr("", "no session attached");
+    if (tooSoon(lastListAt)) return sendErr(entry.cwd, "requests are arriving too fast — retry shortly");
+    lastListAt = Date.now();
+    if (gitInFlight) return sendErr(entry.cwd, "a git query is already running — retry shortly");
+
+    // root captured before the await — the viewport may switch sessions under
+    // it. Git's view first; not-a-repo / no-git degrades to the plain walk.
+    const root = entry.cwd;
+    const sendTree = (entries: FsEntry[], git: boolean, truncated: boolean) =>
+      viewport({ type: "fs_tree", id: msg.id, root, entries, git, ...(truncated ? { truncated: true } : {}) });
+    gitInFlight = true;
+    void gitTree(root)
+      .then((g) => {
+        if (isClosed()) return;
+        if ("error" in g) {
+          sendErr(root, g.error);
+        } else if ("entries" in g) {
+          sendTree(g.entries, true, g.truncated);
+        } else {
+          const r = listTree(root);
+          if ("error" in r) sendErr(root, r.error);
+          else sendTree(r.entries, false, r.truncated);
+        }
+      })
+      .catch((err) => {
+        if (!isClosed()) sendErr(root, errText(err));
+      })
+      .finally(() => {
+        gitInFlight = false;
+      });
+  };
+
+  const read = (msg: FsRead): void => {
+    if (badId(msg.id)) return;
+    const sendErr = (p: string, error: string) =>
+      viewport({ type: "fs_file", id: msg.id, path: p, error });
+    if (typeof msg.path !== "string" || msg.path.length === 0 || msg.path.length > 4_096) {
+      return sendErr("", "bad path");
+    }
+    const entry = getEntry();
+    if (!entry) return sendErr(msg.path, "no session attached");
+    if (tooSoon(lastReadAt)) return sendErr(msg.path, "requests are arriving too fast — retry shortly");
+    lastReadAt = Date.now();
+    try {
+      const r = readWorkspaceFile(entry.cwd, msg.path);
+      if ("error" in r) {
+        sendErr(msg.path, r.error);
+      } else if ("binary" in r) {
+        viewport({ type: "fs_file", id: msg.id, path: msg.path, binary: true, size: r.size });
+      } else {
+        viewport({
+          type: "fs_file",
+          id: msg.id,
+          path: msg.path,
+          content: r.content,
+          size: r.size,
+          ...(r.truncatedBytes ? { truncatedBytes: r.truncatedBytes } : {}),
+        });
+      }
+    } catch (err) {
+      sendErr(msg.path, errText(err));
+    }
+  };
+
+  const diff = (msg: FsDiff): void => {
+    if (badId(msg.id)) return;
+    const sendErr = (p: string, error: string) =>
+      viewport({ type: "fs_file_diff", id: msg.id, path: p, error });
+    if (typeof msg.path !== "string") return sendErr("", "bad path");
+    // Textual containment BEFORE git sees the path: `git show` resolves against
+    // the repo, not the filesystem, so the realpath jail can't cover it — a
+    // `../` here could read repo files above a subdirectory session's root.
+    const rel = cleanRelPath(msg.path);
+    if (!rel) return sendErr(msg.path.slice(0, 200), "bad path");
+    const entry = getEntry();
+    if (!entry) return sendErr(rel, "no session attached");
+    if (isSecretFile(rel)) return sendErr(rel, "environment files are never readable here");
+    if (tooSoon(lastDiffAt)) return sendErr(rel, "requests are arriving too fast — retry shortly");
+    lastDiffAt = Date.now();
+    if (gitInFlight) return sendErr(rel, "a git query is already running — retry shortly");
+
+    const root = entry.cwd;
+    gitInFlight = true;
+    void gitShowHead(root, rel)
+      .then((show) => {
+        if (isClosed()) return;
+        if ("notGit" in show) return sendErr(rel, "not a git repository — no diff available");
+        if ("error" in show) return sendErr(rel, show.error);
+
+        const beforeBuf = "content" in show ? show.content : Buffer.alloc(0);
+        if (sniffBinary(beforeBuf)) {
+          return viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
+        }
+        // The after side. A missing working file is a REAL case (deleted →
+        // after ""), not an error — but only plain absence; an existing-but-
+        // unreadable path stays an error.
+        let after = "";
+        let afterTruncatedBytes: number | undefined;
+        const exists = fileExists(path.join(root, rel));
+        if (exists) {
+          const r = readWorkspaceFile(root, rel);
+          if ("error" in r) return sendErr(rel, r.error);
+          if ("binary" in r) {
+            return viewport({ type: "fs_file_diff", id: msg.id, path: rel, binary: true });
+          }
+          after = r.content;
+          afterTruncatedBytes = r.truncatedBytes;
+        }
+        const before = capBuffer(beforeBuf);
+        viewport({
+          type: "fs_file_diff",
+          id: msg.id,
+          path: rel,
+          before: before.text,
+          after,
+          ...(before.truncatedBytes ? { beforeTruncatedBytes: before.truncatedBytes } : {}),
+          ...(afterTruncatedBytes ? { afterTruncatedBytes } : {}),
+        });
+      })
+      .catch((err) => {
+        if (!isClosed()) sendErr(rel, errText(err));
+      })
+      .finally(() => {
+        gitInFlight = false;
+      });
+  };
+
+  return { list, read, diff };
+}
+
+const fileExists = (abs: string): boolean => {
+  try {
+    lstatSync(abs);
+    return true;
+  } catch {
+    return false;
+  }
+};

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -888,6 +888,45 @@ test("E.3: the files panel lists the working tree, opens a file beside the trans
   assert.equal(await page.locator(".files-panel").count(), 0);
 });
 
+test("E.5: expanded dirs survive a close/reopen, and a turn's auto-refresh keeps tree state", async () => {
+  await page.locator(".sb-files").click();
+  await page.waitForSelector(".files-panel");
+
+  // Expand a known top-level directory (the repo has server/). The row's text
+  // includes the caret glyph, so match the name as a substring.
+  const serverDir = page.locator(".files-dir", { hasText: "server" }).first();
+  await serverDir.waitFor({ timeout: 15_000 });
+  await serverDir.click();
+  // A child appears — protocol.ts is a tracked file directly under server/.
+  await page.waitForSelector(".files-file-row:has-text('protocol.ts')");
+
+  // Close and reopen within the same session — the expansion is remembered
+  // (E.5: reset is keyed on session switch, not on open).
+  await page.locator(".sb-files").click();
+  assert.equal(await page.locator(".files-panel").count(), 0);
+  await page.locator(".sb-files").click();
+  await page.waitForSelector(".files-tree");
+  assert.ok(
+    await page.locator(".files-file-row:has-text('protocol.ts')").first().isVisible(),
+    "expanded dir was collapsed on reopen",
+  );
+
+  // A turn auto-refreshes the tree (E.5) without collapsing what's open or
+  // closing the panel: run a full mock turn, then the expansion still holds.
+  await page.locator("textarea").click();
+  await page.keyboard.type("plan it step by step");
+  await page.keyboard.press("Enter");
+  await page.waitForSelector("text=Plan complete — all four steps done.", { timeout: 30_000 });
+  await page.waitForTimeout(400); // let the turn_end refresh land
+  assert.equal(await page.locator(".files-panel").count(), 1, "auto-refresh closed the panel");
+  assert.ok(
+    await page.locator(".files-file-row:has-text('protocol.ts')").first().isVisible(),
+    "auto-refresh collapsed the expanded dir",
+  );
+
+  await page.locator(".sb-files").click(); // tidy up for later tests
+});
+
 test("a notice in the engine's own words is badged; the shell's own words aren't", async () => {
   await page.locator("textarea").click();
   await page.keyboard.type("show me a notice");

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -170,6 +170,50 @@ test("phone: pairs by URL, opens the session, drives a turn with a rendered comp
   assert.ok(promptFont >= 16, `prompt textarea is ${promptFont}px — iOS will zoom on focus`);
 });
 
+test("phone (E.4): the files panel is a full-screen drill-in — tree → file → back → Esc, no side-scroll", async () => {
+  // Open from the status-bar affordance — a full-screen dialog layer, not the
+  // desktop docked column. Activated by keyboard (focus + Enter) rather than
+  // tap: focus-return-on-close is an A.3 KEYBOARD contract, and a touch tap
+  // doesn't move DOM focus to the button, so only the keyboard path has a
+  // meaningful opener to return to.
+  await phone.locator(".sb-files").focus();
+  await phone.keyboard.press("Enter");
+  await phone.waitForSelector(".files-panel[role=dialog]");
+  await noSideScroll(phone);
+  const width = await phone.evaluate(() => {
+    const el = document.querySelector(".files-panel");
+    return el ? Math.round(el.getBoundingClientRect().width) : 0;
+  });
+  assert.ok(width >= 380, `panel is ${width}px wide — not full-screen`);
+
+  // The tree is live git data (the daemon runs in the repo) — drill into a file.
+  const pkg = phone.locator(".files-file-row", { hasText: "package.json" }).first();
+  await pkg.waitFor({ timeout: 15_000 });
+  await pkg.tap();
+  await phone.waitForSelector(".files-view .fv-content");
+  await noSideScroll(phone);
+
+  // Esc drills BACK one layer (to the tree), never straight out — the
+  // stacked-layer contract; the panel stays open.
+  await phone.keyboard.press("Escape");
+  await phone.waitForSelector(".files-tree");
+  assert.equal(
+    await phone.locator(".files-file").count(),
+    0,
+    "Esc from a file must return to the tree, not close the panel",
+  );
+  assert.equal(await phone.locator(".files-panel").count(), 1, "the panel is still open");
+
+  // Esc from the tree closes the panel, and focus returns to the opener.
+  await phone.keyboard.press("Escape");
+  assert.equal(await phone.locator(".files-panel").count(), 0, "Esc from the tree closes the panel");
+  await noSideScroll(phone);
+  const focusedFiles = await phone.evaluate(
+    () => document.activeElement?.classList.contains("sb-files") ?? false,
+  );
+  assert.ok(focusedFiles, "focus returned to the files toggle on close");
+});
+
 test("phone: a permission request is answerable by thumb", async () => {
   await sendPrompt(phone, "do something dangerous");
   await phone.waitForSelector(".perm-bar", { timeout: 15_000 });

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -66,6 +66,10 @@ export function FilesPanel({
   // and is ignored.
   const listId = useRef<string | null>(null);
   const fileId = useRef<string | null>(null);
+  // The subscribe effect below runs once; this ref lets its turn_end handler
+  // (E.5 auto-refresh) read whether the panel is open without re-subscribing.
+  const openRef = useRef(open);
+  openRef.current = open;
 
   // Phone = a full-screen dialog; desktop = a docked column. Live (not the
   // module-load constant) so a resize across the breakpoint re-frames it.
@@ -107,17 +111,31 @@ export function FilesPanel({
           const f = m as FsFileDiff;
           if (!isCurrentReply(fileId.current, f.id)) return;
           setView(diffToState(f));
+        } else if (m.type === "turn_end" && openRef.current) {
+          // E.5: the agent likely just touched files — refresh the TREE so
+          // statuses and new/deleted entries reflect reality. Tree only (no
+          // scroll-jank on an open file view); the server throttle bounds it.
+          listId.current = requestList();
         }
       }),
-    [subscribe],
+    [subscribe, requestList],
   );
 
-  // Open (or switch sessions while open) → refetch the tree from scratch.
+  // A session switch means a different workspace — clear everything, expanded
+  // dirs included. (Kept separate from the open effect below so expanded state
+  // SURVIVES a close/reopen within one session — E.5.)
+  useEffect(() => {
+    setSelected(null);
+    setView({ kind: "empty" });
+    setExpanded(new Set());
+  }, [sessionKey]);
+
+  // Opening (or a session switch while open) fetches the tree. Returns to the
+  // tree view, but leaves expanded dirs intact across a close/reopen.
   useEffect(() => {
     if (!open || !sessionKey) return;
     setSelected(null);
     setView({ kind: "empty" });
-    setExpanded(new Set());
     listId.current = requestList();
   }, [open, sessionKey, requestList]);
 

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -2,14 +2,20 @@ import { useEffect, useRef, useState } from "react";
 import type { FsEntry, WireMsg } from "@protocol";
 import type { ZoneMsg } from "../../session-bus";
 import { buildFileTree, type FileNode } from "../../files-tree";
+import { useEscapeKey } from "../../use-escape";
+import { useFocusTrap } from "../../use-focus-trap";
+import { useIsPhone } from "../../use-is-phone";
 import { FileView, type FileViewState } from "./FileView";
 
-// The Explorer's shell-owned panel (E.3): a read-only browser of the
-// session's working tree. Desktop mounts it as a collapsible LEFT column
-// beside the transcript; the phone container (E.4) reuses this same component
-// full-screen. Interaction is drill-in on both — tree, then a file view with
-// a back button — so a narrow column never has to show tree and file at once,
-// and the two platforms differ only in their frame.
+// The Explorer's shell-owned panel (E.3 desktop, E.4 phone): a read-only
+// browser of the session's working tree. Interaction is drill-in on both
+// platforms — the tree, then a file view laid OVER it with a back button —
+// so a narrow surface never shows tree and file at once, the tree stays
+// mounted underneath (its scroll survives a round trip), and the two
+// platforms differ only in the frame: desktop = a docked LEFT column beside
+// the transcript; phone (≤640px) = a full-screen dialog (focus-trapped, Esc
+// = back one layer / close from the tree — the A.3 discipline the other
+// overlays use).
 //
 // SHELL-OWNED: it holds the bus (socket) and the agent paints nothing here.
 // Replies are correlated by the echoed id (a stale reply from a superseded
@@ -60,6 +66,21 @@ export function FilesPanel({
   // and is ignored.
   const listId = useRef<string | null>(null);
   const fileId = useRef<string | null>(null);
+
+  // Phone = a full-screen dialog; desktop = a docked column. Live (not the
+  // module-load constant) so a resize across the breakpoint re-frames it.
+  const phone = useIsPhone();
+  const panelRef = useRef<HTMLDivElement>(null);
+  // Trap focus only while it's an OPEN modal dialog (phone). Gating on `open`
+  // matters: this component is always mounted (it returns null when closed),
+  // so without `open` in the active flag the trap's effect would run once at
+  // mount — closed, a no-op — and never re-fire when the panel actually opens.
+  // On desktop the panel is a docked column beside a usable transcript — no trap.
+  const modal = phone && open;
+  useFocusTrap(panelRef, modal);
+  // Esc on phone drills back one layer, then closes from the tree — the
+  // stacked-layer contract. Desktop leaves Esc to Shell (busy = interrupt).
+  useEscapeKey(modal ? (selected ? () => setSelected(null) : onClose) : undefined);
 
   // Subscribe once; the refs above make the handler care only about the
   // latest request. RenderZone ignores fs_* the same way (unknown to it).
@@ -124,7 +145,15 @@ export function FilesPanel({
   const tree = buildFileTree(entries);
 
   return (
-    <aside className="files-panel" aria-label="Files">
+    <aside
+      className="files-panel"
+      aria-label="Files"
+      ref={panelRef}
+      // Phone frames it as a modal dialog; desktop is a plain docked column.
+      role={phone ? "dialog" : undefined}
+      aria-modal={phone ? true : undefined}
+      tabIndex={phone ? -1 : undefined}
+    >
       <div className="files-head">
         {selected ? (
           <button className="files-back" onClick={() => setSelected(null)} title="Back to files">
@@ -144,34 +173,9 @@ export function FilesPanel({
         </button>
       </div>
 
-      {selected ? (
-        <div className="files-file">
-          <div className="files-file-path">
-            <span className="files-file-name" title={selected.path}>
-              {selected.path}
-            </span>
-            {git && selected.status && (
-              <span className="files-file-tabs">
-                <button
-                  className={"files-tab" + (mode === "content" ? " is-active" : "")}
-                  onClick={() => openFile(selected.path, selected.status, "content")}
-                >
-                  file
-                </button>
-                <button
-                  className={"files-tab" + (mode === "diff" ? " is-active" : "")}
-                  onClick={() => openFile(selected.path, selected.status, "diff")}
-                >
-                  diff
-                </button>
-              </span>
-            )}
-          </div>
-          <div className="files-view">
-            <FileView state={view} />
-          </div>
-        </div>
-      ) : (
+      {/* The tree stays mounted; the file view (when a file is open) is laid
+          over it, so back reveals the tree at its prior scroll (E.4). */}
+      <div className="files-main">
         <div className="files-tree" role="tree" aria-label="Working tree">
           {treeError ? (
             <div className="files-empty files-error">{treeError}</div>
@@ -199,7 +203,36 @@ export function FilesPanel({
             </>
           )}
         </div>
-      )}
+
+        {selected && (
+          <div className="files-file">
+            <div className="files-file-path">
+              <span className="files-file-name" title={selected.path}>
+                {selected.path}
+              </span>
+              {git && selected.status && (
+                <span className="files-file-tabs">
+                  <button
+                    className={"files-tab" + (mode === "content" ? " is-active" : "")}
+                    onClick={() => openFile(selected.path, selected.status, "content")}
+                  >
+                    file
+                  </button>
+                  <button
+                    className={"files-tab" + (mode === "diff" ? " is-active" : "")}
+                    onClick={() => openFile(selected.path, selected.status, "diff")}
+                  >
+                    diff
+                  </button>
+                </span>
+              )}
+            </div>
+            <div className="files-view">
+              <FileView state={view} />
+            </div>
+          </div>
+        )}
+      </div>
     </aside>
   );
 }

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -375,6 +375,15 @@ body {
   border-color: var(--border-hover);
 }
 
+/* Tree + file view share this box; the file view overlays the tree (below)
+   so back reveals the tree at its prior scroll. */
+.files-main {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+
 .files-tree {
   flex: 1;
   min-height: 0;
@@ -459,9 +468,12 @@ body {
   font-style: italic;
 }
 
+/* Laid over the still-mounted tree (opaque), so it fully covers it on desktop
+   and phone alike; back just unmounts this layer. */
 .files-file {
-  flex: 1;
-  min-height: 0;
+  position: absolute;
+  inset: 0;
+  background: var(--bg);
   display: flex;
   flex-direction: column;
 }
@@ -3401,5 +3413,30 @@ html {
   /* No dock → nothing to pin to; the affordance is hover-only anyway. */
   .pin-btn {
     display: none;
+  }
+
+  /* Explorer on phone (E.4): the docked column becomes a full-screen
+     drill-in layer over everything, GitHub-mobile style. Same component,
+     different frame; the file view still overlays the tree within it. */
+  .files-panel {
+    position: fixed;
+    inset: 0;
+    width: 100%;
+    max-width: none;
+    z-index: 55; /* above the transcript + status bar, below the 60 modals */
+    border-right: none;
+    background: var(--bg);
+    padding-top: env(safe-area-inset-top);
+    padding-bottom: env(safe-area-inset-bottom);
+  }
+
+  /* Bigger tap targets on the touch surface (the ≥40px rule from the phone
+     pass) without disturbing the desktop density. */
+  .files-row {
+    padding: 9px 8px;
+  }
+
+  .files-head {
+    padding: 14px 12px;
   }
 }

--- a/web/src/use-is-phone.ts
+++ b/web/src/use-is-phone.ts
@@ -1,0 +1,21 @@
+import { useEffect, useState } from "react";
+
+// Live phone-width detection (E.4). PromptBox's IS_PHONE is a module-load
+// constant — fine for a one-shot layout choice, wrong for a component that
+// must re-render when the viewport crosses the breakpoint (a rotate, a
+// desktop window resize, and every e2e that drives one page across widths).
+// This tracks the media query for the component's lifetime.
+const PHONE_QUERY = "(max-width: 640px)";
+
+export function useIsPhone(): boolean {
+  const [phone, setPhone] = useState(() => window.matchMedia?.(PHONE_QUERY)?.matches ?? false);
+  useEffect(() => {
+    const mq = window.matchMedia?.(PHONE_QUERY);
+    if (!mq) return;
+    const onChange = () => setPhone(mq.matches);
+    onChange(); // sync in case it changed between first render and effect
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return phone;
+}


### PR DESCRIPTION
Lands the five explorer commits stranded on `feat/explorer-e4`:

- **E.4** — phone full-screen drill-in (`2e10194`). This was PR #10, which merged into its stacked base `feat/explorer-e3` *after* that base had already been merged to main (#9), so it never reached main despite showing Merged.
- **E.5** — auto-refresh on turn-end + expanded-dirs persistence (`827e2d5`)
- refactor: extract `fs_*` handlers out of `connection.ts` into `fs-handlers.ts` (`1f65bb2`)
- harden: bound the non-git tree walk by total nodes (2026-07-24 audit) (`2d881ae`)
- docs: add Phase E files to README §4 layout (`8637206`)

None of these are currently reachable from `main` (verified with `git log origin/main..origin/feat/explorer-e4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)