### PR TITLE
sync: main → next after v0.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "A faithful browser re-skin of the terminal coding agent you already use \u2014 Claude Code, Codex, or Gemini CLI \u2014 with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Flow b's closing step: after a release, `next` absorbs what landed on `main` (the 0.3.3 version bump and the release merge commit) so the next cycle starts from a clean diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)