### PR TITLE
fix(codex): keep the SDK runtime in sync

### DIFF
--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -6805,3 +6805,46 @@ per-repo `git status --ignored` runs in **40 ms** and emits **<400 bytes**
     `footer`; follows the dataviz stat-tile guidance.
   - Done when: a mock turn renders the tile, it pins to the dock, and an
     update-in-place re-send (same wire id) changes the value live.
+
+## Moved 2026-08-08 (seventh lean-out pass — verbatim original)
+
+### Step F.10 — Codex runtime/version parity hotfix (full body)
+
+- [x] **Step F.10 — Codex runtime/version parity hotfix (opened 2026-08-08)**
+  - **Goal:** restore the product's faithful-skin promise for Codex sessions:
+    the engine Mirafold drives must be the same installed Codex the user drives
+    in a terminal, so one version owns the config, model cache, model default,
+    and accepted reasoning efforts.
+  - **Proven cause:** Kyle's `config.toml` sets
+    `model_reasoning_effort = "max"`; terminal Codex 0.147.0 wrote the current
+    `models_cache.json` and defaults to GPT-5.6 Sol, which supports `max`.
+    Mirafold 0.3.4 instead launches the SDK-vendored Codex 0.142.5. That older
+    engine logs `missing field base_instructions` while parsing the 0.147.0
+    cache, falls back to its built-in GPT-5.5 default, then sends the inherited
+    `max` effort to a model that accepts only through `xhigh`. The resulting
+    API 400 and cache warning are therefore one version-skew chain, not two
+    independent failures.
+  - **Build:** resolve the user's installed `codex` executable (honoring
+    `MIRAFOLD_CODEX_BIN`) and pass it through the SDK's
+    `codexPathOverride`; if none exists, retain the SDK's bundled fallback.
+    Ask that resolved engine for both model catalogs so picker and turns cannot
+    split across versions. Raise the existing `@openai/codex-sdk` floor from
+    0.142.5 to the current stable 0.147.0 so the fallback is compatible too.
+    No new dependency: the SDK remains six files with one transitive
+    `@openai/codex`; wrapper unpacked size is 77,268 bytes versus 76,741
+    (+527 bytes). The separate per-model `/effort` picker redesign remains
+    V.2/F.5 follow-up; it did not set the inherited value in this failure.
+  - **Files:** `server/adapters/types.ts`, `server/adapters/codex.ts`, their
+    focused tests, `package.json`, `yarn.lock`, `docs/ADAPTERS.md`, this plan.
+  - **Done when:** a regression test pins the external executable through
+    `CodexOptions` and the engine/catalog single-source rule; focused tests,
+    typecheck, Tier 1, build, and dependency audit are green; then one live
+    subscription-backed prompt succeeds with Kyle's unchanged `max` setting
+    and resolves GPT-5.6 rather than the vendored GPT-5.5. Land through a
+    DCO-signed feature-branch PR into `next` under `docs/RELEASING.md` flow b.
+  - **Outcome:** Mirafold now uses one resolved executable for SDK turns and
+    both model-catalog paths, preferring the installed Codex and falling back
+    to the SDK's updated 0.147.0 binary. The unchanged live subscription setup
+    selected GPT-5.6 Sol and replied `ok` without an error. Focused tests
+    (53/53), Tier 1 (536/536), typecheck, build, package dry-run, and the
+    production dependency audit (0 vulnerabilities) passed.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2456,6 +2456,14 @@ fix restores what that agent's *terminal* user already sees — nothing invented
 
 - [x] **Step F.8 — `!` terminal parity + hardening** — done 2026-07-17 (Kyle: "we must never hide ANYTHING"); bang `cd` persists inside the workspace (EXIT-trap cwd handoff; an escape resets with the terminal's own notice), silent success renders "(completed with no output)", and the transcript reaches the agent immediately as its own turn (the engine's internal shell can't follow a bang `cd` — the one disclosed divergence). Same-day hardening: 0700 handoff dir, FIFO-stall gate, closing-fence escaping, 400ms bang throttle. F.3 extended: `session_created` carries the model label (status bar + fleet show agent → model from attach). SECURITY.md disclosure note queued under R.7. Tests in all three tiers. → PLAN-ARCHIVE.md.
 
+- [x] **Step F.10 — Codex runtime/version parity hotfix** — done 2026-08-08;
+  Mirafold now points the SDK at the user's installed Codex when present,
+  retains the current SDK binary as fallback, and asks that one engine for
+  both model catalogs. A live subscription prompt with Kyle's unchanged
+  `max` setting resolved GPT-5.6 Sol and replied `ok`; focused tests (53/53),
+  Tier 1 (536/536), typecheck, build, package dry-run, and production audit
+  (0 vulnerabilities) passed. → PLAN-ARCHIVE.md.
+
 - [ ] **Step F.5 — Codex app-server migration (approvals, streaming, visible
   reasoning)** *(post-launch, demand-gated — the big one)*
   - Goal: close the three live-confirmed divergences from terminal Codex, all
@@ -2467,10 +2475,11 @@ fix restores what that agent's *terminal* user already sees — nothing invented
     path). (2) **No streaming** — the reply lands as one buffered
     `item.completed` lump. (3) **Reasoning can be entirely absent** — observed:
     79 reasoning tokens spent, no `reasoning` item emitted at all.
