### PR TITLE
sync: main → next after v0.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Closing step per docs/RELEASING.md: next absorbs the 0.3.4 version bump and release merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)