### PR TITLE
feat(onboarding): add native folder picker

### DIFF
--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -6848,3 +6848,70 @@ per-repo `git status --ignored` runs in **40 ms** and emits **<400 bytes**
     selected GPT-5.6 Sol and replied `ok` without an error. Focused tests
     (53/53), Tier 1 (536/536), typecheck, build, package dry-run, and the
     production dependency audit (0 vulnerabilities) passed.
+
+## Moved 2026-08-08 (native working-directory picker — full body)
+
+### Phase N2 — Native working-directory picker (opened 2026-08-08)
+
+**Goal:** keep the launch directory as the honest default, but make changing it
+a normal graphical choice instead of requiring the user to type a filesystem
+path. Manual entry stays beside the picker for precision and as the fallback.
+
+**Proven constraint:** Mirafold's browser UI cannot use `showDirectoryPicker()`
+for this job: the web API returns a capability-scoped directory handle and its
+leaf name, not the host's absolute path that the local agent process needs as
+`cwd`. The authenticated local daemon must therefore open the host operating
+system's own folder dialog and return only the path the user explicitly chose.
+Remote relay viewports may still type a host path, but must never pop a dialog
+on the unattended host.
+
+**Dependency call:** add no package. macOS already supplies AppleScript's
+`choose folder`; Windows supplies `FolderBrowserDialog` through Windows
+PowerShell; Linux desktop users commonly have Zenity or KDialog, tried in that
+order. A native-dialog package would add platform binaries and supply-chain
+surface merely to wrap facilities the operating systems already provide. If no
+Linux dialog helper is installed, the existing editable path remains available.
+
+- [x] **N2.1 — Host-native picker service + local-only wire**
+  - Build: bounded, shell-free child processes for macOS (`osascript`), Windows
+    (`FolderBrowserDialog`), and Linux (`zenity`, then `kdialog`); one global
+    dialog at a time, cancellation as a quiet result, selected-directory
+    validation, output caps, and abort on viewport close. Add an additive
+    correlated `pick_folder` / `folder_picked` request-reply pair. Advertise
+    availability in the `agents` hello; refuse the request over the relay.
+  - Files: `server/folder-picker.ts`, a small session handler,
+    `server/sessions/connection.ts`, `server/protocol.ts`, focused tests.
+
+- [x] **N2.2 — Onboarding browse control**
+  - Build: put a real `browse…` button beside the still-editable working-dir
+    field; click opens the host dialog at the field's current valid directory,
+    a choice replaces the field, cancel changes nothing, errors stay in the
+    card, and the button cannot stack dialogs. Hide it when the daemon says no
+    native picker is available (including relay viewports).
+  - Files: `web/src/components/Onboarding.tsx`, `web/src/components/Shell.tsx`,
+    `web/src/session-bus.ts`, `web/src/styles.css`.
+
+- [x] **N2.3 — Regression proof + documentation**
+  - Done when: Tier 1 pins every platform recipe, cancellation, fallback,
+    validation, and concurrency; a real-daemon browser test substitutes a
+    harmless Zenity fixture, clicks `browse…`, observes the chosen absolute
+    path in the field, and creates the session in that directory; remote and
+    hostile request behavior are pinned; typecheck, all three automated tiers,
+    build/package, and accessibility checks are green. README's working-dir
+    contract names the graphical path and its manual fallback. Land via a
+    DCO-signed `feature/*` PR into `next`; `main` and release state stay put.
+
+**Outcome:** both startup routes now offer a compact native `browse…` control
+while preserving the editable absolute-path field. Mirafold opens the host
+dialog with fixed executable/argument arrays, validates the selected directory,
+caps output, allows only one dialog globally and per connection, aborts on
+disconnect, and gives the child a strict desktop/session allowlist rather than
+the daemon's credential-bearing environment. The correlated response is sent
+only to the requesting local viewport and clicks are never queued across a
+reconnect; relay, unsupported-platform, and helper-missing cases retain manual
+entry without claiming a picker exists. No package was added. Focused tests
+(51/51), Tier 1 (551/551), typecheck, package dry-run, production audit (0
+vulnerabilities), the real-daemon/real-browser picker proof, phone no-overflow,
+axe, and protected GitHub Tier 1/2/3 checks passed. The direct local full Tier 2
+and Tier 3 runs also exposed four unchanged baseline failures, each reproduced
+from an isolated `origin/next`; PR #22 records those controls explicitly.

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -6915,3 +6915,63 @@ vulnerabilities), the real-daemon/real-browser picker proof, phone no-overflow,
 axe, and protected GitHub Tier 1/2/3 checks passed. The direct local full Tier 2
 and Tier 3 runs also exposed four unchanged baseline failures, each reproduced
 from an isolated `origin/next`; PR #22 records those controls explicitly.
+
+## Moved 2026-08-08 (stable Tier-3 browser gates — full body)
+
+### Phase N3 — Stable Tier-3 browser gates (opened + done 2026-08-08)
+
+**Goal:** keep the browser suite's real guarantees while removing the three
+observed timing/state races that intermittently blocked otherwise-good PRs.
+
+**Proven causes:**
+
+- Activity: the test waited for the transient `.activity-line`, then made a
+  second Playwright round-trip to read it. On the failed PR #22 run the first
+  wait succeeded, the scripted turn correctly ended and removed the line, and
+  the second call waited 30 seconds for an element that was supposed to stay
+  gone. The unchanged executable head had passed immediately before the
+  docs-only commit that caused the rerun.
+- Mermaid: the failed run never reached the outer `.rc-diagram`; the shared
+  session could carry a preceding turn across the test boundary and leave the
+  diagram prompt contending with the one-follow-up gate. The lazy Mermaid
+  runtime was never implicated by the trace.
+- Follow-tail: re-arming only in the delayed `scroll` event let streamed paint
+  move the bottom beyond the 24px slack after the user's downward gesture but
+  before that event measured it. This one was a narrow product race, not only
+  a test race; it matched the watch item root-caused on 2026-07-24.
+
+- [x] **N3.1 — Replace elapsed-time luck with a controlled busy state**
+  - The activity test now owns its daemon, page, and session and uses the mock
+    permission request as a deterministic latch. It asserts presence, elapsed
+    text, glyph movement, viewport placement, no blank busy frames, and clean
+    teardown while the test—not timer scheduling—controls when the turn ends.
+
+- [x] **N3.2 — Isolate the Mermaid renderer proof**
+  - The diagram test now owns its session, so it reaches the renderer or fails
+    for a renderer reason. Its guarantee is otherwise unchanged: it drives the
+    production lazy chunk, sandboxed iframe, CSP, postMessage sizing handshake,
+    SVG render, and parse-error fallback.
+
+- [x] **N3.3 — Close the real follow-tail re-arm race**
+  - Instant following and input-based upward detachment remain intact.
+    Downward wheel/touch intent that will reach the current bottom now arms
+    synchronously against the geometry at input time, before streamed paint
+    can move the target ahead of a later `scroll` event. Pure Tier-1 tests pin
+    pixel, line, page, direction, and exact boundary decisions. The browser
+    test owns deterministic scrollback, proves a real upward wheel detaches
+    during growth, then uses a permission latch and real downward wheel to
+    prove later tool/output frames keep following without a new prompt.
+
+- [x] **N3.4 — Prove the flakes are gone**
+  - Focused unchanged repetition: activity 6/6, Mermaid 5/5, follow-tail 6/6;
+    pure intent boundaries 3/3. Full Tier 1 passed 554/554, typecheck and
+    diff validation passed, and two consecutive unchanged full Tier-3 runs
+    passed 78/78 in 183s and 186s. PR #22's implementation head `a091ba1`
+    then passed DCO, Cloudflare Pages, Tier 1 (1m23s), and the combined Tier
+    2 + Tier 3 protected job (6m41s) on the loaded GitHub runner.
+
+**Outcome:** the two test-only flakes now synchronize on owned state instead
+of shared-session timing, while the follow-tail watch item is fixed in product
+code. No dependency was added. The checks retain their original user-visible
+guarantees and now fail at the component they name: busy chrome, Mermaid
+rendering, or follow-tail behavior.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1937,17 +1937,16 @@ with it. Both sequence BEFORE R.5.**
     turned it from guessing into reading, and it should have been the first
     move rather than the fifth. Both halves stay in the tree for next time.
 