-    (4, added 2026-07-16 via F.7) **the SDK vendors its own codex binary**, so
-    sessions can run an older default model than the user's terminal codex —
-    observed: vendored 0.142.5 → gpt-5.5 vs terminal 0.144.5 → gpt-5.6-sol;
-    the app-server surface drives the system codex and closes this too.
+    (4, added 2026-07-16 via F.7) ~~**the SDK vendors its own codex binary**,
+    so sessions can run an older default model than the user's terminal
+    codex~~ — closed by F.10 on 2026-08-08: SDK turns and catalogs now use the
+    installed Codex when present, with the current bundled binary retained
+    only as fallback. F.5 still owns the first three app-server divergences.
   - Build: drive Codex's **app-server** (JSON-RPC 2.0, the surface behind the
     VS Code extension — see codex.spike.md's original event table):
     `requestApproval` → `permission_request` (the browser bar + wire machinery

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -142,7 +142,7 @@ processes, clear timers. After `close()`, no further messages may be emitted.
 
 | Capability | `claude-code` | `codex` | `gemini-cli` | `mock` |
 |---|---|---|---|---|
-| Drive surface | `@anthropic-ai/claude-agent-sdk`, one warm `query()` for the session's life | `@openai/codex-sdk` (spawns `codex` CLI), one warm `Thread`, `runStreamed` per turn | `gemini` CLI headless: `-p … -o stream-json`, one process **per turn** | scripted timers |
+| Drive surface | `@anthropic-ai/claude-agent-sdk`, one warm `query()` for the session's life | `@openai/codex-sdk`, pointed at the user's installed `codex` CLI when present (SDK-bundled fallback), one warm `Thread`, `runStreamed` per turn | `gemini` CLI headless: `-p … -o stream-json`, one process **per turn** | scripted timers |
 | Warm-conversation mechanism | never-ending query + async prompt queue (prompt cache preserved) | persistent `Thread` (`thread.id` resumable) | `--session-id` first turn, `--resume` after | n/a |
 | Text streaming granularity | token-level (`includePartialMessages`) | **buffered** — one `text_delta` per completed item (SDK emits no token deltas today) | chunked `message` events | 16-char chunks |
 | Thinking stream (`thinking_delta`) | ✅ full fidelity | ✅ when reasoning items appear | ❌ observed absent → never fires (I3 proof) | ✅ scripted |
@@ -163,6 +163,16 @@ process spawn per turn; Codex text arrives buffered rather than token-streamed
 from the Codex spike remains **unverified live**: the `requestApproval` shape
 (probe ran with `approval_policy:"never"`, which skips execution) — if the SDK
 ever grows an approval callback, capture it before wiring `permission_request`.
+
+**Codex executable parity (F.10, 2026-08-08):** `CodexSession` resolves the
+user's installed `codex` executable (including `MIRAFOLD_CODEX_BIN`) and passes
+it as the SDK's `codexPathOverride`. The SDK's bundled engine is only the
+fallback when no external executable exists. Turns, `/model`, and engine-default
+resolution all query that one resolved executable. This is load-bearing: two
+Codex versions share `~/.codex/config.toml` and `models_cache.json`; letting a
+newer terminal write those files while an older SDK engine reads them caused a
+cache-schema failure, an older fallback model, and an invalid inherited
+reasoning effort. Do not reintroduce separate "picker" and "engine" binaries.
 
 ## 5. Generative UI: the MCP contract
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@anthropic-ai/claude-agent-sdk": "^0.3.201",
     "@lydell/node-pty": "^1.2.0-beta.12",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@openai/codex-sdk": "^0.142.5",
+    "@openai/codex-sdk": "^0.147.0",
     "@parcel/watcher": "^2.6.0",
     "express": "^5.2.1",
     "ws": "^8.21.0",

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -653,6 +653,18 @@ function withOpenAiKey(value: string | undefined, fn: () => void) {
   }
 }
 
