### PR TITLE
release: v0.3.4

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,82 @@
+# Releasing Mirafold — the flow-b runbook
+
+Adopted 2026-08-07 (first exercised as the `v0.3.3` release). One principle
+generates every rule here:
+
+> **`main` is the production mirror: it advances only at release time, so the
+> code on `main` and the code people install are always the same thing.**
+
+"Production" is two surfaces that update together on a `main` push: the npm
+package (published by CI on a tag) and app.mirafold.com (Cloudflare Pages
+rebuilds on every push to `main`). Flow b keeps them in lockstep by making a
+`main` push and a release the same event.
+
+## The branches
+
+| branch | what it is | protection (GitHub rulesets) |
+| --- | --- | --- |
+| `main` | the production mirror — every commit on it is inside some release | required checks (Tier 1, Tier 2+3, DCO), no force-push/delete; repo-admin bypass exists for emergencies but a direct push breaks the flow-b invariant — don't, except as step one of an immediate release |
+| `next` | staging — day-to-day work accumulates here | PR-only for everyone (0 approvals, same required checks), no bypass, no force-push/delete |
+| `feature/*` | working branches, cut from `next` | none — name them anything, force-push freely |
+| `release/x.y.z` | short-lived release prep, cut from `next` (or from `main` for a hotfix) | none — it exists for hours |
+
+Two mechanics to know:
+
+- **Every commit headed for a PR needs a DCO sign-off** — commit with
+  `git commit -s`. The DCO check is required on both protected branches.
+- **A `v*` tag publishes only `main`'s current tip.** The release workflow's
+  first step fails any tag pointing elsewhere (a feature branch, an old `main`
+  commit). The tag trigger itself is branch-blind by platform design; the
+  guard is what makes a mis-aimed tag a red workflow run instead of a bad
+  release.
+
+## The release cycle
+
+1. **Feature work**: branch off `next`, commit with `-s`, PR into `next`,
+   merge on green. Repeat until `next` holds the release you want.
+2. **Cut the release branch**: `git switch -c release/x.y.z origin/next`.
+3. **Bump the version** in `package.json` to `x.y.z` on that branch — commit
+   `release: vx.y.z` (signed off). npm refuses to republish an existing
+   version, so a missing bump kills the publish at the last step.
+4. **PR `release/x.y.z` → `main`**, merge on green.
+5. **Tag and push — this is the publish, and it's a human act** (the signing
+   key lives only on the release manager's machine):
+
+   ```
+   git switch main && git pull
+   npm pack                       # builds; prints mirafold-x.y.z.tgz
+   sha256sum mirafold-x.y.z.tgz   # goes into the tag message
+   git tag -s vx.y.z -m "sha256 <that hash>"
+   git push origin vx.y.z
+   ```
+
+   The tag message carries the tarball's SHA-256 so the signed tag attests to
+   the exact bytes. No hand-run `npm publish`, ever — the tag push triggers
+   `.github/workflows/release.yml`, which re-verifies (guard, tag↔version
+   check, typecheck, tests) and publishes with provenance via npm trusted
+   publishing. A manual dispatch of that workflow is a dry-run rehearsal.
+6. **Verify the same day**: the release run is green including the guard step;
+   `npm view mirafold version` shows `x.y.z`; the registry tarball's sha256
+   matches the signed tag message (`curl` it down and `sha256sum`).
+7. **Close the loop — do not skip**: PR `main` → `next` and merge it. The
+   version bump and release merge commit now exist on `main` only; until this
+   sync lands, the next cycle's release PR will conflict on `package.json`.
+   Push `main`'s tip to a `sync/*` branch first
+   (`git push origin main:refs/heads/sync/main-into-next-vx.y.z`) so the PR is
+   a fixed snapshot rather than tracking `main`.
+8. Delete the merged `feature/*`, `release/*`, and `sync/*` branches.
+
+## Hotfixes
+
+Same cycle in miniature, starting from `main` instead of `next`:
+cut `release/x.y.(z+1)` **from `main`**, commit the fix + version bump there
+(signed off), PR → `main`, merge on green, tag, verify — then the same
+`main` → `next` sync, which delivers the fix to staging too.
+
+## Holding a feature out of a release
+
+Don't merge it into `next` yet — that's the whole mechanism. The branch stays
+alive and periodically merges `next` *into itself* to avoid rotting. If
+something already on `next` must not ship: cut `release/x.y.z` from the last
+good commit before it, or revert the unwanted merge on the release branch
+only. There is no second staging branch, deliberately.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mirafold",
   "version": "0.3.3",
-  "description": "A faithful browser re-skin of the terminal coding agent you already use \u2014 Claude Code, Codex, or Gemini CLI \u2014 with generative UI layered on top.",
+  "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",
   "author": "Kyle Serrecchia (https://github.com/kserrec)",
@@ -78,7 +78,7 @@
     "concurrently": "^10.0.3",
     "esbuild": "^0.28.1",
     "highlight.js": "^11.11.1",
-    "mermaid": "^11.16.0",
+    "mermaid": "^11.16.1",
     "playwright-core": "^1.61.1",
     "qrcode-generator": "^2.0.4",
     "react": "^19.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1485,9 +1485,9 @@ devlop@^1.0.0, devlop@^1.1.0:
     dequal "^2.0.0"
 
 dompurify@^3.3.3:
-  version "3.4.12"
-  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.12.tgz#6fa2265e9bbdce882c4ace4107626051b448ffa8"
-  integrity sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==
+  version "3.4.13"
+  resolved "https://registry.yarnpkg.com/dompurify/-/dompurify-3.4.13.tgz#fc28949d59f92d62e28a3a764bcbeee35897a1be"
+  integrity sha512-2vmYIoqjze2d+kakP8S/nS5shfsl587kzwEjcGlTdiksUVgFHnFCsLYDVj/JNqJVOQZGSYBTmuycv0PodwmnMQ==
   optionalDependencies:
     "@types/trusted-types" "^2.0.7"
 
@@ -2260,10 +2260,10 @@ merge-descriptors@^2.0.0:
   resolved "https://registry.yarnpkg.com/merge-descriptors/-/merge-descriptors-2.0.0.tgz#ea922f660635a2249ee565e0449f951e6b603808"
   integrity sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==
 
-mermaid@^11.16.0:
-  version "11.16.0"
-  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.16.0.tgz#dc946bc84bde9d093ba14940d49df1d9f7d8c32f"
-  integrity sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==
+mermaid@^11.16.1:
+  version "11.16.1"
+  resolved "https://registry.yarnpkg.com/mermaid/-/mermaid-11.16.1.tgz#57ae2342f6c45b967113b04c9258430bdd057ee8"
+  integrity sha512-TQsq6u22fAn3rek5VOubrhKPo1g5hwC3FXUN9hiyupTckcYiGuuKGkNQrKYwGJkXUxZdojwRG46gsSCFZMDp4g==
   dependencies:
     "@braintree/sanitize-url" "^7.1.2"
     "@iconify/utils" "^3.0.2"


### PR DESCRIPTION
Release PR per docs/RELEASING.md: `next` → `release/0.3.4` → `main`. Carries the flow-b runbook and the dependency fixes clearing all six Dependabot alerts, plus the version bump. After merge, the signed `v0.3.4` tag on main's tip publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)