-- [ ] **Two timing-fragile Tier-3 assertions, still flaky (2026-07-30).**
-  Separate from the wedge above and NOT product bugs — both assert on
-  wall-clock rendering rather than on state, in headless Chrome on a loaded
-  machine:
-  - `a busy turn never looks idle…` demands a CSS animation advance at
-    least one frame within a 128ms sample. Fix: assert the busy STATE the
-    indicator derives from, not the glyph's motion.
-  - `diagram component: mermaid renders as SVG inside the sandbox` — seen
-    twice; mermaid lazy-loads inside a sandboxed iframe.
-  Neither is worth a hunt; both are worth a rewrite when someone is in the
-  file. Combined they are the residual "sometimes 76/77".
+- [x] **Two timing-fragile Tier-3 assertions — resolved 2026-08-08 (N3).**
+  Neither failure was a product-rendering defect. The activity test split a
+  transient-element assertion across two Playwright calls, so a legitimate
+  `turn_end` could remove the line between the wait and the read. Its own
+  session now uses a permission request to hold the exact busy state under
+  test. Mermaid's outer component never arrived at all: the shared session
+  could inherit the preceding turn's one-follow-up prompt gate. Its test now
+  owns a session while retaining the production lazy chunk, sandbox, CSP,
+  postMessage, and parse-error paths. Focused repetition and two complete
+  78-test browser runs passed unchanged; protected proof remains N3.4.
 
 - [x] **Step R.6b — The packaged-artifact pass (opened + done 2026-07-30,
   after the day's two blockers)** — `scripts/packaged-pass.mjs`: `npm pack`,
@@ -2160,6 +2159,51 @@ was added. Protected Tier 1/2/3 checks, Cloudflare, and DCO passed on PR #22.
   tests, real-daemon browser proof, accessibility/phone checks, typecheck,
   build/package, production audit, README, and protected CI complete.
   → PLAN-ARCHIVE.md.
+
+## Phase N3 — Stable Tier-3 browser gates (opened 2026-08-08)
+
+**Goal:** keep the browser suite's real guarantees while removing the three
+observed timing/state races that intermittently block otherwise-good PRs.
+
+**Proven causes:**
+
+- Activity: the test waited for the transient `.activity-line`, then made a
+  second Playwright round-trip to read it. On the failed PR #22 run the first
+  wait succeeded, the scripted turn correctly ended and removed the line, and
+  the second call waited 30 seconds for an element that was supposed to stay
+  gone.
+- Mermaid: the failed run never reached the outer `.rc-diagram`; the shared
+  session could carry a preceding turn across the test boundary and leave the
+  diagram prompt contending with the one-follow-up gate.
+- Follow-tail: re-arming only in the delayed `scroll` event let streamed paint
+  move the bottom beyond the 24px slack after the user's downward gesture but
+  before that event measured it. This one was a narrow product race, not only
+  a test race.
+
+- [x] **N3.1 — Replace elapsed-time luck with a controlled busy state**
+  - Give the test its own daemon/page/session and use the mock permission ask
+    as a deterministic latch. Assert presence, elapsed text, movement,
+    viewport placement, no blank busy frames, and clean teardown while the
+    test—not timer scheduling—controls when the turn may end.
+- [x] **N3.2 — Isolate the Mermaid renderer proof**
+  - Give the diagram test its own session so it reaches the real lazy chunk,
+    sandbox, postMessage handshake, and parse-error path without inheriting a
+    prior test's one-follow-up prompt-gate state.
+- [x] **N3.3 — Close the real follow-tail re-arm race**
+  - Preserve instant following and input-based upward detachment. When a
+    downward wheel/touch gesture will reach the current bottom, arm following
+    synchronously against that pre-input geometry so streamed paint cannot
+    move the target before a later `scroll` event measures it. Pin the
+    decision as a pure Tier-1 rule and drive it with real wheel input in an
+    isolated browser test.
+- [ ] **N3.4 — Prove the flakes are gone**
+  - Run each isolated test repeatedly, then the full Tier-3 suite and all
+    protected PR checks. Archive this phase only after the exact final head is
+    green.
+  - Local proof complete: activity 6/6, Mermaid 5/5, follow-tail 6/6, pure
+    intent boundaries 3/3, Tier 1 554/554, typecheck, and two consecutive
+    unchanged full Tier-3 runs at 78/78. Remaining: protected PR checks on the
+    pushed code head.
 
 ## Phase V — Visual + fidelity gaps flagged by Kyle (opened 2026-07-17; ✅ COMPLETE)
 
@@ -2580,21 +2624,19 @@ anywhere; each is independent.
 
 - [x] **Step Q.5 — Pin the `.env` guard's edges** — done 2026-07-12; traversal + cross-cwd denials pinned across all four guarded readers, non-vacuous by weakening the guard. (Symlink bypass stays the documented accepted residual.) → PLAN-ARCHIVE.md.
 
-- **WATCH ITEM (2026-07-24): the follow-tail re-arm race** — seen once on the
+- [x] **WATCH ITEM (2026-07-24): the follow-tail re-arm race — closed
+  2026-08-08 by N3.3.** Seen once on the
   CI runner (app.e2e.ts "re-follows once back at the bottom", sat 188px above
-  the tail), green on rerun and on every local run; ROOT-CAUSED same day, fix
-  deferred. Mechanism: re-arming depends on `use-follow-tail.ts`'s `onScroll`
+  the tail), green on rerun and on every local run; root-caused same day.
+  Mechanism: re-arming depended on `use-follow-tail.ts`'s `onScroll`
   measuring within `BOTTOM_SLACK_PX` (24) of the bottom, but scroll events
   fire a frame after the scroll — under load the stream can paint >24px in
   that gap, so a reader (or the test's single programmatic jump) landing at
   the bottom mid-stream measures as "not at bottom" and follow never re-arms.
-  A REAL product race, not only test fragility — narrow, and a human recovers
-  by scrolling again, which is why it's a watch item not a blocker. Proposed
-  fix shape when picked up: arm on INTENT like detach already does (a
-  downward wheel/touch ending near the bottom re-arms), so re-arming stops
-  depending on winning a paint race; the hook's two locked decisions
-  (2026-07-20 trace) must be re-read first. The test's single jump + single
-  sample then stops being timing-sensitive on its own.
+  A real product race, not only test fragility. Downward wheel/touch intent
+  that reaches the current bottom now re-arms synchronously against pre-input
+  geometry; the existing instant-follow and input-detach decisions remain.
+  Pure boundary tests and a controlled real-wheel browser scenario pin it.
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2141,6 +2141,56 @@ own env/config. Live-verified on Kyle's machine.
 - [x] **N.5 — Session creation honors the choice** — done 2026-07-17. → PLAN-ARCHIVE.md.
 - [x] **N.6 — Live verification + docs reconciliation** — done 2026-07-17. → PLAN-ARCHIVE.md.
 
+## Phase N2 — Native working-directory picker (opened 2026-08-08)
+
+**Goal:** keep the launch directory as the honest default, but make changing it
+a normal graphical choice instead of requiring the user to type a filesystem
+path. Manual entry stays beside the picker for precision and as the fallback.
+
+**Proven constraint:** Mirafold's browser UI cannot use `showDirectoryPicker()`
+for this job: the web API returns a capability-scoped directory handle and its
+leaf name, not the host's absolute path that the local agent process needs as
+`cwd`. The authenticated local daemon must therefore open the host operating
+system's own folder dialog and return only the path the user explicitly chose.
+Remote relay viewports may still type a host path, but must never pop a dialog
+on the unattended host.
+
+**Dependency call:** add no package. macOS already supplies AppleScript's
+`choose folder`; Windows supplies `FolderBrowserDialog` through Windows
+PowerShell; Linux desktop users commonly have Zenity or KDialog, tried in that
+order. A native-dialog package would add platform binaries and supply-chain
+surface merely to wrap facilities the operating systems already provide. If no
+Linux dialog helper is installed, the existing editable path remains available.
+
+- [ ] **N2.1 — Host-native picker service + local-only wire**
+  - Build: bounded, shell-free child processes for macOS (`osascript`), Windows
+    (`FolderBrowserDialog`), and Linux (`zenity`, then `kdialog`); one global
+    dialog at a time, cancellation as a quiet result, selected-directory
+    validation, output caps, and abort on viewport close. Add an additive
+    correlated `pick_folder` / `folder_picked` request-reply pair. Advertise
+    availability in the `agents` hello; refuse the request over the relay.
+  - Files: `server/folder-picker.ts`, a small session handler,
+    `server/sessions/connection.ts`, `server/protocol.ts`, focused tests.
+
+- [ ] **N2.2 — Onboarding browse control**
+  - Build: put a real `browse…` button beside the still-editable working-dir
+    field; click opens the host dialog at the field's current valid directory,
+    a choice replaces the field, cancel changes nothing, errors stay in the
+    card, and the button cannot stack dialogs. Hide it when the daemon says no
+    native picker is available (including relay viewports).
+  - Files: `web/src/components/Onboarding.tsx`, `web/src/components/Shell.tsx`,
+    `web/src/session-bus.ts`, `web/src/styles.css`.
+
+- [ ] **N2.3 — Regression proof + documentation**
+  - Done when: Tier 1 pins every platform recipe, cancellation, fallback,
+    validation, and concurrency; a real-daemon browser test substitutes a
+    harmless Zenity fixture, clicks `browse…`, observes the chosen absolute
+    path in the field, and creates the session in that directory; remote and
+    hostile request behavior are pinned; typecheck, all three automated tiers,
+    build/package, and accessibility checks are green. README's working-dir
+    contract names the graphical path and its manual fallback. Land via a
+    DCO-signed `feature/*` PR into `next`; `main` and release state stay put.
+
 ## Phase V — Visual + fidelity gaps flagged by Kyle (opened 2026-07-17; ✅ COMPLETE)
 
 Full bodies + dated status in PLAN-ARCHIVE.md ("Moved 2026-07-19").

--- a/PLAN.md
+++ b/PLAN.md
@@ -2160,50 +2160,19 @@ was added. Protected Tier 1/2/3 checks, Cloudflare, and DCO passed on PR #22.
   build/package, production audit, README, and protected CI complete.
   → PLAN-ARCHIVE.md.
 
-## Phase N3 — Stable Tier-3 browser gates (opened 2026-08-08)
+## Phase N3 — Stable Tier-3 browser gates (✅ COMPLETE 2026-08-08)
 
-**Goal:** keep the browser suite's real guarantees while removing the three
-observed timing/state races that intermittently block otherwise-good PRs.
-
-**Proven causes:**
-
-- Activity: the test waited for the transient `.activity-line`, then made a
-  second Playwright round-trip to read it. On the failed PR #22 run the first
-  wait succeeded, the scripted turn correctly ended and removed the line, and
-  the second call waited 30 seconds for an element that was supposed to stay
-  gone.
-- Mermaid: the failed run never reached the outer `.rc-diagram`; the shared
-  session could carry a preceding turn across the test boundary and leave the
-  diagram prompt contending with the one-follow-up gate.
-- Follow-tail: re-arming only in the delayed `scroll` event let streamed paint
-  move the bottom beyond the 24px slack after the user's downward gesture but
-  before that event measured it. This one was a narrow product race, not only
-  a test race.
-
-- [x] **N3.1 — Replace elapsed-time luck with a controlled busy state**
-  - Give the test its own daemon/page/session and use the mock permission ask
-    as a deterministic latch. Assert presence, elapsed text, movement,
-    viewport placement, no blank busy frames, and clean teardown while the
-    test—not timer scheduling—controls when the turn may end.
-- [x] **N3.2 — Isolate the Mermaid renderer proof**
-  - Give the diagram test its own session so it reaches the real lazy chunk,
-    sandbox, postMessage handshake, and parse-error path without inheriting a
-    prior test's one-follow-up prompt-gate state.
-- [x] **N3.3 — Close the real follow-tail re-arm race**
-  - Preserve instant following and input-based upward detachment. When a
-    downward wheel/touch gesture will reach the current bottom, arm following
-    synchronously against that pre-input geometry so streamed paint cannot
-    move the target before a later `scroll` event measures it. Pin the
-    decision as a pure Tier-1 rule and drive it with real wheel input in an
-    isolated browser test.
-- [ ] **N3.4 — Prove the flakes are gone**
-  - Run each isolated test repeatedly, then the full Tier-3 suite and all
-    protected PR checks. Archive this phase only after the exact final head is
-    green.
-  - Local proof complete: activity 6/6, Mermaid 5/5, follow-tail 6/6, pure
-    intent boundaries 3/3, Tier 1 554/554, typecheck, and two consecutive
-    unchanged full Tier-3 runs at 78/78. Remaining: protected PR checks on the
-    pushed code head.
+- [x] **N3.1 — Controlled busy-state proof** — own session + permission latch;
+  no transient-locator race. → PLAN-ARCHIVE.md.
+- [x] **N3.2 — Isolated Mermaid renderer proof** — own session, production
+  lazy chunk/sandbox/CSP/postMessage paths retained. → PLAN-ARCHIVE.md.
+- [x] **N3.3 — Deterministic follow-tail re-arm** — wheel/touch intent arms
+  synchronously against pre-input geometry; pure boundaries + real-wheel e2e.
+  → PLAN-ARCHIVE.md.
+- [x] **N3.4 — Repetition + protected proof** — focused activity 6/6,
+  Mermaid 5/5, follow-tail 6/6; Tier 1 554/554; two unchanged full Tier-3
+  runs 78/78; PR #22's DCO, Cloudflare, Tier 1, and combined Tier 2/3 checks
+  passed on implementation head `a091ba1`. → PLAN-ARCHIVE.md.
 
 ## Phase V — Visual + fidelity gaps flagged by Kyle (opened 2026-07-17; ✅ COMPLETE)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2141,55 +2141,25 @@ own env/config. Live-verified on Kyle's machine.
 - [x] **N.5 — Session creation honors the choice** — done 2026-07-17. → PLAN-ARCHIVE.md.
 - [x] **N.6 — Live verification + docs reconciliation** — done 2026-07-17. → PLAN-ARCHIVE.md.
 
-## Phase N2 — Native working-directory picker (opened 2026-08-08)
+## Phase N2 — Native working-directory picker (opened + ✅ COMPLETE 2026-08-08)
 
-**Goal:** keep the launch directory as the honest default, but make changing it
-a normal graphical choice instead of requiring the user to type a filesystem
-path. Manual entry stays beside the picker for precision and as the fallback.
+✅ COMPLETE — full body + dated outcome in PLAN-ARCHIVE.md ("Moved 2026-08-08").
+The startup screen keeps the launch directory as an editable default and adds
+an operating-system folder dialog for local viewports. The request is bounded,
+credential-scrubbed, never replayed, and refused over the relay; no dependency
+was added. Protected Tier 1/2/3 checks, Cloudflare, and DCO passed on PR #22.
 
-**Proven constraint:** Mirafold's browser UI cannot use `showDirectoryPicker()`
-for this job: the web API returns a capability-scoped directory handle and its
-leaf name, not the host's absolute path that the local agent process needs as
-`cwd`. The authenticated local daemon must therefore open the host operating
-system's own folder dialog and return only the path the user explicitly chose.
-Remote relay viewports may still type a host path, but must never pop a dialog
-on the unattended host.
-
-**Dependency call:** add no package. macOS already supplies AppleScript's
-`choose folder`; Windows supplies `FolderBrowserDialog` through Windows
-PowerShell; Linux desktop users commonly have Zenity or KDialog, tried in that
-order. A native-dialog package would add platform binaries and supply-chain
-surface merely to wrap facilities the operating systems already provide. If no
-Linux dialog helper is installed, the existing editable path remains available.
-
-- [ ] **N2.1 — Host-native picker service + local-only wire**
-  - Build: bounded, shell-free child processes for macOS (`osascript`), Windows
-    (`FolderBrowserDialog`), and Linux (`zenity`, then `kdialog`); one global
-    dialog at a time, cancellation as a quiet result, selected-directory
-    validation, output caps, and abort on viewport close. Add an additive
-    correlated `pick_folder` / `folder_picked` request-reply pair. Advertise
-    availability in the `agents` hello; refuse the request over the relay.
-  - Files: `server/folder-picker.ts`, a small session handler,
-    `server/sessions/connection.ts`, `server/protocol.ts`, focused tests.
-
-- [ ] **N2.2 — Onboarding browse control**
-  - Build: put a real `browse…` button beside the still-editable working-dir
-    field; click opens the host dialog at the field's current valid directory,
-    a choice replaces the field, cancel changes nothing, errors stay in the
-    card, and the button cannot stack dialogs. Hide it when the daemon says no
-    native picker is available (including relay viewports).
-  - Files: `web/src/components/Onboarding.tsx`, `web/src/components/Shell.tsx`,
-    `web/src/session-bus.ts`, `web/src/styles.css`.
-
-- [ ] **N2.3 — Regression proof + documentation**
-  - Done when: Tier 1 pins every platform recipe, cancellation, fallback,
-    validation, and concurrency; a real-daemon browser test substitutes a
-    harmless Zenity fixture, clicks `browse…`, observes the chosen absolute
-    path in the field, and creates the session in that directory; remote and
-    hostile request behavior are pinned; typecheck, all three automated tiers,
-    build/package, and accessibility checks are green. README's working-dir
-    contract names the graphical path and its manual fallback. Land via a
-    DCO-signed `feature/*` PR into `next`; `main` and release state stay put.
+- [x] **N2.1 — Host-native picker service + local-only wire** — done
+  2026-08-08; shell-free macOS, Windows, and Linux recipes; correlated
+  non-replayed wire pair; validation, cancellation, concurrency, abort, and
+  relay refusal pinned. → PLAN-ARCHIVE.md.
+- [x] **N2.2 — Onboarding browse control** — done 2026-08-08; compact
+  `browse…` beside the editable path in both startup routes, capability-gated
+  with manual entry retained as the universal fallback. → PLAN-ARCHIVE.md.
+- [x] **N2.3 — Regression proof + documentation** — done 2026-08-08; focused
+  tests, real-daemon browser proof, accessibility/phone checks, typecheck,
+  build/package, production audit, README, and protected CI complete.
+  → PLAN-ARCHIVE.md.
 
 ## Phase V — Visual + fidelity gaps flagged by Kyle (opened 2026-07-17; ✅ COMPLETE)
 

--- a/README.md
+++ b/README.md
@@ -204,8 +204,11 @@ type WireMsg =
                                                    //  true ⇒ tail replay, don't reset)
   | { type: "agents"; agents: { agent: AgentName; live: boolean }[]; // P.4: onboarding
       default: AgentName; cwd?: string; home?: string;             //   (4.8: + cwd/home)
+      folderPicker?: boolean;                         // N2: host dialog is available
       relay?: { url: string; code: string } }        // R.4: pairing info for the QR —
                                                      //   local viewports only
+  | { type: "folder_picked"; id: string; path?: string; // N2: local, per-viewport
+      canceled?: true; error?: string }                 //   reply; never replayed
   | { type: "usage"; model?: string; inputTokens: number;          // T2.6: status-bar
       outputTokens: number; costUsd?: number }                     //   accounting
   // 4.9: the `!` passthrough's lifecycle + OUTPUT stream (broadcast, replayed).
@@ -239,7 +242,8 @@ type ClientMsg =
   | { type: "bang_kill"; id: string }
   | { type: "ping" }                                     // 4.4: liveness probe
   | { type: "watch_sessions" }             // 4.6: be a fleet watcher, not a viewport
-  | { type: "rename"; sessionId: string; name: string }; // 4.6: fleet rename
+  | { type: "rename"; sessionId: string; name: string }  // 4.6: fleet rename
+  | { type: "pick_folder"; id: string; cwd?: string };   // N2: explicit local GUI request
 ```
 
 `Action` (also in `protocol.ts`) is the complete vocabulary of what a
@@ -258,6 +262,10 @@ connection metadata any forwarder handles — IPs, timing, byte counts — never
 content or keys. R.4 added exactly one optional field
 (`agents.relay`, the pairing info for the connect-a-device QR — sent to
 local viewports only, never across the relay).
+N2 likewise added only `agents.folderPicker` plus the correlated
+`pick_folder`/`folder_picked` pair. The reply is local plumbing: it goes only
+to the viewport that clicked Browse and is never broadcast, buffered, or
+replayed.
 
 **The `!` passthrough (Step 4.9).** A prompt starting with `!` is
 intercepted by the trusted shell and the server runs the rest in a
@@ -467,6 +475,8 @@ server/            the local daemon (Node, run with tsx)
   render-tools.ts    render_* tools as an in-process MCP server (Claude
                      adapter) + RENDER_GUIDANCE
   protocol.ts        WireMsg/ClientMsg/Action — the shared wire contract
+  folder-picker.ts   local-only host dialog recipes (macOS/Windows/Linux),
+                     executable lookup, validation, and credential-safe spawn
   registry-spec.ts   zod shapes per component — spec = tool schema = validation
   provider-policy.ts the dated per-provider credential-policy matrix (R.4i) —
                      cited by path from CLAUDE.md/BUSINESS.md; stays at root
@@ -481,6 +491,9 @@ server/            the local daemon (Node, run with tsx)
                        cockpit derivation and every viewport (2026-07-29)
     connection.ts      one viewport's server side, transport-agnostic (R.1) —
                        shared verbatim by local sockets and relay viewports
+    folder-picker-handler.ts
+                       per-viewport native-picker request/reply boundary;
+                       explicitly unavailable through the relay
     actions.ts         Phase 2 mediation: allowlisted tools component actions may run
     bang-handlers.ts   the `!` passthrough's request layer (4.9): the bang/
                        bang_input/bang_kill handlers connection.ts delegates to,
@@ -624,6 +637,9 @@ web/               the browser app (React 19 + Vite)
                      bytes)
   src/session-bus.ts the shell's message bus (H.9): one SocketClient + the
                      pub/sub fan-out and senders Shell.tsx consumes
+  src/folder-picker-requests.ts
+                     correlated local picker requests shared by the session
+                     shell and the fleet's new-session card
   src/tab-status.ts  the tab status light: brand-M favicon + corner badge
                      (busy / permission) and title, painted from wire state
   src/use-escape.ts  useEscapeKey — the one Esc idiom behind every overlay
@@ -1332,12 +1348,26 @@ against the mock before the live agent.
 
 A session's working directory defaults to the directory the daemon was
 launched from (`process.cwd()`) — terminal parity, Step 4.8 — and the
-onboarding picker takes any existing path (`~` expands; a typo'd path rejects
-the create instead of silently creating a stray dir). The trusted shell shows
-the session's cwd at the prompt (`~/Projects/foo ❯`) and its leaf in the
-status bar. File mutation and bash ask for approval on the shell's permission
-bar exactly as in the terminal, honoring the allowlists in your inherited
-`settings.json`.
+onboarding card accepts any existing path (`~` expands; a typo'd path rejects
+the create instead of silently creating a stray dir). On a local viewport,
+**browse…** opens the host operating system's normal folder dialog and puts the
+chosen absolute path into that same field; typing remains available. macOS and
+Windows use their built-in dialogs. Linux uses Zenity when available, then
+KDialog as a fallback; if neither is installed, the card simply keeps the
+manual field. The same is true when a Linux daemon has no graphical desktop
+session. A relay viewport cannot open desktop UI on the daemon's computer, so
+it also keeps manual entry for a path on that host.
+
+The browser does not open this dialog itself: browser directory handles do not
+reveal the absolute host path an agent process needs as its `cwd`. The explicit
+click makes one authenticated, local WebSocket request to the daemon, which
+opens the native dialog without a shell and returns only the selected directory.
+The dialog child receives desktop-session variables but no model credentials,
+relay credentials, or custom provider environment variables. The trusted shell
+then shows the session's cwd at the prompt (`~/Projects/foo ❯`) and its leaf in
+the status bar. File mutation and bash ask for approval on the shell's
+permission bar exactly as in the terminal, honoring the allowlists in your
+inherited `settings.json`.
 
 ## 9. Life of a turn (end to end)
 

--- a/server/folder-picker.test.ts
+++ b/server/folder-picker.test.ts
@@ -1,0 +1,154 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import {
+  createFolderPicker,
+  folderPickerAvailable,
+  folderPickerCommands,
+  folderPickerEnvironment,
+  folderPickerStartDir,
+  runFolderPickerCommand,
+  type FolderPickerProcessResult,
+} from "./folder-picker";
+
+test("N2 native recipes: macOS, Windows, and both Linux desktop dialogs", () => {
+  const mac = folderPickerCommands("/Users/kyle/project", "darwin", {});
+  assert.equal(mac.length, 1);
+  assert.equal(mac[0].file, "/usr/bin/osascript");
+  assert.match(mac[0].args.join(" "), /choose folder/);
+  assert.equal(mac[0].env?.MIRAFOLD_FOLDER_PICKER_START, "/Users/kyle/project");
+
+  const win = folderPickerCommands("C:\\work\\project", "win32", { SystemRoot: "C:\\Windows" });
+  assert.equal(win.length, 1);
+  assert.equal(
+    win[0].file,
+    path.join("C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+  );
+  assert.deepEqual(win[0].args.slice(0, 3), ["-NoLogo", "-NoProfile", "-STA"]);
+  assert.match(win[0].args.at(-1)!, /FolderBrowserDialog/);
+  assert.match(win[0].args.at(-1)!, /\{\n  \[Console\]/);
+
+  const linux = folderPickerCommands("/home/kyle/project", "linux", {});
+  assert.deepEqual(
+    linux.map((c) => c.file),
+    ["zenity", "kdialog"],
+  );
+  assert.ok(linux[0].args.includes("--directory"));
+  assert.ok(linux[1].args.includes("--getexistingdirectory"));
+});
+
+test("native helpers receive desktop state but no daemon credentials or loader hooks", () => {
+  assert.deepEqual(
+    folderPickerEnvironment(
+      {
+        PATH: "/usr/bin",
+        DISPLAY: ":1",
+        LANG: "en_US.UTF-8",
+        OPENAI_API_KEY: "must-not-cross",
+        MIRAFOLD_ENTITLEMENT_TOKEN: "must-not-cross",
+        CUSTOM_PROVIDER_SECRET: "must-not-cross",
+        LD_PRELOAD: "/tmp/must-not-load.so",
+      },
+      {
+        MIRAFOLD_FOLDER_PICKER_START: "/home/kyle/project",
+        ANOTHER_PRIVATE_VALUE: "must-not-cross",
+      },
+    ),
+    {
+      PATH: "/usr/bin",
+      DISPLAY: ":1",
+      LANG: "en_US.UTF-8",
+      MIRAFOLD_FOLDER_PICKER_START: "/home/kyle/project",
+    },
+  );
+});
+
+test("folderPickerAvailable requires a real platform helper", () => {
+  const env = { PATH: "/mock/bin", DISPLAY: ":1" };
+  assert.equal(folderPickerAvailable("linux", env, () => undefined), false);
+  assert.equal(
+    folderPickerAvailable("linux", { PATH: "/mock/bin" }, () => "/mock/bin/zenity"),
+    false,
+    "a helper without a graphical Linux session is not usable",
+  );
+  assert.equal(
+    folderPickerAvailable("linux", env, (file) =>
+      file === "kdialog" ? "/mock/bin/kdialog" : undefined,
+    ),
+    true,
+  );
+});
+
+test("folderPickerStartDir expands home and lets a half-typed path fall back", () => {
+  const fallback = path.resolve("/daemon/start");
+  const expanded = path.resolve("/home/kyle/project");
+  const exists = (candidate: string) => candidate === expanded;
+  assert.equal(folderPickerStartDir("~/project", fallback, "/home/kyle", exists), expanded);
+  assert.equal(folderPickerStartDir("~/missing", fallback, "/home/kyle", exists), fallback);
+  assert.equal(folderPickerStartDir("", fallback, "/home/kyle", exists), fallback);
+});
+
+test("Linux falls through a broken Zenity to KDialog and validates the chosen directory", async () => {
+  const chosen = path.resolve("/picked/project");
+  const calls: string[] = [];
+  const picker = createFolderPicker({
+    platform: "linux",
+    env: { PATH: "/mock/bin" },
+    locate: (file) => `/mock/bin/${file}`,
+    directoryExists: (candidate) => candidate === chosen || candidate === path.resolve("/start"),
+    fallbackDir: () => path.resolve("/start"),
+    run: async (command): Promise<FolderPickerProcessResult> => {
+      calls.push(path.basename(command.file));
+      return calls.length === 1
+        ? { code: 1, stdout: "", stderr: "Gtk-WARNING: Failed to open display" }
+        : { code: 0, stdout: `${chosen}\n`, stderr: "" };
+    },
+  });
+  assert.equal(await picker(), chosen);
+  assert.deepEqual(calls, ["zenity", "kdialog"]);
+});
+
+test("Cancel is quiet and does not fall through to a second Linux dialog", async () => {
+  let calls = 0;
+  const picker = createFolderPicker({
+    platform: "linux",
+    locate: (file) => `/mock/${file}`,
+    directoryExists: () => true,
+    run: async () => {
+      calls++;
+      return { code: 1, stdout: "", stderr: "" };
+    },
+  });
+  assert.equal(await picker(), undefined);
+  assert.equal(calls, 1);
+});
+
+test("A picker cannot stack, and a non-directory result is refused", async () => {
+  const chosen = path.resolve("/picked/project");
+  let release!: (result: FolderPickerProcessResult) => void;
+  const picker = createFolderPicker({
+    platform: "linux",
+    locate: (file) => `/mock/${file}`,
+    directoryExists: (candidate) => candidate !== chosen,
+    run: () =>
+      new Promise<FolderPickerProcessResult>((resolve) => {
+        release = resolve;
+      }),
+  });
+  const first = picker();
+  await Promise.resolve();
+  await assert.rejects(picker(), /already open/);
+  release({ code: 0, stdout: `${chosen}\n`, stderr: "" });
+  await assert.rejects(first, /not a directory/);
+});
+
+test("Native picker output is capped", async () => {
+  await assert.rejects(
+    runFolderPickerCommand({
+      file: process.execPath,
+      args: ["-e", `process.stdout.write("x".repeat(20000))`],
+      canceled: () => false,
+    }),
+    /too much output/,
+  );
+});

--- a/server/folder-picker.ts
+++ b/server/folder-picker.ts
@@ -1,0 +1,395 @@
+// Host-native working-directory picker (N2): the browser cannot turn a
+// FileSystemDirectoryHandle into the absolute path an agent process needs as
+// cwd, so an explicit onboarding click asks the LOCAL daemon to open the
+// operating system's own directory dialog. No shell is involved: every path
+// is an argv/env value, never executable text.
+
+import { spawn } from "node:child_process";
+import { accessSync, constants, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const PICKER_TITLE = "Choose a Mirafold working directory";
+const PICKER_OUTPUT_MAX_BYTES = 16_384;
+const LINUX_DIALOG_STARTUP_ERROR =
+  /failed to open display|cannot open display|could not connect to display|could not load the qt platform plugin|no qt platform plugin/i;
+
+// Native dialogs need the signed-in desktop session, locale, and temporary
+// directory — not the daemon's model-provider keys, relay credentials, or an
+// arbitrary provider's custom env_key. An allowlist makes that true even for
+// credential names Mirafold has never seen before. Loader/plugin overrides are
+// deliberately absent too: these helpers should use their system defaults.
+const PICKER_ENV_KEYS = new Set([
+  "PATH",
+  "PATHEXT",
+  "HOME",
+  "USER",
+  "USERNAME",
+  "LOGNAME",
+  "LANG",
+  "LANGUAGE",
+  "LC_ALL",
+  "LC_CTYPE",
+  "LC_MESSAGES",
+  "LC_COLLATE",
+  "LC_NUMERIC",
+  "LC_TIME",
+  "LC_MONETARY",
+  "LC_PAPER",
+  "LC_NAME",
+  "LC_ADDRESS",
+  "LC_TELEPHONE",
+  "LC_MEASUREMENT",
+  "LC_IDENTIFICATION",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "DISPLAY",
+  "WAYLAND_DISPLAY",
+  "XAUTHORITY",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "XDG_RUNTIME_DIR",
+  "XDG_CURRENT_DESKTOP",
+  "XDG_SESSION_DESKTOP",
+  "XDG_SESSION_TYPE",
+  "XDG_DATA_DIRS",
+  "XDG_CONFIG_DIRS",
+  "XDG_CONFIG_HOME",
+  "DESKTOP_SESSION",
+  "GDK_BACKEND",
+  "GTK_THEME",
+  "QT_QPA_PLATFORM",
+  "QT_STYLE_OVERRIDE",
+  "KDE_FULL_SESSION",
+  "KDE_SESSION_VERSION",
+  "__CF_USER_TEXT_ENCODING",
+  "SYSTEMROOT",
+  "WINDIR",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "COMSPEC",
+  "PSMODULEPATH",
+  "SESSIONNAME",
+  "MIRAFOLD_FOLDER_PICKER_START",
+]);
+
+const MAC_SCRIPT = [
+  'set startFolder to POSIX file (system attribute "MIRAFOLD_FOLDER_PICKER_START")',
+  `return POSIX path of (choose folder with prompt "${PICKER_TITLE}" default location startFolder)`,
+].join("\n");
+
+const WINDOWS_SCRIPT = [
+  "Add-Type -AssemblyName System.Windows.Forms",
+  "$dialog = New-Object System.Windows.Forms.FolderBrowserDialog",
+  `$dialog.Description = '${PICKER_TITLE}'`,
+  "$dialog.SelectedPath = $env:MIRAFOLD_FOLDER_PICKER_START",
+  "if ($dialog.ShowDialog() -eq [System.Windows.Forms.DialogResult]::OK) {",
+  "  [Console]::OutputEncoding = [System.Text.UTF8Encoding]::new()",
+  "  [Console]::Out.Write($dialog.SelectedPath)",
+  "}",
+].join("\n");
+
+export type FolderPickerCommand = {
+  file: string;
+  args: string[];
+  env?: Record<string, string>;
+  /** Exit code/stderr shape produced when the user presses Cancel. */
+  canceled: (code: number | null, stderr: string) => boolean;
+};
+
+export type FolderPickerProcessResult = {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+};
+
+export type RunFolderPickerCommand = (
+  command: FolderPickerCommand,
+  signal?: AbortSignal,
+) => Promise<FolderPickerProcessResult>;
+
+type LocateExecutable = (
+  file: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+) => string | undefined;
+
+/** Platform recipes, exported so Tier 1 pins the native contract without
+ *  opening a real GUI. Linux tries the two desktop-standard helpers in order. */
+export function folderPickerCommands(
+  startDir: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): FolderPickerCommand[] {
+  const startEnv = { MIRAFOLD_FOLDER_PICKER_START: startDir };
+  if (platform === "darwin") {
+    return [
+      {
+        file: "/usr/bin/osascript",
+        args: ["-e", MAC_SCRIPT],
+        env: startEnv,
+        // AppleScript's `choose folder` reports user cancellation as -128.
+        canceled: (code, stderr) => code === 1 && /user canceled|-128/i.test(stderr),
+      },
+    ];
+  }
+  if (platform === "win32") {
+    const systemPowerShell = env.SystemRoot
+      ? path.join(
+          env.SystemRoot,
+          "System32",
+          "WindowsPowerShell",
+          "v1.0",
+          "powershell.exe",
+        )
+      : "powershell.exe";
+    return [
+      {
+        file: systemPowerShell,
+        args: ["-NoLogo", "-NoProfile", "-STA", "-Command", WINDOWS_SCRIPT],
+        env: startEnv,
+        // FolderBrowserDialog writes nothing and exits successfully on Cancel.
+        canceled: () => false,
+      },
+    ];
+  }
+  if (platform === "linux") {
+    const initial = startDir.endsWith(path.sep) ? startDir : startDir + path.sep;
+    return [
+      {
+        file: "zenity",
+        args: [
+          "--file-selection",
+          "--directory",
+          `--title=${PICKER_TITLE}`,
+          `--filename=${initial}`,
+        ],
+        canceled: (code, stderr) => code === 1 && !LINUX_DIALOG_STARTUP_ERROR.test(stderr),
+      },
+      {
+        file: "kdialog",
+        args: ["--title", PICKER_TITLE, "--getexistingdirectory", startDir],
+        canceled: (code, stderr) => code === 1 && !LINUX_DIALOG_STARTUP_ERROR.test(stderr),
+      },
+    ];
+  }
+  return [];
+}
+
+/** Resolve a command exactly as a spawn would, but return an absolute file so
+ *  a later cwd change cannot reinterpret a relative PATH entry. */
+export function locateExecutable(
+  file: string,
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+): string | undefined {
+  const names =
+    platform === "win32" && !path.extname(file)
+      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+          .split(";")
+          .filter(Boolean)
+          .map((ext) => file + ext.toLowerCase())
+      : [file];
+  const direct = path.isAbsolute(file) || file.includes("/") || file.includes("\\");
+  const dirs = direct ? [""] : (env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  for (const dir of dirs) {
+    for (const name of names) {
+      const candidate = direct ? name : path.resolve(dir, name);
+      try {
+        if (!statSync(candidate).isFile()) continue;
+        accessSync(candidate, platform === "win32" ? constants.F_OK : constants.X_OK);
+        return candidate;
+      } catch {
+        // Missing, a directory, or not executable — normal lookup continues.
+      }
+    }
+  }
+  return undefined;
+}
+
+export function folderPickerAvailable(
+  platform: NodeJS.Platform = process.platform,
+  env: NodeJS.ProcessEnv = process.env,
+  locate: LocateExecutable = locateExecutable,
+): boolean {
+  if (platform === "linux" && !env.DISPLAY?.trim() && !env.WAYLAND_DISPLAY?.trim()) {
+    return false;
+  }
+  return folderPickerCommands(process.cwd(), platform, env).some((c) =>
+    Boolean(locate(c.file, platform, env)),
+  );
+}
+
+/** Build the deliberately narrow environment inherited by the native helper.
+ * Matching case-insensitively also preserves Windows' environment semantics. */
+export function folderPickerEnvironment(
+  source: NodeJS.ProcessEnv = process.env,
+  additions: NodeJS.ProcessEnv = {},
+): Record<string, string> {
+  const safe: Record<string, string> = {};
+  for (const [key, value] of Object.entries({ ...source, ...additions })) {
+    if (value !== undefined && PICKER_ENV_KEYS.has(key.toUpperCase())) safe[key] = value;
+  }
+  return safe;
+}
+
+function abortError(): Error {
+  const err = new Error("folder picker aborted");
+  err.name = "AbortError";
+  return err;
+}
+
+/** Spawn one native dialog with bounded output and no shell. */
+export function runFolderPickerCommand(
+  command: FolderPickerCommand,
+  signal?: AbortSignal,
+): Promise<FolderPickerProcessResult> {
+  if (signal?.aborted) return Promise.reject(abortError());
+  return new Promise((resolve, reject) => {
+    const child = spawn(command.file, command.args, {
+      env: folderPickerEnvironment(process.env, command.env),
+      stdio: ["ignore", "pipe", "pipe"],
+      ...(signal ? { signal } : {}),
+    });
+    let stdout = Buffer.alloc(0);
+    let stderr = Buffer.alloc(0);
+    let settled = false;
+    const finish = (err: Error | null, result?: FolderPickerProcessResult) => {
+      if (settled) return;
+      settled = true;
+      if (err) reject(err);
+      else resolve(result!);
+    };
+    const capture = (which: "stdout" | "stderr", chunk: Buffer) => {
+      const next = Buffer.concat([which === "stdout" ? stdout : stderr, chunk]);
+      if (next.byteLength > PICKER_OUTPUT_MAX_BYTES) {
+        child.kill();
+        finish(new Error("The system folder picker returned too much output."));
+        return;
+      }
+      if (which === "stdout") stdout = next;
+      else stderr = next;
+    };
+    child.stdout.on("data", (chunk: Buffer) => capture("stdout", chunk));
+    child.stderr.on("data", (chunk: Buffer) => capture("stderr", chunk));
+    child.once("error", (err) => finish(err));
+    child.once("close", (code) =>
+      finish(null, {
+        code,
+        stdout: stdout.toString("utf8"),
+        stderr: stderr.toString("utf8"),
+      }),
+    );
+  });
+}
+
+function isDirectory(candidate: string): boolean {
+  try {
+    return statSync(candidate).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** Start the dialog somewhere useful. A half-typed/nonexistent path is the
+ *  reason the picker may have been opened, so it falls back instead of erroring. */
+export function folderPickerStartDir(
+  requested: string | undefined,
+  fallback = process.cwd(),
+  home = os.homedir(),
+  directoryExists: (candidate: string) => boolean = isDirectory,
+): string {
+  const raw = requested?.trim();
+  if (!raw) return fallback;
+  const expanded = raw.replace(/^~(?=[/\\]|$)/, home);
+  const candidate = path.resolve(expanded);
+  return directoryExists(candidate) ? candidate : fallback;
+}
+
+export type PickHostDirectory = (
+  requestedStart?: string,
+  signal?: AbortSignal,
+) => Promise<string | undefined>;
+
+/** One shared service instance means two tabs cannot stack native dialogs on
+ *  the host. Dependencies are injectable so tests never open a real GUI. */
+export function createFolderPicker(opts: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  locate?: LocateExecutable;
+  run?: RunFolderPickerCommand;
+  fallbackDir?: () => string;
+  homeDir?: () => string;
+  directoryExists?: (candidate: string) => boolean;
+} = {}): PickHostDirectory {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const locate = opts.locate ?? locateExecutable;
+  const run = opts.run ?? runFolderPickerCommand;
+  const fallbackDir = opts.fallbackDir ?? (() => process.cwd());
+  const homeDir = opts.homeDir ?? os.homedir;
+  const directoryExists = opts.directoryExists ?? isDirectory;
+  let active = false;
+
+  return async (requestedStart, signal) => {
+    if (signal?.aborted) throw abortError();
+    if (active) throw new Error("A folder picker is already open on this computer.");
+    active = true;
+    try {
+      const startDir = folderPickerStartDir(
+        requestedStart,
+        fallbackDir(),
+        homeDir(),
+        directoryExists,
+      );
+      const commands = folderPickerCommands(startDir, platform, env);
+      let lastFailure: Error | undefined;
+      for (const recipe of commands) {
+        const executable = locate(recipe.file, platform, env);
+        if (!executable) continue;
+        const command = { ...recipe, file: executable };
+        let result: FolderPickerProcessResult;
+        try {
+          result = await run(command, signal);
+        } catch (err) {
+          if (signal?.aborted || (err instanceof Error && err.name === "AbortError")) throw err;
+          if ((err as NodeJS.ErrnoException)?.code === "ENOENT") continue;
+          lastFailure = err instanceof Error ? err : new Error(String(err));
+          // On Linux, a present helper can still be unusable under the active
+          // desktop; try the other toolkit before surfacing the failure.
+          if (platform === "linux") continue;
+          throw lastFailure;
+        }
+        if (recipe.canceled(result.code, result.stderr)) return undefined;
+        if (result.code !== 0) {
+          lastFailure = new Error("The system folder picker could not open.");
+          if (platform === "linux") continue;
+          throw lastFailure;
+        }
+        // Windows cancellation is a successful process with empty stdout;
+        // all three platform tools append at most one line ending on success.
+        const selected = result.stdout.replace(/\r?\n$/, "");
+        if (!selected) return undefined;
+        const absolute = path.resolve(selected);
+        if (!directoryExists(absolute)) {
+          throw new Error("The system folder picker returned a path that is not a directory.");
+        }
+        return absolute;
+      }
+      if (lastFailure) throw lastFailure;
+      throw new Error(
+        platform === "linux"
+          ? "No graphical folder picker is available. Install Zenity or KDialog, or type the path."
+          : "No graphical folder picker is available. Type the path instead.",
+      );
+    } finally {
+      active = false;
+    }
+  };
+}
+
+export const pickHostDirectory = createFolderPicker();

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -120,9 +120,11 @@ const WIRE: WireByType = {
     default: "claude-code",
     cwd: "/home/u/proj",
     home: "/home/u",
+    folderPicker: true,
     relay: { url: "wss://relay.mirafold.sh", code: "abc123def456ghij" },
     version: "0.0.1",
   },
+  folder_picked: { type: "folder_picked", id: "fp1", path: "/home/u/other-project" },
   refused: {
     type: "refused",
     reason: "subscription_over_relay",
@@ -213,6 +215,7 @@ const CLIENT: ClientByType = {
   interrupt_session: { type: "interrupt_session", sessionId: "s1" },
   prompt_session: { type: "prompt_session", sessionId: "s1", text: "run the tests" },
   refresh_agents: { type: "refresh_agents" },
+  pick_folder: { type: "pick_folder", id: "fp1", cwd: "/home/u/proj" },
   fs_list: { type: "fs_list", id: "f1" },
   fs_listdir: { type: "fs_listdir", id: "f4", path: "src" },
   fs_read: { type: "fs_read", id: "f2", path: "src/app.ts" },
@@ -323,4 +326,10 @@ test("Q.2 load-bearing frames keep their exact shape (a rename fails here loudly
   // (the never-broadcast secret path) must not silently change field names.
   assert.deepEqual(CLIENT.permission_response, { type: "permission_response", id: "p1", allow: true });
   assert.deepEqual(CLIENT.bang_input, { type: "bang_input", data: "hunter2\n", id: "b1" });
+  assert.deepEqual(CLIENT.pick_folder, { type: "pick_folder", id: "fp1", cwd: "/home/u/proj" });
+  assert.deepEqual(WIRE.folder_picked, {
+    type: "folder_picked",
+    id: "fp1",
+    path: "/home/u/other-project",
+  });
 });

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -170,9 +170,16 @@ type WireMsgBody =
       default: AgentName;
       cwd?: string;
       home?: string;
+      // N2: this viewport can ask the daemon to open a native folder dialog
+      // on the host. False/absent keeps the manual path field only (old
+      // daemon, relay viewport, or Linux without Zenity/KDialog).
+      folderPicker?: boolean;
       relay?: { url: string; code: string; ws?: string };
       version?: string;
     }
+  // N2: one local, per-viewport reply to `pick_folder`; never broadcast or
+  // replayed. Cancel is explicit so an empty reply cannot strand the button.
+  | { type: "folder_picked"; id: string; path?: string; canceled?: true; error?: string }
   // The daemon refused to attach this REMOTE (relay) viewport to the
   // session because the session's credential can't be used over the paid relay
   // — a subscription-backed agent (closed-model reselling posture). Sent instead
@@ -514,6 +521,10 @@ export type ClientMsg =
   // "start your local server and it appears here" promise is live — no
   // reload. Server-side throttled; a burst degrades to the cached answer.
   | { type: "refresh_agents" }
+  // N2: an explicit user gesture asks the LOCAL daemon to open the host OS's
+  // folder dialog. `cwd` is only the suggested starting directory; the daemon
+  // validates it and returns the actual selected path in `folder_picked`.
+  | { type: "pick_folder"; id: string; cwd?: string }
   // Phase E (Explorer): the read-only file browser's per-viewport queries.
   // `id` is client-minted (the bang-id grammar) so the issuing component can
   // correlate the one reply each request gets. The path is a REQUEST — the

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -5,6 +5,7 @@ import { PROMPT_GATE_REFUSAL, type SessionEntry, type SessionRegistry } from "./
 import { runActionTool } from "./actions";
 import { createBangHandlers } from "./bang-handlers";
 import { createFsHandlers } from "./fs-handlers";
+import { createFolderPickerHandler } from "./folder-picker-handler";
 import {
   ADAPTER_AGENTS,
   availableAgents,
@@ -22,6 +23,7 @@ import { VERSION } from "../version";
 // lifecycle; re-exported because the Tier-1 pin imports it from here.
 export { escapeTranscriptFence } from "./bang-handlers";
 import { envInt } from "../env";
+import { folderPickerAvailable } from "../folder-picker";
 
 // Minimum gap between refresh_agents-triggered probe sweeps per connection
 // (N.3). The picker polls every few seconds; anything faster serves the
@@ -87,6 +89,11 @@ export function openConnection(
   const fs = createFsHandlers({
     viewport,
     getEntry: () => entry,
+    isClosed: () => closed,
+  });
+  const folderPicker = createFolderPickerHandler({
+    viewport,
+    remote,
     isClosed: () => closed,
   });
 
@@ -160,6 +167,7 @@ export function openConnection(
       default: defaultAgent(),
       cwd: process.cwd(),
       home: os.homedir(),
+      folderPicker: !remote && folderPickerAvailable(),
       version: VERSION,
       ...(relay ? { relay } : {}),
     });
@@ -422,6 +430,9 @@ export function openConnection(
           if (!closed) sendAgents();
         });
         break;
+      case "pick_folder":
+        folderPicker.pick(msg);
+        break;
       case "fs_list":
         // Explorer tree/read/diff (Phase E) — per-viewport queries handled
         // in fs-handlers.ts (jail, throttle, git-in-flight, one reply each).
@@ -454,6 +465,7 @@ export function openConnection(
 
   const close = () => {
     closed = true;
+    folderPicker.close();
     if (entry) {
       registry.detach(entry, viewport);
       log.info(`viewport detached ← session ${entry.id}`);

--- a/server/sessions/folder-picker-handler.test.ts
+++ b/server/sessions/folder-picker-handler.test.ts
@@ -1,0 +1,87 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { WireMsg } from "../protocol";
+import { createFolderPickerHandler } from "./folder-picker-handler";
+
+const settle = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+test("local picker success and cancellation each produce one correlated reply", async () => {
+  const seen: WireMsg[] = [];
+  const choices = ["/chosen/project", undefined];
+  const handler = createFolderPickerHandler({
+    viewport: (msg) => seen.push(msg),
+    remote: false,
+    isClosed: () => false,
+    pickDirectory: async () => choices.shift(),
+  });
+  handler.pick({ type: "pick_folder", id: "fp-one", cwd: "~/start" });
+  await settle();
+  handler.pick({ type: "pick_folder", id: "fp-two" });
+  await settle();
+  assert.deepEqual(seen, [
+    { type: "folder_picked", id: "fp-one", path: "/chosen/project" },
+    { type: "folder_picked", id: "fp-two", canceled: true },
+  ]);
+});
+
+test("relay viewports cannot open host UI, and hostile request shapes are bounded", async () => {
+  const seen: WireMsg[] = [];
+  let called = 0;
+  const remote = createFolderPickerHandler({
+    viewport: (msg) => seen.push(msg),
+    remote: true,
+    isClosed: () => false,
+    pickDirectory: async () => {
+      called++;
+      return "/must-not-run";
+    },
+  });
+  remote.pick({ type: "pick_folder", id: "fp-remote" });
+  assert.equal(called, 0);
+  assert.match((seen[0] as Extract<WireMsg, { type: "folder_picked" }>).error!, /only on the computer/);
+
+  const local = createFolderPickerHandler({
+    viewport: (msg) => seen.push(msg),
+    remote: false,
+    isClosed: () => false,
+    pickDirectory: async () => "/must-not-run",
+  });
+  local.pick({ type: "pick_folder", id: "bad id" });
+  local.pick({ type: "pick_folder", id: "fp-long", cwd: "x".repeat(4_097) });
+  await settle();
+  assert.equal(called, 0);
+  assert.equal(seen.length, 2, "bad id dropped; long path answered once");
+  assert.match((seen[1] as Extract<WireMsg, { type: "folder_picked" }>).error!, /too long/);
+});
+
+test("one connection cannot stack dialogs, and close aborts the in-flight picker", async () => {
+  const seen: WireMsg[] = [];
+  let aborted = false;
+  const handler = createFolderPickerHandler({
+    viewport: (msg) => seen.push(msg),
+    remote: false,
+    isClosed: () => false,
+    pickDirectory: (_cwd, signal) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => {
+          aborted = true;
+          const err = new Error("aborted");
+          err.name = "AbortError";
+          reject(err);
+        });
+      }),
+  });
+  handler.pick({ type: "pick_folder", id: "fp-first" });
+  handler.pick({ type: "pick_folder", id: "fp-second" });
+  assert.deepEqual(seen, [
+    {
+      type: "folder_picked",
+      id: "fp-second",
+      error: "A folder picker is already open. Choose a folder or cancel it first.",
+    },
+  ]);
+  handler.close();
+  await settle();
+  assert.equal(aborted, true);
+  assert.equal(seen.length, 1, "an aborted/closed viewport receives no late reply");
+});

--- a/server/sessions/folder-picker-handler.ts
+++ b/server/sessions/folder-picker-handler.ts
@@ -1,0 +1,80 @@
+// Per-viewport wire handler for N2's host-native working-directory picker.
+// The dialog is local shell chrome: never broadcast, replayed, or reachable
+// through the paid relay. Every well-formed request gets one correlated reply.
+
+import type { ClientMsg, WireMsg } from "../protocol";
+import { errText } from "../adapters/types";
+import { pickHostDirectory, type PickHostDirectory } from "../folder-picker";
+import { CLIENT_ID_RE } from "./fs-handlers";
+
+type PickFolder = Extract<ClientMsg, { type: "pick_folder" }>;
+
+export type FolderPickerHandler = {
+  pick: (msg: PickFolder) => void;
+  close: () => void;
+};
+
+export function createFolderPickerHandler(opts: {
+  viewport: (msg: WireMsg) => void;
+  remote: boolean;
+  isClosed: () => boolean;
+  pickDirectory?: PickHostDirectory;
+}): FolderPickerHandler {
+  const pickDirectory = opts.pickDirectory ?? pickHostDirectory;
+  let active: AbortController | null = null;
+
+  const reply = (msg: Extract<WireMsg, { type: "folder_picked" }>) => {
+    if (!opts.isClosed()) opts.viewport(msg);
+  };
+
+  const pick = (msg: PickFolder): void => {
+    if (typeof msg.id !== "string" || !CLIENT_ID_RE.test(msg.id)) return;
+    if (opts.remote) {
+      reply({
+        type: "folder_picked",
+        id: msg.id,
+        error:
+          "Folder browsing is available only on the computer running Mirafold. Type a path on that computer instead.",
+      });
+      return;
+    }
+    if (typeof msg.cwd === "string" && msg.cwd.length > 4_096) {
+      reply({ type: "folder_picked", id: msg.id, error: "The working-directory path is too long." });
+      return;
+    }
+    if (active) {
+      reply({
+        type: "folder_picked",
+        id: msg.id,
+        error: "A folder picker is already open. Choose a folder or cancel it first.",
+      });
+      return;
+    }
+
+    const controller = new AbortController();
+    active = controller;
+    void pickDirectory(typeof msg.cwd === "string" ? msg.cwd : undefined, controller.signal)
+      .then((selected) => {
+        reply(
+          selected
+            ? { type: "folder_picked", id: msg.id, path: selected }
+            : { type: "folder_picked", id: msg.id, canceled: true },
+        );
+      })
+      .catch((err) => {
+        if (controller.signal.aborted) return;
+        reply({ type: "folder_picked", id: msg.id, error: errText(err) });
+      })
+      .finally(() => {
+        if (active === controller) active = null;
+      });
+  };
+
+  return {
+    pick,
+    close: () => {
+      active?.abort();
+      active = null;
+    },
+  };
+}

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1,11 +1,11 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { type Browser, type Page } from "playwright-core";
 import { fixtureGit as git, startDaemon, TestClient, type Daemon } from "./itest-harness";
-import { assertAxeClean, launchChrome } from "./e2e-harness";
+import { assertAxeClean, launchChrome, noSideScroll } from "./e2e-harness";
 import type { ClientMsg } from "../protocol";
 import { startOllamaFixture } from "./ollama-fixture";
 import { startRelayStub } from "../relay/relay-stub";
@@ -136,6 +136,60 @@ test("the agent picker flexes to the window — no internal scrollbar through th
     await d2.stop();
   }
 });
+
+test(
+  "N2: browse opens the host picker, fills cwd, and creates the session there",
+  { skip: process.platform !== "linux" && "the harmless Zenity fixture is Linux-specific" },
+  async () => {
+    // Substitute Zenity at the ordinary PATH seam: production still invokes
+    // the real platform helper, while this child prints one known directory
+    // and opens no GUI. The browser + daemon + WebSocket path remain real.
+    const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-folder-picker-e2e-"));
+    const picked = path.join(fixture, "picked project");
+    const zenity = path.join(fixture, "zenity");
+    mkdirSync(picked);
+    writeFileSync(
+      zenity,
+      `#!/usr/bin/env node\n` +
+        `if ("OPENAI_API_KEY" in process.env || "MIRAFOLD_TEST_PICKER_SECRET" in process.env) process.exit(9);\n` +
+        `process.stdout.write(${JSON.stringify(picked)});\n`,
+    );
+    chmodSync(zenity, 0o755);
+    const token = "e2e-folder-picker-9c2f";
+    const d2 = await startDaemon({
+      MIRAFOLD_TOKEN: token,
+      MIRAFOLD_TEST_PICKER_SECRET: "must-not-cross",
+      DISPLAY: ":99",
+      PATH: `${fixture}${path.delimiter}${process.env.PATH ?? ""}`,
+    });
+    const page2 = await browser.newPage();
+    try {
+      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
+      await page2.waitForSelector(".onb-cwd-browse");
+      await page2.setViewportSize({ width: 390, height: 844 });
+      await noSideScroll(page2);
+      await assertAxeClean(page2, "onboarding folder picker");
+
+      await page2.locator(".onb-cwd-browse").click();
+      await page2.waitForFunction(
+        (expected) =>
+          (document.querySelector("#onb-cwd") as HTMLInputElement | null)?.value === expected,
+        picked,
+      );
+      assert.equal(await page2.locator("#onb-cwd").inputValue(), picked);
+
+      await page2.setViewportSize({ width: 1100, height: 800 });
+      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
+      await page2.waitForURL(/\/s\/[\w-]+/);
+      await page2.waitForSelector(".sb-cwd");
+      assert.equal(await page2.locator(".sb-cwd").getAttribute("title"), picked);
+    } finally {
+      await page2.close();
+      await d2.stop();
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  },
+);
 
 test("onboarding → a full mock turn renders in the DOM", async () => {
   // An empty registry opens straight into "choose your agent".

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -446,29 +446,51 @@ test("status-list component: one verdict pill per row, glyph + word, all five st
 });
 
 test("diagram component: mermaid renders as SVG inside the sandbox; broken source shows itself", async () => {
-  await page.locator("textarea").click();
-  await page.keyboard.type("diagram demo");
-  await page.keyboard.press("Enter");
-  const block = page.locator(".rc-diagram", { hasText: "Relay pairing flow" });
-  await block.waitFor({ timeout: 20_000 });
-  // The runtime is a lazy ~3.6 MB chunk — give the first render room.
-  const frame = block.locator("iframe.rc-diagram-frame");
-  await frame.waitFor({ timeout: 20_000 });
-  const svg = page
-    .frameLocator(".rc-diagram:has-text('Relay pairing flow') iframe")
-    .locator("#host svg");
-  await svg.waitFor({ timeout: 20_000 });
-  // The frame reported its measured height back — the host sized to fit.
-  const h = await frame.evaluate((el) => el.getBoundingClientRect().height);
-  assert.ok(h > 130, `frame did not grow to the diagram (h=${h})`);
-  // The shell-drawn chrome badges the sandbox, outside the frame.
-  assert.match(await block.locator(".rc-diagram-badge").innerText(), /sandboxed/);
+  // This test used to borrow the suite's long-lived session. Its failure was
+  // misattributed to Mermaid's lazy chunk, but the outer .rc-diagram never
+  // arrived: an earlier test could finish its DOM assertions just before its
+  // turn_end and leave this prompt contending with the one-follow-up gate.
+  // Own a session so this test reaches the renderer or fails for a renderer
+  // reason; the actual lazy chunk, iframe, CSP, postMessage, and parse error
+  // paths below remain production-real.
+  const token = "e2e-diagram-9c2f";
+  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
+  try {
+    const page2 = await browser.newPage();
+    try {
+      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
+      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
+      await page2.waitForURL(/\/s\/[\w-]+/);
+      await page2.waitForSelector("textarea");
+      await page2.locator("textarea").fill("diagram demo");
+      await page2.keyboard.press("Enter");
 
-  // Broken source: the failure state carries the message AND the source text.
-  const failed = page.locator(".rc-diagram-failed", { hasText: "broken diagram" });
-  await failed.waitFor({ timeout: 20_000 });
-  assert.match(await failed.innerText(), /diagram didn't render/);
-  assert.ok((await failed.locator(".rc-diagram-source").innerText()).includes("nope"));
+      const block = page2.locator(".rc-diagram", { hasText: "Relay pairing flow" });
+      await block.waitFor({ timeout: 20_000 });
+      // The runtime is a lazy ~3.6 MB chunk — give the first render room.
+      const frame = block.locator("iframe.rc-diagram-frame");
+      await frame.waitFor({ timeout: 20_000 });
+      const svg = page2
+        .frameLocator(".rc-diagram:has-text('Relay pairing flow') iframe")
+        .locator("#host svg");
+      await svg.waitFor({ timeout: 20_000 });
+      // The frame reported its measured height back — the host sized to fit.
+      const h = await frame.evaluate((el) => el.getBoundingClientRect().height);
+      assert.ok(h > 130, `frame did not grow to the diagram (h=${h})`);
+      // The shell-drawn chrome badges the sandbox, outside the frame.
+      assert.match(await block.locator(".rc-diagram-badge").innerText(), /sandboxed/);
+
+      // Broken source: the failure state carries the message AND the source text.
+      const failed = page2.locator(".rc-diagram-failed", { hasText: "broken diagram" });
+      await failed.waitFor({ timeout: 20_000 });
+      assert.match(await failed.innerText(), /diagram didn't render/);
+      assert.ok((await failed.locator(".rc-diagram-source").innerText()).includes("nope"));
+    } finally {
+      await page2.close();
+    }
+  } finally {
+    await d2.stop();
+  }
 });
 
 test("image component: a resolved shot renders as a real <img>; a refused one says why", async () => {
@@ -1339,61 +1361,189 @@ test("status bar: new sits beside home, end is the far-right control, ?new opens
 });
 
 test("streaming holds a scrolled-up reader in place, and re-follows once back at the bottom", async () => {
-  await page.locator("textarea").click();
-  await page.keyboard.type("plan it step by step");
-  await page.keyboard.press("Enter");
-  await page.waitForSelector("text=Read the current implementation", { timeout: 15_000 });
+  // Own the transcript and make it scrollable at a fixed viewport. The old
+  // version borrowed 40 prior tests' worth of content, then jumped to the
+  // bottom programmatically and sampled once; neither is a user's re-arm
+  // path, and the delayed scroll event raced the next streamed paint.
+  const token = "e2e-follow-tail-9c2f";
+  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
+  try {
+    const page2 = await browser.newPage();
+    try {
+      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
+      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
+      await page2.waitForURL(/\/s\/[\w-]+/);
+      await page2.setViewportSize({ width: 900, height: 520 });
+      await page2.waitForSelector("textarea");
 
-  const zone = page.locator(".render-zone");
-  const geom = () =>
-    zone.evaluate((el) => ({ top: el.scrollTop, h: el.scrollHeight, view: el.clientHeight }));
+      const zone = page2.locator(".render-zone");
+      const geom = () =>
+        zone.evaluate((el) => ({ top: el.scrollTop, h: el.scrollHeight, view: el.clientHeight }));
+      const sendPlan = async () => {
+        const before = await page2.locator(".turn-user", { hasText: "plan it step by step" }).count();
+        await page2.locator("textarea").fill("plan it step by step");
+        await page2.keyboard.press("Enter");
+        await page2.waitForFunction(
+          (n) =>
+            [...document.querySelectorAll(".turn-user")].filter((el) =>
+              el.textContent?.includes("plan it step by step"),
+            ).length > n,
+          before,
+          { timeout: 15_000 },
+        );
+      };
 
-  // A real wheel, up, over the transcript — the reader going back to look at
-  // something while the agent is still talking. Several notches: landing
-  // within the follow slack of the bottom would prove nothing, since that
-  // position is *supposed* to keep following.
-  await zone.hover();
-  const atWheel = await geom();
-  for (let i = 0; i < 4; i++) {
-    await page.mouse.wheel(0, -600);
-    await page.waitForTimeout(150);
+      // Two completed turns supply deterministic scrollback; the next is the
+      // live stream under test. One turn measured only 28px taller than this
+      // fixed viewport, too little for a meaningful 100px upward-wheel proof.
+      for (let i = 0; i < 2; i++) {
+        const completeBefore = await page2
+          .locator(".turn-assistant", { hasText: "Plan complete — all four steps done." })
+          .count();
+        await sendPlan();
+        await page2.waitForFunction(
+          (n) =>
+            [...document.querySelectorAll(".turn-assistant")].filter((el) =>
+              el.textContent?.includes("Plan complete — all four steps done."),
+            ).length > n,
+          completeBefore,
+          { timeout: 30_000 },
+        );
+        await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+          timeout: 15_000,
+        });
+      }
+      const seeded = await geom();
+      assert.ok(
+        seeded.h - seeded.view > 300,
+        `seed turn did not make scrollback (content ${seeded.h}px, viewport ${seeded.view}px)`,
+      );
+
+      const todoBefore = await page2.locator(".rc-todos").count();
+      const finalBefore = await page2
+        .locator(".turn-assistant", { hasText: "Plan complete — all four steps done." })
+        .count();
+      await sendPlan();
+      await page2.waitForFunction(
+        (n) => document.querySelectorAll(".rc-todos").length > n,
+        todoBefore,
+        { timeout: 15_000 },
+      );
+
+      // A real wheel up over the transcript: the reader is steering into
+      // scrollback while the agent is still producing output.
+      await zone.hover();
+      const atWheel = await geom();
+      await page2.mouse.wheel(0, -1_000);
+      await page2.waitForFunction(
+        ({ top }) => {
+          const el = document.querySelector(".render-zone");
+          return Boolean(
+            el &&
+              el.scrollTop < top - 100 &&
+              el.scrollHeight - el.scrollTop - el.clientHeight > 200,
+          );
+        },
+        atWheel,
+        { timeout: 5_000 },
+      );
+      const before = await geom();
+
+      // New output must grow below without moving the scrolled-up reader.
+      await page2.waitForFunction(
+        ({ top, h }) => {
+          const el = document.querySelector(".render-zone");
+          return Boolean(el && el.scrollHeight > h && Math.abs(el.scrollTop - top) <= 1);
+        },
+        before,
+        { timeout: 5_000 },
+      );
+
+      // Let that timed turn finish, then use a permission request as a latch
+      // for the re-arm half. Sending the request legitimately returns to the
+      // tail; scroll up once more while the engine is guaranteed to remain
+      // busy until this test answers.
+      await page2.waitForFunction(
+        (n) =>
+          [...document.querySelectorAll(".turn-assistant")].filter((el) =>
+            el.textContent?.includes("Plan complete — all four steps done."),
+          ).length > n,
+        finalBefore,
+        { timeout: 30_000 },
+      );
+      await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+        timeout: 15_000,
+      });
+      await page2.locator("textarea").fill("run something dangerous");
+      await page2.keyboard.press("Enter");
+      await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
+
+      await zone.hover();
+      const latchedAtWheel = await geom();
+      await page2.mouse.wheel(0, -1_000);
+      await page2.waitForFunction(
+        ({ top }) => {
+          const el = document.querySelector(".render-zone");
+          return Boolean(
+            el &&
+              el.scrollTop < top - 100 &&
+              el.scrollHeight - el.scrollTop - el.clientHeight > 200,
+          );
+        },
+        latchedAtWheel,
+        { timeout: 5_000 },
+      );
+
+      // A real downward gesture that reaches the current tail arms from its
+      // pre-input geometry. The unanswered permission keeps the premise
+      // stable; no timer can end the turn between the gesture and assertion.
+      const beforeReturn = await geom();
+      await page2.mouse.wheel(0, beforeReturn.h + beforeReturn.view);
+      await page2.waitForFunction(
+        () => {
+          const el = document.querySelector(".render-zone");
+          return Boolean(
+            el &&
+              document.querySelector(".stop-btn") &&
+              document.querySelector(".perm-bar") &&
+              el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
+          );
+        },
+        undefined,
+        { timeout: 5_000 },
+      );
+      const rearmed = await geom();
+
+      // Allowing resolves the latch and starts tool/output frames without a
+      // new user prompt (which would arm following independently). Do not
+      // merely prove one scroll landed: that later content must carry the
+      // viewport with it.
+      await page2.locator(".perm-allow").click();
+      await page2.waitForFunction(
+        (h) => {
+          const el = document.querySelector(".render-zone");
+          return Boolean(
+            el &&
+              el.scrollHeight > h &&
+              el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
+          );
+        },
+        rearmed.h,
+        { timeout: 5_000 },
+      );
+      await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+        timeout: 15_000,
+      });
+      await page2.waitForFunction(() => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(el && el.scrollHeight - el.scrollTop - el.clientHeight <= 60);
+      });
+    } finally {
+      await page2.close();
+    }
+  } finally {
+    await d2.stop();
   }