+test("F.10: the installed Codex executable drives the SDK engine", () => {
+  const saved = process.env.MIRAFOLD_CODEX_BIN;
+  try {
+    process.env.MIRAFOLD_CODEX_BIN = "/operator/chosen/codex";
+    const o = capturedCodexOptions({ kind: "subscription" });
+    assert.equal(o.codexPathOverride, "/operator/chosen/codex");
+  } finally {
+    if (saved === undefined) delete process.env.MIRAFOLD_CODEX_BIN;
+    else process.env.MIRAFOLD_CODEX_BIN = saved;
+  }
+});
+
 test("N.5: a subscription choice withholds the env API key — the explicit pick beats env precedence", () => {
   withOpenAiKey("sk-env", () => {
     const o = capturedCodexOptions({ kind: "subscription" });

--- a/server/adapters/codex.ts
+++ b/server/adapters/codex.ts
@@ -20,6 +20,7 @@ import {
   capOutput,
   envWithout,
   errText,
+  installedAgentBin,
   joinTextBlocks,
 } from "./types";
 import { MIRAFOLD_MCP, RENDER_ID_RE, generativeUIMsg, renderMcpCommand } from "./render-mcp-cmd";
@@ -319,7 +320,15 @@ export class CodexSession implements AgentSession {
     // the user's config.toml answer for us.
     const binding = providerBinding(kind, opts.endpoint, opts.provider);
     this.firstPartyOpenAI = binding["model_provider"] === "openai";
+    // Faithful-skin runtime parity: when the user has Codex installed, drive
+    // that exact executable rather than the SDK's separately-versioned bundled
+    // engine. Both versions share ~/.codex/config.toml and models_cache.json;
+    // splitting them lets a newer terminal write state an older engine cannot
+    // parse, then silently changes the default model (F.10, reproduced live).
+    // A machine with no external Codex keeps the SDK's bundled fallback.
+    const installedCodex = installedAgentBin("MIRAFOLD_CODEX_BIN", "codex");
     const codex = (opts.makeCodex ?? ((o: CodexOptions) => new Codex(o)))({
+      ...(installedCodex ? { codexPathOverride: installedCodex } : {}),
       ...(kind === "api-key" && process.env.OPENAI_API_KEY
         ? { apiKey: process.env.OPENAI_API_KEY }
         : {}),
@@ -349,18 +358,17 @@ export class CodexSession implements AgentSession {
       },
     });
     this.codex = codex;
-    // Both catalogs carry the binding: a picker row you can't run, or an
-    // engine default from a provider this session isn't using, is worse than
-    // no answer at all.
-    this.listModels = opts.listModels ?? (() => listCodexModels(undefined, undefined, binding));
-    // The ENGINE's catalog — asked of the binary the SDK actually spawns
-    // (reached through its resolved executablePath; falls back to the PATH
-    // binary if the SDK's internals ever reshape). Distinct from listModels,
-    // which asks the USER's binary for terminal-parity picker rows.
+    // Both catalogs ask the exact binary the SDK actually spawns and carry the
+    // same provider binding. A picker row from one version followed by a turn
+    // on another is the version-skew bug F.10 removes. The private-field read
+    // is failure-soft: injected test doubles may omit it, in which case the
+    // catalog helper performs its ordinary installed-binary lookup.
     const engineBin = (codex as unknown as { exec?: { executablePath?: string } }).exec
       ?.executablePath;
+    const engineModels = () => listCodexModels(undefined, engineBin, binding);
+    this.listModels = opts.listModels ?? engineModels;
     this.listEngineModels =
-      opts.listEngineModels ?? (() => listCodexModels(undefined, engineBin, binding));
+      opts.listEngineModels ?? engineModels;
     // Model-axis neutralization: only when the pick forces the first-party
     // provider away from a CUSTOM config default whose top-level model would
     // ride along wrongly. An explicit model override wins outright.

--- a/server/adapters/types.test.ts
+++ b/server/adapters/types.test.ts
@@ -1,9 +1,53 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { capOutput, toolDetail } from "./types";
+import path from "node:path";
+import os from "node:os";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { agentBin, capOutput, installedAgentBin, toolDetail } from "./types";
 
 // The default cap is 64 KB (TOOL_OUTPUT_CAP_BYTES), read at module load.
 const CAP = 64_000;
+
+test("installedAgentBin honors the explicit operator override", () => {
+  const key = "MIRAFOLD_TEST_AGENT_BIN";
+  const saved = process.env[key];
+  try {
+    process.env[key] = "/operator/chosen/agent";
+    assert.equal(installedAgentBin(key, "agent"), "/operator/chosen/agent");
+    assert.equal(agentBin(key, "agent"), "/operator/chosen/agent");
+  } finally {
+    if (saved === undefined) delete process.env[key];
+    else process.env[key] = saved;
+  }
+});
+
+test("installedAgentBin finds PATH executables and preserves the non-SDK ENOENT fallback", () => {
+  const key = "MIRAFOLD_TEST_AGENT_BIN";
+  const name = `mirafold-agent-${process.pid}`;
+  const shadowDir = mkdtempSync(path.join(os.tmpdir(), "mirafold-agent-shadow-"));
+  // A same-named directory can be searchable (`X_OK`) but is not executable.
+  // PATH lookup must keep going to the real file in the next directory.
+  mkdirSync(path.join(shadowDir, name));
+  const dir = mkdtempSync(path.join(os.tmpdir(), "mirafold-agent-bin-"));
+  const file = path.join(dir, process.platform === "win32" ? `${name}.cmd` : name);
+  writeFileSync(file, "");
+  if (process.platform !== "win32") chmodSync(file, 0o755);
+  const savedPath = process.env.PATH;
+  const savedOverride = process.env[key];
+  try {
+    delete process.env[key];
+    process.env.PATH = `${shadowDir}${path.delimiter}${dir}`;
+    assert.equal(installedAgentBin(key, name), file);
+    assert.equal(agentBin(key, name), file);
+    assert.equal(installedAgentBin(key, `${name}-missing`), undefined);
+    assert.equal(agentBin(key, `${name}-missing`), `${name}-missing`);
+  } finally {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedOverride === undefined) delete process.env[key];
+    else process.env[key] = savedOverride;
+  }
+});
 
 test("capOutput leaves sub-cap text untouched", () => {
   const r = capOutput("hello");

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -1,20 +1,51 @@
 import path from "node:path";
-import { existsSync } from "node:fs";
+import { accessSync, constants, statSync } from "node:fs";
 import type { AgentName, WireMsg } from "../protocol";
 import type { CredentialKind } from "../provider-policy";
 
 export type { AgentName } from "../protocol";
 import { envInt } from "../env";
 
-/** Resolve which `name`d agent binary to spawn: the env override wins (an
- *  operator knob, and the seam the adapter tests use to substitute a scripted
- *  stub), else the copy installed beside node (nvm global installs land
- *  there), else PATH. Resolved per call so a test can flip the env var. */
-export function agentBin(envVar: string, name: string): string {
+/** Resolve an agent executable that is actually installed outside an SDK.
+ *  The env override is explicit operator intent, so return it even when it is
+ *  a bare name or currently missing (the eventual spawn then fails honestly).
+ *  Otherwise mirror normal command lookup: beside node first (global npm/nvm
+ *  installs), then PATH. `undefined` lets an SDK retain its bundled fallback. */
+export function installedAgentBin(envVar: string, name: string): string | undefined {
   const override = process.env[envVar];
   if (override) return override;
-  const beside = path.join(path.dirname(process.execPath), name);
-  return existsSync(beside) ? beside : name;
+
+  const names =
+    process.platform === "win32"
+      ? [
+          name,
+          ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+            .split(";")
+            .filter(Boolean)
+            .map((ext) => name + ext.toLowerCase()),
+        ]
+      : [name];
+  const dirs = [path.dirname(process.execPath), ...(process.env.PATH ?? "").split(path.delimiter)];
+  for (const dir of dirs) {
+    if (!dir) continue;
+    for (const file of names) {
+      const candidate = path.join(dir, file);
+      try {
+        if (!statSync(candidate).isFile()) continue;
+        accessSync(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+        return candidate;
+      } catch {
+        // Not runnable here — continue exactly as normal PATH lookup would.
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Resolve which `name`d agent binary to spawn. Non-SDK adapters need a
+ *  command even when lookup misses so their first turn can surface ENOENT. */
+export function agentBin(envVar: string, name: string): string {
+  return installedAgentBin(envVar, name) ?? name;
 }
 
 /** The human-readable message of an unknown catch value. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,54 +324,54 @@
   dependencies:
     "@tybys/wasm-util" "^0.10.3"
 
-"@openai/codex-darwin-arm64@npm:@openai/codex@0.142.5-darwin-arm64":
-  version "0.142.5-darwin-arm64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-darwin-arm64.tgz#259a909fb12c7c47c871ed1bc0c2e733412f14ca"
-  integrity sha512-l43p8xv+Z/2/b6fCUc7/FmcQZsaPB7RFizLponGwHAnFOWe3i9Vky69p+up3BUam9AetoQQUv7Mo+2KdaFEqhA==
+"@openai/codex-darwin-arm64@npm:@openai/codex@0.147.0-darwin-arm64":
+  version "0.147.0-darwin-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-darwin-arm64.tgz#10a1f074e7ac0d213cee58232e7d9297f7afb9f0"
+  integrity sha512-BEUVkiOW7kLcRyrMLfAr/h9wF8sRVJyZDy6OHtVn6QGDXiv3BvAZVTY1Pu9xF7KdIdkYXbp4uayN0aDQQaAUJw==
 
-"@openai/codex-darwin-x64@npm:@openai/codex@0.142.5-darwin-x64":
-  version "0.142.5-darwin-x64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-darwin-x64.tgz#8e3c5475206aafaa8d80c6eae2b819e2617fd084"
-  integrity sha512-yk6A06/VmW7NFsa48OVPaj//g/zeSpd79wjuqfXZwW8ZKRYQm3+wCd3hWjPl79F3QnXvDvM2j3JMIBL3m3GXXg==
+"@openai/codex-darwin-x64@npm:@openai/codex@0.147.0-darwin-x64":
+  version "0.147.0-darwin-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-darwin-x64.tgz#51f038ba6c2d6f20d250c3a7fd5e9dbede16e072"
+  integrity sha512-Tb8McE5SvJIH0Vs5R6sq7u+quiC931yan2KOOl6km1OdZ82+Wi7eF5XrSFPs5CF7xCgoIK4Vs+byMbT5hN+ZUw==
 
-"@openai/codex-linux-arm64@npm:@openai/codex@0.142.5-linux-arm64":
-  version "0.142.5-linux-arm64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-linux-arm64.tgz#f079e167c75170b452dbae8b5498f97c1fec421b"
-  integrity sha512-77ka5PSnm5HdxdBT99IwntCasmbqevlS0eiC0AtEb6ZXCLkim2gm0AWm+jNYy0EhbssvNK+KghayWo34HMgXeA==
+"@openai/codex-linux-arm64@npm:@openai/codex@0.147.0-linux-arm64":
+  version "0.147.0-linux-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-linux-arm64.tgz#be6c86b9f6c68ff13f8287a9436758fddac5b520"
+  integrity sha512-SLC1JXw2TYfr/c3HhrJubyyLelq7vTOLWVmiThFA+z0+WgzCPmaseJ/kzDD3Gge/TO7fCnnj7UcPmC0d2c8XAg==
 
-"@openai/codex-linux-x64@npm:@openai/codex@0.142.5-linux-x64":
-  version "0.142.5-linux-x64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-linux-x64.tgz#985850a578b50c4c91e7ae4bb01b721b64e2f861"
-  integrity sha512-pxY+d3NgNE57Y/MApD3/TZUAygxJN6I9h3ZeDUwe67mxWjUxsuapxMRFTKSznCalYbRAeZp752+AAXmUbmguEg==
+"@openai/codex-linux-x64@npm:@openai/codex@0.147.0-linux-x64":
+  version "0.147.0-linux-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-linux-x64.tgz#4ee93c1bbe90a5677e0f08ab8af770dabc56aa5b"
+  integrity sha512-0W9MBxPpWW0cSkNqrTDN2jR7rzzT7oNMhQY5446lT2Lw5cz5yhDTck4Va9rjkQEm+HlFzP/dmEMSZbXfJsINmw==
 
-"@openai/codex-sdk@^0.142.5":
-  version "0.142.5"
-  resolved "https://registry.yarnpkg.com/@openai/codex-sdk/-/codex-sdk-0.142.5.tgz#47ebe9159c2cb46a14308fd0a181ca1c1fb6209d"
-  integrity sha512-MConZ+eoBoZmkc4reezuzOgLtoI1BQBzo/nVYsSjtAIBpwKcgeEm1rfmqfUnTfFaBNHFTxBntcS7ZeQYuDPbWA==
+"@openai/codex-sdk@^0.147.0":
+  version "0.147.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex-sdk/-/codex-sdk-0.147.0.tgz#89814f6b51f0057e759f94c743c57e52aeef98d7"
+  integrity sha512-nJL0maDBZy31uEArs+u46tW22veNdHjfs96AGaFTnI3jF+g8U+a422uaPiDZwEKmyxcNwStTRz6sIh6C7XxGFQ==
   dependencies:
-    "@openai/codex" "0.142.5"
+    "@openai/codex" "0.147.0"
 
-"@openai/codex-win32-arm64@npm:@openai/codex@0.142.5-win32-arm64":
-  version "0.142.5-win32-arm64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-win32-arm64.tgz#98513e237b3802f7a2fd04152351f282b94f3c62"
-  integrity sha512-65BEqGbUZ7r0ayunIHdBjo5crwgbwKX/6puOcO+VCswUw/dXvDsN2IGcbXB52+bS9U5+FxP783cUHfTT6m40DQ==
+"@openai/codex-win32-arm64@npm:@openai/codex@0.147.0-win32-arm64":
+  version "0.147.0-win32-arm64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-win32-arm64.tgz#ef8f7be57a5618d16a6292121d0a68b8ce857d28"
+  integrity sha512-e2ZstJ8zT8Rm1nvR7CUVO+Gr3cTChE41+VfOzGhynzDXEoW0wfbjUQbc2bWbh1arG94LMm4y3dqBtUIbSrfeGA==
 
-"@openai/codex-win32-x64@npm:@openai/codex@0.142.5-win32-x64":
-  version "0.142.5-win32-x64"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5-win32-x64.tgz#a49a474ac281bf72128d490c1dd8dac1886479b4"
-  integrity sha512-a+wI4PEx9a2fg6V5ueTTDkOkr1XpEvA5RFXIbo/L2hOfzMmGtyRnbG24bCGu5Q2RSgVxSQV0aLkdb3vdYMNH9A==
+"@openai/codex-win32-x64@npm:@openai/codex@0.147.0-win32-x64":
+  version "0.147.0-win32-x64"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0-win32-x64.tgz#55adaf7e849a3ccaec8b9e98f2ce90f55fd758f1"
+  integrity sha512-oT7Ss5fAPf2fiWE9QNURqZcQGAAawSVxmIUdgPzckq4KFZAM+pRz9JbM4Rr498CjtbNgTOjWvDJ+DXvIBSfOPA==
 
-"@openai/codex@0.142.5":
-  version "0.142.5"
-  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.142.5.tgz#6a75d1a31da4f5e8b15c3aae7a5816ac29232d68"
-  integrity sha512-WQEpD7l3k68eIAP0aq28EdR18ENBAf8DyprzFhzNwCOQJSv4nHzpwT8Fl30IJacprko2ZCmUBZjM2u941l2yLw==
+"@openai/codex@0.147.0":
+  version "0.147.0"
+  resolved "https://registry.yarnpkg.com/@openai/codex/-/codex-0.147.0.tgz#1792030d147156695a2b86db0ec1a000ab9a83fc"
+  integrity sha512-EQLEXecAG2ptxI7UpBMo2TR/ga5596/c/OsYF/0LoUDh5JANZ7IoGqlzBEWbuEVQ76JePIbtTW/ihCkp1a7Z3w==
   optionalDependencies:
-    "@openai/codex-darwin-arm64" "npm:@openai/codex@0.142.5-darwin-arm64"
-    "@openai/codex-darwin-x64" "npm:@openai/codex@0.142.5-darwin-x64"
-    "@openai/codex-linux-arm64" "npm:@openai/codex@0.142.5-linux-arm64"
-    "@openai/codex-linux-x64" "npm:@openai/codex@0.142.5-linux-x64"
-    "@openai/codex-win32-arm64" "npm:@openai/codex@0.142.5-win32-arm64"
-    "@openai/codex-win32-x64" "npm:@openai/codex@0.142.5-win32-x64"
+    "@openai/codex-darwin-arm64" "npm:@openai/codex@0.147.0-darwin-arm64"
+    "@openai/codex-darwin-x64" "npm:@openai/codex@0.147.0-darwin-x64"
+    "@openai/codex-linux-arm64" "npm:@openai/codex@0.147.0-linux-arm64"
+    "@openai/codex-linux-x64" "npm:@openai/codex@0.147.0-linux-x64"
+    "@openai/codex-win32-arm64" "npm:@openai/codex@0.147.0-win32-arm64"
+    "@openai/codex-win32-x64" "npm:@openai/codex@0.147.0-win32-x64"
 
 "@oxc-project/types@=0.138.0":
   version "0.138.0"


### PR DESCRIPTION
## Summary

- Prefer the installed Codex executable, honoring MIRAFOLD_CODEX_BIN, for SDK-backed sessions while retaining the SDK-bundled fallback.
- Use that same resolved executable for turns and both model-catalog paths.
- Raise the bundled fallback from Codex SDK 0.142.5 to 0.147.0.

## Root cause

Mirafold 0.3.4 ran the SDK-vendored Codex 0.142.5 against the shared model cache written by terminal Codex 0.147.0. The older engine could not parse the newer cache schema, fell back to its built-in GPT-5.5 default, inherited reasoning effort max from the shared config, and received the reported unsupported-value response.

## Verification

- Live subscription-backed prompt with the unchanged max setting resolved gpt-5.6-sol and returned ok with no errors.
- Focused Codex regression tests: 53/53.
- Tier 1: 536/536.
- TypeScript typecheck and production build passed.
- Package dry-run passed.
- Production dependency audit: 0 vulnerabilities.