-  await page.waitForTimeout(400);
-  const before = await geom();
-  // The wheel must actually have moved the reader UP. Without this the test
-  // can pass vacuously in the exact state that motivated it: a permanently
-  // in-flight smooth scroll owning scrollTop, wheel deltas overwritten before
-  // they become scroll events, the reader carried along the whole time
-  // (2026-07-20 — the trace that produced this assertion).
-  assert.ok(
-    before.top < atWheel.top - 100,
-    `the wheel did not scroll the reader up: ${atWheel.top} → ${before.top}`,
-  );
-  assert.ok(
-    before.h - before.top - before.view > 200,
-    "the wheel must land well clear of the bottom for this test to mean anything",
-  );
-
-  // Position holds for as long as output keeps landing below.
-  let grew = false;
-  for (let i = 0; i < 20 && !grew; i++) {
-    await page.waitForTimeout(500);
-    const now = await geom();
-    assert.ok(
-      Math.abs(now.top - before.top) <= 1,
-      `streaming moved a scrolled-up reader: ${before.top} → ${now.top}`,
-    );
-    grew = now.h > before.h;
-  }
-  assert.ok(grew, "no output painted during the hold window — the assertion proved nothing");
-
-  // Back to the bottom re-arms follow, with no toggle to press.
-  await zone.evaluate((el) => el.scrollTo({ top: el.scrollHeight }));
-  await page.waitForSelector("text=Plan complete — all four steps done.", { timeout: 30_000 });
-  await page.waitForTimeout(1200);
-  const end = await geom();
-  const gap = end.h - end.top - end.view;
-  assert.ok(gap <= 60, `expected to be following the tail again, sat ${gap}px above it`);
 });
 
 // The frame sampler's in-page globals (armed before the prompt, read after).
@@ -1416,87 +1566,98 @@ const awaitIdle = () =>
   });
 
 test("a busy turn never looks idle: the indicator is up, moving, and on screen whenever the stop button is", async () => {
-  await awaitIdle();
-  // Frame-by-frame watcher, armed BEFORE the prompt goes out: any frame
-  // where the turn is in flight (stop button present) but no activity line
-  // is painted is the 2026-07-28 bug — work happening with nothing showing.
-  // It also counts glyph frame CHANGES: a present-but-frozen line is the
-  // 2026-07-29 bug (the CSS pulse was dead under the rise-animation
-  // override, so "thinking…" never moved). The sampler is an ANONYMOUS
-  // callback on setInterval — a named function const here dies in-page on
-  // tsx's keepNames __name wrapper (same trap `eventually` documents below).
-  await page.evaluate(() => {
-    const w = window as unknown as BusyWatch;
-    w.__busyFrames = 0;
-    w.__blankFrames = 0;
-    w.__glyphFlips = 0;
-    w.__lastGlyph = "";
-    w.__watch = window.setInterval(() => {
-      if (document.querySelector(".stop-btn")) {
-        w.__busyFrames++;
-        const glyph = document.querySelector(".activity-glyph")?.textContent;
-        if (glyph === undefined) w.__blankFrames++;
-        else if (glyph !== w.__lastGlyph) {
-          if (w.__lastGlyph !== "") w.__glyphFlips++;
-          w.__lastGlyph = glyph;
-        }
-      }
-    }, 16);
-  });
-  await page.locator("textarea").click();
-  // The checklist turn runs multiple seconds — long enough to observe the
-  // glyph cycle and to scroll mid-turn below.
-  await page.keyboard.type("plan it step by step");
-  await page.keyboard.press("Enter");
-  await page.waitForSelector(".activity-line", { timeout: 15_000 });
-  // The elapsed counter is painted from the first frame — (0s) and upward.
-  assert.match(
-    (await page.locator(".activity-line").textContent()) ?? "",
-    /\(\d+s\)/,
-    "no elapsed counter in the activity line",
-  );
-  // Mid-turn, scroll the transcript to its top: the indicator is prompt-area
-  // chrome, not a transcript entry — no scroll position may hide it.
-  await page.evaluate(() => {
-    document.querySelector(".render-zone")!.scrollTop = 0;
-  });
-  const visible = await page.evaluate(() => {
-    const r = document.querySelector(".activity-line")?.getBoundingClientRect();
-    return Boolean(r && r.height > 0 && r.top >= 0 && r.bottom <= window.innerHeight);
-  });
-  assert.ok(visible, "indicator off screen while the transcript is scrolled up");
-  // Turn over: the stop button goes, and the activity line goes with it.
-  await page.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
-    timeout: 30_000,
-  });
-  const frames = await page.evaluate(() => {
-    const w = window as unknown as BusyWatch;
-    window.clearInterval(w.__watch);
-    return { busy: w.__busyFrames, blank: w.__blankFrames, flips: w.__glyphFlips };
-  });
-  // Sanity floor, not a strength claim (recalibrated 2026-07-28: a bigger
-  // floor flaked whenever the reply streamed fast).
-  assert.ok(frames.busy > 0, "the sampler never saw the turn in flight");
-  assert.equal(
-    frames.blank,
-    0,
-    `${frames.blank} frame(s) had a turn in flight with no activity line painted`,
-  );
-  // Aliveness: the glyph must visibly CYCLE, not merely exist. Measured
-  // against the sampler's own window rather than the turn's length — under
-  // load the mock turn can finish in ~300 ms, which is fewer than three
-  // 140 ms glyph frames, so a flat `flips >= 3` fails on a perfectly
-  // healthy indicator (observed 2/5 runs, 2026-07-29; same class as the
-  // 07-28 recalibration of the busy-frame floor above). The honest
-  // guarantee is a RATE: at least one frame change per ~250 ms of observed
-  // busy time, and never zero once the window is long enough to hold one.
-  const busyMs = frames.busy * 16;
-  const expectedFlips = Math.max(1, Math.floor(busyMs / 250));
-  assert.ok(
-    frames.flips >= Math.min(expectedFlips, 3),
-    `the glyph barely moved: ${frames.flips} frame changes over ${busyMs}ms of busy samples`,
-  );
-  assert.equal(await page.locator(".activity-line").count(), 0);
+  // Own the state under test. The old shared-page/checklist version waited
+  // for a transient line, then made another Playwright round-trip to read it;
+  // a loaded runner could deliver the scripted turn_end between those calls,
+  // correctly remove the line, and make textContent() wait 30 seconds for an
+  // element that was supposed to stay gone. A permission request is the
+  // mock's deterministic latch: the turn cannot end until this test answers.
+  const token = "e2e-busy-indicator-9c2f";
+  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
+  try {
+    const page2 = await browser.newPage();
+    try {
+      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
+      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
+      await page2.waitForURL(/\/s\/[\w-]+/);
+      await page2.waitForSelector("textarea");
+
+      // Frame-by-frame watcher, armed BEFORE the prompt goes out: any frame
+      // where the turn is in flight (stop button present) but no activity line
+      // is painted is the 2026-07-28 bug — work happening with nothing showing.
+      // It also counts glyph frame CHANGES: a present-but-frozen line is the
+      // 2026-07-29 bug. The callback stays anonymous because tsx's keepNames
+      // wrapper does not exist inside the page.
+      await page2.evaluate(() => {
+        const w = window as unknown as BusyWatch;
+        w.__busyFrames = 0;
+        w.__blankFrames = 0;
+        w.__glyphFlips = 0;
+        w.__lastGlyph = "";
+        w.__watch = window.setInterval(() => {
+          if (document.querySelector(".stop-btn")) {
+            w.__busyFrames++;
+            const glyph = document.querySelector(".activity-glyph")?.textContent;
+            if (glyph === undefined) w.__blankFrames++;
+            else if (glyph !== w.__lastGlyph) {
+              if (w.__lastGlyph !== "") w.__glyphFlips++;
+              w.__lastGlyph = glyph;
+            }
+          }
+        }, 16);
+      });
+
+      await page2.locator("textarea").fill("run something dangerous");
+      await page2.keyboard.press("Enter");
+      await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
+      // The permission bar holds the busy state open, so this waits for real
+      // movement rather than betting that a timed mock reply stays alive long
+      // enough for two browser round-trips.
+      await page2.waitForFunction(
+        () => (window as unknown as BusyWatch).__glyphFlips >= 3,
+        undefined,
+        { timeout: 5_000 },
+      );
+
+      // Scroll and snapshot in one page task while the latch is still held.
+      // The elapsed text and viewport placement cannot disappear between two
+      // Playwright calls now.
+      const held = await page2.evaluate(() => {
+        document.querySelector(".render-zone")!.scrollTop = 0;
+        const line = document.querySelector(".activity-line");
+        const r = line?.getBoundingClientRect();
+        return {
+          text: line?.textContent ?? "",
+          visible: Boolean(r && r.height > 0 && r.top >= 0 && r.bottom <= window.innerHeight),
+        };
+      });
+      assert.match(held.text, /\(\d+s\)/, "no elapsed counter in the activity line");
+      assert.ok(held.visible, "indicator off screen while the transcript is scrolled up");
+
+      await page2.locator(".perm-deny").click();
+      await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+        timeout: 15_000,
+      });
+      await page2.waitForSelector(".activity-line", { state: "detached", timeout: 5_000 });
+      const frames = await page2.evaluate(() => {
+        const w = window as unknown as BusyWatch;
+        window.clearInterval(w.__watch);
+        return { busy: w.__busyFrames, blank: w.__blankFrames, flips: w.__glyphFlips };
+      });
+      assert.ok(frames.busy > 0, "the sampler never saw the turn in flight");
+      assert.equal(
+        frames.blank,
+        0,
+        `${frames.blank} frame(s) had a turn in flight with no activity line painted`,
+      );
+      assert.ok(frames.flips >= 3, `the glyph moved only ${frames.flips} time(s) while held busy`);
+      assert.equal(await page2.locator(".activity-line").count(), 0);
+    } finally {
+      await page2.close();
+    }
+  } finally {
+    await d2.stop();
+  }
 });
 
 // In-page globals for the queued-follow-up sampler below.

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -8,6 +8,7 @@ import { SocketClient } from "../ws";
 import { tildify } from "../tildify";
 import { useArmedConfirm } from "../use-armed-confirm";
 import { paintTabStatus } from "../tab-status";
+import { createFolderPickerRequests } from "../folder-picker-requests";
 
 // 4.6 Mission control, grown into the Phase M cockpit: every live session in
 // the registry with name, cwd, live activity, pending permission, and usage —
@@ -89,6 +90,7 @@ export function FleetView() {
   const [daemon, setDaemon] = useState<{
     cwd?: string;
     home?: string;
+    folderPicker?: boolean;
     // The agents hello's relay info (protocol.ts) — RelayInfo mirrors its
     // shape, `ws` included (static-origin serving).
     relay?: RelayInfo;
@@ -125,6 +127,9 @@ export function FleetView() {
     s.setHello(() => ({ type: "watch_sessions" }));
     return s;
   });
+  const [folderPicker] = useState(() =>
+    createFolderPickerRequests((msg) => socket.sendIfOpen(msg)),
+  );
 
   // The socket's message handler lives for the socket's life; it reads the
   // picker's openness through this ref so error ROUTING follows the live
@@ -133,6 +138,7 @@ export function FleetView() {
 
   useEffect(() => {
     const offMsg = socket.onMessage((m) => {
+      if (folderPicker.handle(m)) return;
       if (m.type === "sessions") {
         setSessions(m.sessions);
         // Answered ids leave the set once the server's queue no longer
@@ -146,7 +152,7 @@ export function FleetView() {
         });
       } else if (m.type === "agents") {
         setAgents(m.agents);
-        setDaemon({ cwd: m.cwd, home: m.home, relay: m.relay });
+        setDaemon({ cwd: m.cwd, home: m.home, folderPicker: m.folderPicker, relay: m.relay });
       } else if (m.type === "session_created") {
         // The create issued from the onboarding card below: enter the session.
         location.assign(`/s/${m.sessionId}`);
@@ -158,14 +164,18 @@ export function FleetView() {
       }
     });
     const offOpen = socket.onOpen(() => setConnected(true));
-    const offClose = socket.onClose(() => setConnected(false));
+    const offClose = socket.onClose(() => {
+      folderPicker.disconnect();
+      setConnected(false);
+    });
     return () => {
       offMsg();
       offOpen();
       offClose();
+      folderPicker.disconnect();
       socket.close();
     };
-  }, [socket]);
+  }, [socket, folderPicker]);
 
   // Ago labels are honest at 30s; the second-resolution elapsed readout wants
   // a 1s tick — but only while something is actually active, so an idle
@@ -194,6 +204,10 @@ export function FleetView() {
   // fresh arrow each render would restart the 3s timer instead of letting
   // it fire.
   const refreshAgents = useCallback(() => socket.send({ type: "refresh_agents" }), [socket]);
+  const browseFolder = useCallback(
+    (cwd?: string) => folderPicker.request(cwd),
+    [folderPicker],
+  );
 
   const commitRename = (id: string, name: string) => {
     setRenaming(null);
@@ -223,6 +237,7 @@ export function FleetView() {
           agents={agents}
           defaultCwd={tildify(daemon.cwd, daemon.home)}
           error={onbError}
+          onBrowse={daemon.folderPicker ? browseFolder : undefined}
           onPick={(agent, cwd, backend) => {
             setOnbError(null);
             socket.send({ type: "create", agent, cwd, ...(backend ? { backend } : {}) });

--- a/web/src/components/Onboarding.tsx
+++ b/web/src/components/Onboarding.tsx
@@ -197,6 +197,7 @@ export function Onboarding({
   defaultCwd,
   error,
   onPick,
+  onBrowse,
   onRefresh,
   onDismiss,
 }: {
@@ -204,6 +205,9 @@ export function Onboarding({
   defaultCwd?: string;
   error?: string | null;
   onPick: (agent: AgentName, cwd?: string, backend?: BackendChoice) => void;
+  // Present only when this LOCAL daemon advertised a host-native picker.
+  // Cancel resolves undefined; errors reject and stay inside this card.
+  onBrowse?: (cwd?: string) => Promise<string | undefined>;
   // Ask the daemon to re-probe local servers and re-send the hello (N.3);
   // called on a slow poll while the card is open.
   onRefresh?: () => void;
@@ -214,6 +218,8 @@ export function Onboarding({
   onDismiss?: () => void;
 }) {
   const [cwd, setCwd] = useState("");
+  const [browsing, setBrowsing] = useState(false);
+  const [browseError, setBrowseError] = useState<string | null>(null);
   // Which agent's backend menu is open (the second step), if any.
   const [picking, setPicking] = useState<AgentName | null>(null);
   // Which discovered server's model catalog is open (the third step) — its
@@ -246,6 +252,20 @@ export function Onboarding({
   const pickingRow = picking ? agents?.find((a) => a.agent === picking) : undefined;
   const pick = (agent: AgentName, backend?: BackendChoice) =>
     onPick(agent, cwd.trim() || undefined, backend);
+  const browse = async () => {
+    if (!onBrowse || browsing) return;
+    setBrowseError(null);
+    setBrowsing(true);
+    try {
+      const selected = await onBrowse(cwd.trim() || undefined);
+      if (selected) setCwd(selected);
+    } catch (err) {
+      setBrowseError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBrowsing(false);
+    }
+  };
+  const shownError = browseError ?? error;
 
   return (
     // Esc/backdrop walk back the same steps (stepBack above), so the modal's
@@ -266,16 +286,36 @@ export function Onboarding({
       <label className="onb-cwd-label" htmlFor="onb-cwd">
         working directory
       </label>
-      <input
-        id="onb-cwd"
-        className="onb-cwd"
-        type="text"
-        value={cwd}
-        spellCheck={false}
-        placeholder={defaultCwd ?? "~/path/to/project"}
-        onChange={(e) => setCwd(e.target.value)}
-      />
-      {error && <div className="onb-error">{error}</div>}
+      <div className="onb-cwd-row">
+        <input
+          id="onb-cwd"
+          className="onb-cwd"
+          type="text"
+          value={cwd}
+          spellCheck={false}
+          placeholder={defaultCwd ?? "~/path/to/project"}
+          aria-describedby={shownError ? "onb-cwd-error" : undefined}
+          onChange={(e) => {
+            setCwd(e.target.value);
+            setBrowseError(null);
+          }}
+        />
+        {onBrowse && (
+          <button
+            type="button"
+            className="onb-cwd-browse"
+            disabled={browsing}
+            onClick={() => void browse()}
+          >
+            {browsing ? "choosing…" : "browse…"}
+          </button>
+        )}
+      </div>
+      {shownError && (
+        <div className="onb-error" id="onb-cwd-error">
+          {shownError}
+        </div>
+      )}
       {pickingRow ? (
         <BackendMenu
           row={pickingRow}

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -88,6 +88,7 @@ export function Shell() {
     agents: AgentInfo[] | null;
     cwd?: string;
     home?: string;
+    folderPicker?: boolean;
     relay?: { url: string; code: string; ws?: string };
     version?: string;
   }>({ agents: null });
@@ -254,6 +255,7 @@ export function Shell() {
             agents: m.agents,
             cwd: m.cwd,
             home: m.home,
+            folderPicker: m.folderPicker,
             relay: m.relay,
             version: m.version,
           });
@@ -390,6 +392,7 @@ export function Shell() {
           agents={daemonInfo.agents}
           defaultCwd={tildify(daemonInfo.cwd, daemonInfo.home)}
           error={notices.onboarding}
+          onBrowse={daemonInfo.folderPicker ? bus.pickFolder : undefined}
           onPick={(agent, cwd, backend) => {
             setNotices((n) => ({ ...n, onboarding: null }));
             bus.createSession(agent, cwd, backend);

--- a/web/src/folder-picker-requests.test.ts
+++ b/web/src/folder-picker-requests.test.ts
@@ -1,0 +1,48 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { ClientMsg } from "@protocol";
+import { createFolderPickerRequests } from "./folder-picker-requests";
+
+test("folder-picker requests correlate success, cancel, and errors", async () => {
+  const sent: ClientMsg[] = [];
+  let n = 0;
+  const requests = createFolderPickerRequests(
+    (msg) => {
+      sent.push(msg);
+    },
+    () => `fp-${++n}`,
+  );
+  const success = requests.request("~/project");
+  const cancel = requests.request();
+  const failure = requests.request("/bad");
+  assert.deepEqual(sent, [
+    { type: "pick_folder", id: "fp-1", cwd: "~/project" },
+    { type: "pick_folder", id: "fp-2" },
+    { type: "pick_folder", id: "fp-3", cwd: "/bad" },
+  ]);
+  assert.equal(requests.handle({ type: "folder_picked", id: "fp-1", path: "/chosen" }), true);
+  assert.equal(requests.handle({ type: "folder_picked", id: "fp-2", canceled: true }), true);
+  assert.equal(requests.handle({ type: "folder_picked", id: "fp-3", error: "could not open" }), true);
+  assert.equal(await success, "/chosen");
+  assert.equal(await cancel, undefined);
+  await assert.rejects(failure, /could not open/);
+  assert.equal(requests.handle({ type: "pong" }), false);
+});
+
+test("a disconnected click rejects immediately instead of becoming a replayed dialog", async () => {
+  const requests = createFolderPickerRequests(
+    () => false,
+    () => "fp-offline",
+  );
+  await assert.rejects(requests.request(), /connection is not ready/);
+});
+
+test("disconnect rejects every picker still waiting", async () => {
+  const requests = createFolderPickerRequests(
+    () => undefined,
+    () => "fp-waiting",
+  );
+  const waiting = requests.request();
+  requests.disconnect();
+  await assert.rejects(waiting, /connection closed/);
+});

--- a/web/src/folder-picker-requests.ts
+++ b/web/src/folder-picker-requests.ts
@@ -1,0 +1,52 @@
+import type { ClientMsg, WireMsg } from "@protocol";
+
+type FolderPicked = Extract<WireMsg, { type: "folder_picked" }>;
+type PickFolder = Extract<ClientMsg, { type: "pick_folder" }>;
+
+/** Correlated client half of N2's folder-picker request/reply. Shared by the
+ *  session shell and mission control: both surfaces own an Onboarding card. */
+export function createFolderPickerRequests(
+  send: (msg: PickFolder) => void | boolean,
+  mintId: () => string = () => `fp-${Math.random().toString(36).slice(2, 10)}`,
+) {
+  const pending = new Map<
+    string,
+    { resolve: (path: string | undefined) => void; reject: (err: Error) => void }
+  >();
+
+  return {
+    request(cwd?: string): Promise<string | undefined> {
+      const id = mintId();
+      return new Promise((resolve, reject) => {
+        pending.set(id, { resolve, reject });
+        try {
+          if (send({ type: "pick_folder", id, ...(cwd ? { cwd } : {}) }) === false) {
+            throw new Error(
+              "The connection is not ready. Try Browse again once Mirafold is connected.",
+            );
+          }
+        } catch (err) {
+          pending.delete(id);
+          reject(err instanceof Error ? err : new Error(String(err)));
+        }
+      });
+    },
+    /** True means this frame belonged to the picker and should not fan out. */
+    handle(msg: WireMsg): boolean {
+      if (msg.type !== "folder_picked") return false;
+      const reply = msg as FolderPicked;
+      const waiting = pending.get(reply.id);
+      if (!waiting) return true;
+      pending.delete(reply.id);
+      if (reply.error) waiting.reject(new Error(reply.error));
+      else waiting.resolve(reply.path);
+      return true;
+    },
+    disconnect(): void {
+      for (const waiting of pending.values()) {
+        waiting.reject(new Error("The connection closed while the folder picker was open."));
+      }
+      pending.clear();
+    },
+  };
+}

--- a/web/src/session-bus.ts
+++ b/web/src/session-bus.ts
@@ -1,5 +1,6 @@
 import type { Action, AgentName, BackendChoice, WireMsg } from "@protocol";
 import { SocketClient } from "./ws";
+import { createFolderPickerRequests } from "./folder-picker-requests";
 
 /**
  * What the output zone consumes: the wire protocol plus one local control
@@ -23,6 +24,9 @@ export interface SessionBus {
   createSession(agent: AgentName, cwd?: string, backend?: BackendChoice): void;
   /** Ask the daemon to re-probe local servers and re-send the agents hello (N.3). */
   refreshAgents(): void;
+  /** Open the host's native folder dialog. A cancel resolves undefined; a
+   *  daemon/platform failure rejects with the shell-owned explanation. */
+  pickFolder(cwd?: string): Promise<string | undefined>;
   sendPrompt(text: string): void;
   /** Returns the minted bang id so the issuing viewport can correlate. */
   sendBang(command: string): string;
@@ -47,6 +51,7 @@ export function createSessionBus(): SessionBus {
   const socket = new SocketClient();
   const listeners = new Set<(m: ZoneMsg) => void>();
   const connListeners = new Set<(c: boolean, refusal?: string) => void>();
+  const folderPicker = createFolderPickerRequests((msg) => socket.sendIfOpen(msg));
   // The URL carries the session identity; no id yet means "create one".
   let sessionId = location.pathname.match(/^\/s\/([\w-]+)/)?.[1] ?? null;
   // Attach to a known session; otherwise send nothing and wait at onboarding
@@ -61,9 +66,11 @@ export function createSessionBus(): SessionBus {
     for (const c of connListeners) c(true);
   });
   socket.onClose((refusal) => {
+    folderPicker.disconnect();
     for (const c of connListeners) c(false, refusal);
   });
   socket.onMessage((m) => {
+    if (folderPicker.handle(m)) return;
     if (m.type === "session_created") {
       sessionId = m.sessionId;
       history.replaceState(null, "", `/s/${m.sessionId}`);
@@ -107,6 +114,9 @@ export function createSessionBus(): SessionBus {
     },
     refreshAgents() {
       socket.send({ type: "refresh_agents" });
+    },
+    pickFolder(cwd?: string): Promise<string | undefined> {
+      return folderPicker.request(cwd);
     },
     sendPrompt(text: string) {
       // No local echo — the server broadcasts the user_prompt to every

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -3038,9 +3038,17 @@ body {
   color: var(--fg-dim);
 }
 
-.onb-cwd {
-  width: 100%;
+.onb-cwd-row {
+  display: flex;
+  align-items: stretch;
+  gap: 8px;
   margin-bottom: calc(10px + var(--onb-squeeze) * 0.25); /* 10→14px */
+}
+
+.onb-cwd {
+  flex: 1 1 auto;
+  min-width: 0;
+  width: auto;
   padding: calc(8px + var(--onb-squeeze) * 0.1875) 13px; /* 8→11px */
   background: var(--bg-inset);
   border: 1px solid var(--border-mid);
@@ -3057,6 +3065,29 @@ body {
 
 .onb-cwd::placeholder {
   color: var(--fg-faint);
+}
+
+.onb-cwd-browse {
+  flex: none;
+  padding: 0 13px;
+  border: 1px solid var(--border-mid);
+  border-radius: 8px;
+  background: var(--surface-2);
+  color: var(--fg-strong);
+  cursor: pointer;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  font-size: 13px;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+
+.onb-cwd-browse:hover:not(:disabled) {
+  border-color: var(--border-hover);
+  background: var(--surface-hover);
+}
+
+.onb-cwd-browse:disabled {
+  cursor: wait;
+  color: var(--fg-dim);
 }
 
 /* A rejected working dir (no such directory) — fix the path and retry. */

--- a/web/src/use-follow-tail.test.ts
+++ b/web/src/use-follow-tail.test.ts
@@ -1,0 +1,27 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { touchIntentReachesBottom, wheelIntentReachesBottom } from "./use-follow-tail";
+
+const box = {
+  scrollHeight: 1_000,
+  scrollTop: 776,
+  clientHeight: 100,
+}; // 124px from the tail; the shared slack is 24px.
+
+test("downward wheel intent arms against the pre-scroll bottom boundary", () => {
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: 99 }), false);
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: 100 }), true);
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: -1_000 }), false);
+});
+
+test("wheel line/page modes are converted before the reach decision", () => {
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: 6, deltaMode: 1 }), false);
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: 7, deltaMode: 1 }), true);
+  assert.equal(wheelIntentReachesBottom(box, { deltaY: 1, deltaMode: 2 }), true);
+});
+
+test("an upward finger gesture arms only when it reaches the tail", () => {
+  assert.equal(touchIntentReachesBottom(box, 300, 201), false);
+  assert.equal(touchIntentReachesBottom(box, 300, 200), true);
+  assert.equal(touchIntentReachesBottom(box, 200, 300), false);
+});

--- a/web/src/use-follow-tail.ts
+++ b/web/src/use-follow-tail.ts
@@ -37,6 +37,39 @@ import { useRef } from "react";
 // pixel that subpixel scroll heights leave behind. A judgment call, not a
 // measurement.
 const BOTTOM_SLACK_PX = 24;
+const WHEEL_LINE_PX = 16;
+
+type ScrollGeometry = Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">;
+type WheelIntent = { deltaY: number; deltaMode?: number };
+
+const bottomGap = (el: ScrollGeometry) => el.scrollHeight - el.scrollTop - el.clientHeight;
+
+/**
+ * Decide from the geometry that existed when the user steered, before the
+ * browser dispatches a later scroll event and before streamed output can move
+ * the bottom. Exported so the race's exact boundary is pinned without a DOM
+ * test harness.
+ */
+export function wheelIntentReachesBottom(el: ScrollGeometry, e: WheelIntent): boolean {
+  if (e.deltaY <= 0) return false;
+  const deltaPx =
+    e.deltaMode === 1
+      ? e.deltaY * WHEEL_LINE_PX
+      : e.deltaMode === 2
+        ? e.deltaY * el.clientHeight
+        : e.deltaY;
+  return bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
+}
+
+/** Finger moving up scrolls the transcript toward its tail. */
+export function touchIntentReachesBottom(
+  el: ScrollGeometry,
+  previousY: number,
+  nextY: number,
+): boolean {
+  const deltaPx = previousY - nextY;
+  return deltaPx > 0 && bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
+}
 
 export function useFollowTail() {
   const scrollerRef = useRef<HTMLDivElement>(null);
@@ -44,8 +77,7 @@ export function useFollowTail() {
   const lastTop = useRef(0);
   const touchY = useRef<number | null>(null);
 
-  const atBottom = (el: HTMLElement) =>
-    el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_SLACK_PX;
+  const atBottom = (el: HTMLElement) => bottomGap(el) <= BOTTOM_SLACK_PX;
 
   const onScroll = () => {
     const el = scrollerRef.current;
@@ -56,11 +88,16 @@ export function useFollowTail() {
     lastTop.current = el.scrollTop;
   };
 
-  // Steering UP detaches. Steering down does not: at the bottom it produces no
-  // scroll event at all, so nothing would re-arm us and output would stop
-  // following for a reader who never left.
-  const onWheel = (e: { deltaY: number }) => {
-    if (e.deltaY < 0) following.current = false;
+  // Steering UP detaches. A gesture that will reach the current bottom arms
+  // synchronously: waiting for onScroll is racy because streamed paint can
+  // move the bottom by more than the slack before that event runs.
+  const onWheel = (e: WheelIntent) => {
+    if (e.deltaY < 0) {
+      following.current = false;
+      return;
+    }
+    const el = scrollerRef.current;
+    if (el && wheelIntentReachesBottom(el, e)) following.current = true;
   };
 
   const onTouchStart = (e: { touches: { clientY: number }[] | ArrayLike<{ clientY: number }> }) => {
@@ -79,7 +116,14 @@ export function useFollowTail() {
   const onTouchMove = (e: { touches: ArrayLike<{ clientY: number }> }) => {
     const y = e.touches[0]?.clientY;
     if (y === undefined) return;
-    if (touchY.current !== null && y > touchY.current) following.current = false;
+    const previousY = touchY.current;
+    if (previousY !== null && y > previousY) following.current = false;
+    else {
+      const el = scrollerRef.current;
+      if (el && previousY !== null && touchIntentReachesBottom(el, previousY, y)) {
+        following.current = true;
+      }
+    }
     touchY.current = y;
   };
 

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -171,6 +171,23 @@ test("a null hello sends nothing but still flushes the queue (P.4 onboarding)", 
   );
 });
 
+test("sendIfOpen never replays a user-gesture side effect after reconnect", (t) => {
+  const { client, sock } = setup(t);
+  assert.equal(client.sendIfOpen({ type: "pick_folder", id: "fp-before-open" }), false);
+
+  sock().open();
+  assert.deepEqual(sock().parsedSent(), [], "the rejected click was not queued");
+  assert.equal(client.sendIfOpen({ type: "pick_folder", id: "fp-open" }), true);
+  assert.deepEqual(sock().parsedSent(), [{ type: "pick_folder", id: "fp-open" }]);
+
+  sock().close();
+  sock().finishClose();
+  assert.equal(client.sendIfOpen({ type: "pick_folder", id: "fp-disconnected" }), false);
+  t.mock.timers.tick(BACKOFF_MIN_MS);
+  sock().open();
+  assert.deepEqual(sock().parsedSent(), [], "the disconnected click was not replayed");
+});
+
 test("viewportRefusalReason maps relay refusal codes; ordinary drops are undefined", () => {
   assert.match(viewportRefusalReason(4003)!, /Desktop not reachable/); // CLOSE_BAD_CODE
   assert.match(viewportRefusalReason(4004)!, /capacity/); // CLOSE_OVERLOADED

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -407,6 +407,15 @@ export class SocketClient {
     else this.pending.push(msg);
   }
 
+  /** Send a user-gesture side effect only while the channel is usable. Unlike
+   *  send(), this never queues a click to run after a later reconnect. The
+   *  native folder dialog is local-only, so transmit is synchronous here. */
+  sendIfOpen(msg: ClientMsg): boolean {
+    if (!this.ready || this.ws?.readyState !== WebSocket.OPEN) return false;
+    this.transmit(this.stamp(msg));
+    return true;
+  }
+
   close() {
     this.closedByUs = true;
     // Stop being the error-forwarding socket: reports after close would only


### PR DESCRIPTION
## Summary
- add a compact `browse…` control beside the editable startup working-directory field
- open the host operating system folder dialog through the authenticated local daemon on macOS, Windows, and Linux
- keep manual paths as the fallback and make relay viewports unable to open host UI
- eliminate the activity, Mermaid, and follow-tail races that were intermittently blocking this PR

## Design and security
- use additive `pick_folder` / `folder_picked` wire messages with per-viewport correlation and no broadcast or replay
- invoke fixed native helpers without a shell, validate the selected directory, cap output, prevent stacked dialogs, and abort on disconnect
- pass only an allowlisted desktop-session environment to the native helper; provider keys, relay credentials, custom provider variables, and loader hooks do not cross the process boundary
- add no dependency: macOS and Windows provide their dialogs; Linux uses Zenity then KDialog

## Browser-gate fixes
- activity proof owns its daemon/page/session and uses a permission request as a deterministic busy-state latch, so `turn_end` cannot remove a transient locator between assertions
- Mermaid proof owns its session, avoiding inherited one-follow-up prompt-gate state while retaining the production lazy chunk, sandbox, CSP, postMessage, SVG, and parse-error paths
- follow-tail now re-arms synchronously when downward wheel/touch intent reaches the current bottom, using pre-input geometry before streamed paint can outrun the later `scroll` event
- the controlled follow-tail browser scenario uses real wheel input; pure tests pin pixel, line, page, direction, and exact boundary behavior

## Verification
- `yarn typecheck` — green
- `yarn test` — 554/554 green
- focused native picker, wire, request lifecycle, and socket tests — 51/51 green
- full browser picker path — green, including phone-width containment, axe, credential isolation, chosen-path fill, and session creation in that path
- focused unchanged repetition — activity 6/6, Mermaid 5/5, follow-tail 6/6, intent boundaries 3/3
- two consecutive unchanged full Tier-3 runs — 78/78 and 78/78
- implementation head `a091ba1` — DCO, Cloudflare Pages, Tier 1, and combined Tier 2 + Tier 3 protected checks green
- final closeout head `e759091` — DCO, Cloudflare Pages, Tier 1, and combined Tier 2 + Tier 3 protected checks green
- `yarn audit --groups dependencies` — 0 vulnerabilities across 138 packages
- `npm pack --dry-run --cache /tmp/mirafold-npm-pack-cache` — green, 1.4 MB / 17 files
