### PR TITLE
fix(startup): preserve folder leaf and close trust gaps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# Mirafold imports only its documented data settings from this file. Executable
+# overrides, PATH/shell controls, and runtime loader hooks must be exported in
+# the parent terminal; a checkout cannot grant those authorities to itself.
+
 # Which terminal agent Mirafold re-skins. Default: claude-code.
 # (codex, gemini-cli — Phase P.2+.) An agent with no credentials below runs
 # the API-free mock stand-in instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,16 @@ off with a dated status note. **BUSINESS.md** — why and in what sequence
 - No `ANTHROPIC_API_KEY` in `.env` → `MockSession`. Build and verify every
   UI capability against the mock first; live verification (real key) last.
 
+## Git workflow
+
+- Normal work branches (`feature/*`, `fix/*`, `refactor/*`) start from
+  `next` and open pull requests back into `next`.
+- A feature pull request stays open even after its checks pass. Complete the
+  requested review and refactor work there, then ask Kyle explicitly whether
+  to merge when it appears ready. Opening the pull request or getting green
+  checks is not merge approval; merge only after Kyle says yes.
+- `docs/RELEASING.md` is the canonical branch and release runbook.
+
 ## Non-negotiables
 
 - **Wire protocol** (`server/protocol.ts`): later work ADDS message types,

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -6911,7 +6911,8 @@ Linux dialog helper is installed, the existing editable path remains available.
     receive a credential-free system path plus a neutral home-directory cwd.
     Filter relative, project-contained, symlink-back-into-project, and every
     `node_modules/.bin` candidate from Codex/Gemini executable discovery while
-    preserving explicit operator overrides and legitimate global installs.
+    preserving parent-process operator overrides and legitimate global
+    installs.
   - Native-dialog abort/output overflow must settle only after `close`, with a
     short graceful request followed by forced termination. Replace the tests
     that depended on PATH substitution with injected process seams and add
@@ -6921,13 +6922,66 @@ Linux dialog helper is installed, the existing editable path remains available.
     only fixed operating-system locations and inherit a fixed system path,
     credential-scrubbed desktop state, and the user's home as cwd. Shared agent
     lookup rejects relative, project-contained, npm-bin, and symlink-back-into-
-    project candidates while retaining explicit operator overrides. Abort and
-    output overflow request process-group termination, escalate after 250 ms,
-    and reject only after the child closes. Adversarial lookup, environment,
-    cwd, and force-kill regressions replaced the unsafe PATH-substitution seams;
+    project candidates while retaining parent-process operator overrides.
+    Abort and output overflow request process-group termination, escalate after
+    250 ms, and reject only after the child closes. Adversarial lookup,
+    environment, cwd, and force-kill regressions replaced the unsafe
+    PATH-substitution seams;
     README and SECURITY record the `npx` boundary. Local verification passed:
     Tier 1 561/561, Tier 2 143/143, Tier 3 82/82, typecheck, build, 19-file
     package dry-run, secret scan, and production audit (0 vulnerabilities).
+
+- [x] **N2.5 — Keep the chosen folder leaf visible in long paths**
+  - Goal: when the startup working-directory field cannot fit the whole path,
+    show its rightmost leaf folder instead of the filesystem root.
+  - Build: scroll the unfocused controlled input to its logical end after a
+    programmatic path replacement and whenever editing finishes; do not fight
+    the user's caret while they are editing.
+  - Files: `web/src/components/Onboarding.tsx`, `server/testing/app.e2e.ts`.
+  - Done when: a real-browser narrow-width regression proves that the complete
+    value remains intact, the leaf is visible after blur/programmatic state
+    updates, and refocusing still permits ordinary editing.
+  - **Outcome (2026-08-08):** the controlled startup input now moves its
+    viewport to the logical path end after a native selection or other
+    unfocused value replacement, and again when editing ends. While the field
+    has focus, its caret remains authoritative, so the root and middle remain
+    normally editable. A narrow-width browser regression synthesizes the
+    existing correlated folder-pick reply, proves the overflowing input is at
+    its maximum horizontal offset without changing the value, edits at the
+    root, proves blur restores the leaf, and creates the session at the full
+    chosen path. Tier 1 passed 561/561; the focused Tier-3 browser regression
+    passed 1/1; typecheck and the production build passed.
+
+- [x] **N2.6 — Close the post-audit environment and Windows-opener execution
+  paths**
+  - The follow-up audit found that N2.4's executable filter could still be
+    bypassed through the launch checkout's `.env`: `process.loadEnvFile()`
+    copied `MIRAFOLD_CODEX_BIN` and runtime loader controls into the parent
+    environment, after which agent resolution treated them as operator intent.
+    It also found that an unencoded `MIRAFOLD_TOKEN` reached Windows
+    `cmd.exe /c start`, where shell metacharacters became commands.
+  - Replace ambient `.env` mutation with Node's dotenv parser plus an explicit
+    allowlist of supported Mirafold data settings. Load it before dependency
+    modules initialize, keep parent-process values authoritative, and ignore
+    executable overrides, path/shell controls, runtime loader hooks, and
+    unrelated repository variables. Explicit binary overrides exported by the
+    operator continue to work.
+  - Build the startup URL through `URLSearchParams`, then open it on Windows by
+    passing one argument directly to fixed-system `explorer.exe`; no command
+    interpreter remains in the browser-opening path. Pin the hostile `.env`,
+    token round-trip, and Windows metacharacter cases. Correct README, SECURITY,
+    `.env.example`, and the runtime `npx` warning: an installed command prevents
+    package/executable shadowing but does not make a checkout's active `.env`
+    configuration trustworthy.
+  - **Outcome (2026-08-08):** repository `.env` files can configure only the
+    supported data surface and can no longer select agent executables or Node
+    loaders; parent-process overrides retain precedence. Tokens containing
+    command metacharacters are percent-encoded and still authenticate after URL
+    decoding, while Windows sends the resulting URL straight to
+    `%SystemRoot%\\explorer.exe`. Local verification passed Tier 1 563/563,
+    Tier 2 143/143, Tier 3 82/82, typecheck, production build, the 19-file
+    package dry-run, secret/diff scans, and the production dependency audit
+    with 0 vulnerabilities.
 
 **Outcome:** both startup routes now offer a compact native `browse…` control
 while preserving the editable absolute-path field. Mirafold opens the host
@@ -6937,12 +6991,16 @@ disconnect, and gives the child a strict desktop/session allowlist rather than
 the daemon's credential-bearing environment. The correlated response is sent
 only to the requesting local viewport and clicks are never queued across a
 reconnect; relay, unsupported-platform, and helper-missing cases retain manual
-entry without claiming a picker exists. No package was added. Focused tests
-(51/51), Tier 1 (551/551), typecheck, package dry-run, production audit (0
-vulnerabilities), the real-daemon/real-browser picker proof, phone no-overflow,
-axe, and protected GitHub Tier 1/2/3 checks passed. The direct local full Tier 2
-and Tier 3 runs also exposed four unchanged baseline failures, each reproduced
-from an isolated `origin/next`; PR #22 records those controls explicitly.
+entry without claiming a picker exists. Long paths keep their rightmost leaf
+visible whenever the field is not actively being edited. No package was added.
+The original N2 delivery passed focused tests (51/51), Tier 1 (551/551),
+typecheck, package dry-run, production audit (0 vulnerabilities), the
+real-daemon/real-browser picker proof, phone no-overflow, axe, and protected
+GitHub Tier 1/2/3 checks. The direct local full Tier 2 and Tier 3 runs also
+exposed four unchanged baseline failures, each reproduced from an isolated
+`origin/next`; PR #22 records those controls explicitly. N2.5's separate
+follow-up verification is recorded directly above. N2.6's post-audit closure
+is likewise recorded above with the complete 563/143/82 proof.
 
 ## Moved 2026-08-08 (stable Tier-3 browser gates — full body)
 

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -6901,6 +6901,34 @@ Linux dialog helper is installed, the existing editable path remains available.
     contract names the graphical path and its manual fallback. Land via a
     DCO-signed `feature/*` PR into `next`; `main` and release state stay put.
 
+- [x] **N2.4 — Post-refactor executable-trust remediation**
+  - The 2026-08-08 defensive audit proved that npm exec always exposes local
+    package binaries in the child `PATH`. The published launcher resolved its
+    browser opener from that path, and the new Linux picker did the same for
+    Zenity/KDialog; a hostile checkout could therefore run code as the user.
+  - Remove ambient `PATH` from operating-system chrome entirely. Browser
+    openers and native-dialog helpers resolve only fixed system locations and
+    receive a credential-free system path plus a neutral home-directory cwd.
+    Filter relative, project-contained, symlink-back-into-project, and every
+    `node_modules/.bin` candidate from Codex/Gemini executable discovery while
+    preserving explicit operator overrides and legitimate global installs.
+  - Native-dialog abort/output overflow must settle only after `close`, with a
+    short graceful request followed by forced termination. Replace the tests
+    that depended on PATH substitution with injected process seams and add
+    adversarial resolution/cleanup proofs. README and SECURITY must state that
+    plain `npx mirafold` is for already-trusted directories only.
+  - **Outcome (2026-08-08):** browser openers and native dialogs now resolve
+    only fixed operating-system locations and inherit a fixed system path,
+    credential-scrubbed desktop state, and the user's home as cwd. Shared agent
+    lookup rejects relative, project-contained, npm-bin, and symlink-back-into-
+    project candidates while retaining explicit operator overrides. Abort and
+    output overflow request process-group termination, escalate after 250 ms,
+    and reject only after the child closes. Adversarial lookup, environment,
+    cwd, and force-kill regressions replaced the unsafe PATH-substitution seams;
+    README and SECURITY record the `npx` boundary. Local verification passed:
+    Tier 1 561/561, Tier 2 143/143, Tier 3 82/82, typecheck, build, 19-file
+    package dry-run, secret scan, and production audit (0 vulnerabilities).
+
 **Outcome:** both startup routes now offer a compact native `browse…` control
 while preserving the editable absolute-path field. Mirafold opens the host
 dialog with fixed executable/argument arrays, validates the selected directory,

--- a/PLAN.md
+++ b/PLAN.md
@@ -2167,6 +2167,19 @@ was added. Protected Tier 1/2/3 checks, Cloudflare, and DCO passed on PR #22.
   Tier 1 561/561, Tier 2 143/143, Tier 3 82/82, typecheck, build, 19-file
   package dry-run, secret scan, and production audit (0 vulnerabilities).
   → PLAN-ARCHIVE.md.
+- [x] **N2.5 — Keep the chosen folder leaf visible in long paths** — done
+  2026-08-08; programmatic picks and blurred edits reveal the rightmost folder,
+  focused editing retains ordinary caret control, and the complete path still
+  creates the session. Local proof: Tier 1 561/561, focused Tier 3 1/1,
+  typecheck, and production build. → PLAN-ARCHIVE.md.
+- [x] **N2.6 — Close the post-audit environment and Windows-opener execution
+  paths** — done 2026-08-08; checkout `.env` loading is data-only and
+  provenance-aware, startup tokens are percent-encoded, Windows opens URLs
+  directly through fixed-system `explorer.exe`, and the trust guidance names
+  the remaining `.env` boundary honestly. Local proof: Tier 1 563/563, Tier 2
+  143/143, Tier 3 82/82, typecheck, production build, 19-file package dry-run,
+  secret/diff scans, and production audit (0 vulnerabilities). →
+  PLAN-ARCHIVE.md.
 
 ## Phase N3 — Stable Tier-3 browser gates (✅ COMPLETE 2026-08-08)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2159,6 +2159,14 @@ was added. Protected Tier 1/2/3 checks, Cloudflare, and DCO passed on PR #22.
   tests, real-daemon browser proof, accessibility/phone checks, typecheck,
   build/package, production audit, README, and protected CI complete.
   → PLAN-ARCHIVE.md.
+- [x] **N2.4 — Post-refactor executable-trust remediation** — done 2026-08-08;
+  browser and native-dialog identity now comes only from fixed system paths,
+  agent discovery rejects project/npm-controlled candidates, helper processes
+  use a neutral cwd/scrubbed environment and confirm exit after cancellation or
+  output overflow, and the `npx` trust boundary is explicit. Local proof:
+  Tier 1 561/561, Tier 2 143/143, Tier 3 82/82, typecheck, build, 19-file
+  package dry-run, secret scan, and production audit (0 vulnerabilities).
+  → PLAN-ARCHIVE.md.
 
 ## Phase N3 — Stable Tier-3 browser gates (✅ COMPLETE 2026-08-08)
 

--- a/README.md
+++ b/README.md
@@ -1127,16 +1127,26 @@ beta, so a Windows issue report is a gift, not an imposition.
 
 Like launching `claude`/`codex`/`gemini`: sessions default to the directory
 you ran it from, and a second `mirafold` in another project walks to the
-next port (3001, …) and runs independently. `npx mirafold` is the
-zero-install try path; `--no-open` skips the browser; `PORT` moves the base
-port. The daemon prints (and opens) a URL carrying a per-launch auth token
-(§3) — that token, held as a browser cookie, is what keeps another account on
-a shared machine off your socket. With `--no-open` or on a headless box, open
-the exact printed URL (it has the token); `MIRAFOLD_TOKEN=""` disables the token
-on a single-user machine. The package ships only the launcher + the two esbuild bundles + the
-built front end (14 files, ~324 KB tarball); agent credentials come from your
-environment exactly as in a terminal (`ANTHROPIC_API_KEY`, `codex login`,
-`GEMINI_API_KEY`) — none live in the package. **Native-module note:**
+next port (3001, …) and runs independently. `--no-open` skips the browser;
+`PORT` moves the base port. The daemon prints (and opens) a URL carrying a
+per-launch auth token (§3) — that token, held as a browser cookie, is what keeps
+another account on a shared machine off your socket. With `--no-open` or on a
+headless box, open the exact printed URL (it has the token);
+`MIRAFOLD_TOKEN=""` disables the token on a single-user machine.
+
+`npx mirafold` is a convenience only inside a project you already trust. npm
+adds that project's `node_modules/.bin` executables to the launched process and
+may select a project-local `mirafold` package before registry code; the official
+launcher prints this warning when it detects npm exec. Do not use `npx` as a
+way to inspect an unfamiliar checkout. Install Mirafold globally from a neutral
+directory first, then enter the project and run `mirafold`; Mirafold itself
+also refuses project/npm-bin candidates when resolving host chrome and agent
+CLIs.
+
+The package ships only the launcher + the two esbuild bundles + the built front
+end; agent credentials come from your environment exactly as in a terminal
+(`ANTHROPIC_API_KEY`, `codex login`, `GEMINI_API_KEY`) — none live in the
+package. **Native-module note:**
 the `!` PTY ships as `@lydell/node-pty` (swapped 2026-07-23) — prebuilt
 binaries for linux/macOS/Windows × x64/arm64 as platform
 `optionalDependencies`, no install scripts. Nothing compiles at install,
@@ -1363,7 +1373,12 @@ reveal the absolute host path an agent process needs as its `cwd`. The explicit
 click makes one authenticated, local WebSocket request to the daemon, which
 opens the native dialog without a shell and returns only the selected directory.
 The dialog child receives desktop-session variables but no model credentials,
-relay credentials, or custom provider environment variables. The trusted shell
+relay credentials, custom provider environment variables, or caller-supplied
+`PATH`. macOS and Windows helpers use their fixed operating-system locations;
+Linux searches only fixed system binary directories, never the project or an
+npm-injected `node_modules/.bin`. The helper starts from the user's home rather
+than the project, and cancellation/output overflow wait for confirmed exit with
+forced termination as the backstop. The trusted shell
 then shows the session's cwd at the prompt (`~/Projects/foo ❯`) and its leaf in
 the status bar. File mutation and bash ask for approval on the shell's
 permission bar exactly as in the terminal, honoring the allowlists in your

--- a/README.md
+++ b/README.md
@@ -1137,11 +1137,13 @@ headless box, open the exact printed URL (it has the token);
 `npx mirafold` is a convenience only inside a project you already trust. npm
 adds that project's `node_modules/.bin` executables to the launched process and
 may select a project-local `mirafold` package before registry code; the official
-launcher prints this warning when it detects npm exec. Do not use `npx` as a
-way to inspect an unfamiliar checkout. Install Mirafold globally from a neutral
-directory first, then enter the project and run `mirafold`; Mirafold itself
-also refuses project/npm-bin candidates when resolving host chrome and agent
-CLIs.
+launcher prints this warning when it detects npm exec. For an unfamiliar
+checkout, install Mirafold globally from a neutral directory first, then enter
+the project and run `mirafold`; Mirafold refuses project/npm-bin candidates
+when resolving host chrome and agent CLIs. That removes executable shadowing,
+not the need to inspect the checkout: review or temporarily rename its `.env`
+before first launch because supported settings can select endpoints, relay
+access, resource limits, and whether local socket authentication is enabled.
 
 The package ships only the launcher + the two esbuild bundles + the built front
 end; agent credentials come from your environment exactly as in a terminal
@@ -1215,11 +1217,15 @@ third-party app, so the picker shows it as `blocked` and points you at the API
 key (a Codex/ChatGPT subscription works locally, but not over the paid relay).
 Point an agent at a local endpoint (Ollama, a proxy — e.g. `ANTHROPIC_BASE_URL`)
 and it's BYO, no restriction. The one dated source of truth for the whole rule
-is `server/provider-policy.ts`. The env file is
-loaded with `process.loadEnvFile()` and is optional by design. Also settable
-there: `MIRAFOLD_AGENT` (the default agent offered at onboarding), the per-agent
-model overrides `DEFAULT_MODEL` / `CODEX_MODEL` / `GEMINI_MODEL` (unset →
-that agent's own default), `PORT`, the local-server discovery knobs
+is `server/provider-policy.ts`. The optional env file is parsed with Node's
+dotenv parser, then only documented Mirafold data settings are copied into the
+daemon environment; an existing parent-process value always wins. Executable
+overrides, `PATH`/shell controls, runtime loader hooks, and unrelated project
+variables are deliberately ignored there and must be exported by the operator
+before launch. Also settable in `.env`: `MIRAFOLD_AGENT` (the default agent
+offered at onboarding), the per-agent model overrides `DEFAULT_MODEL` /
+`CODEX_MODEL` / `GEMINI_MODEL` (unset → that agent's own default), `PORT`, the
+local-server discovery knobs
 `MIRAFOLD_LOCAL_ENDPOINTS` / `MIRAFOLD_LOCAL_DISCOVERY` (Phase N — the
 onboarding picker probes localhost's well-known runtime ports and offers a
 running Ollama/LM Studio/vLLM per session; see `docs/local-models.md`), and

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -48,14 +48,20 @@ things follow, and they are the whole list:
 - **Use the installed command for an unfamiliar checkout.** `npx`/`npm exec`
   deliberately put a project's local package executables in `PATH` and may
   choose a project-local `mirafold` package. `npx mirafold` is therefore only a
-  convenience for a directory you already trust, never a safe first look at
-  someone else's repository. Install globally from a neutral directory, then
-  enter the checkout and run `mirafold`. The official launcher additionally
-  ignores project/npm-bin candidates for its own host chrome and agent lookup.
+  convenience for a directory you already trust. Install globally from a
+  neutral directory before entering someone else's checkout; the official
+  launcher then ignores project/npm-bin candidates for its own host chrome and
+  agent lookup. This prevents executable shadowing, but does not make the
+  checkout trusted: inspect or temporarily rename its `.env` before first
+  launch because supported settings can still select endpoints, relay access,
+  resource limits, and authentication posture.
 - **Keys stay server-side.** Credentials come from the environment or a `.env`
-  in the launch directory and are never serialized to the browser. That `.env`
-  is the supported place for them; what matters is that the directory is one
-  you trust, per the point above.
+  in the launch directory and are never serialized to the browser. Mirafold
+  parses that file through an explicit allowlist of documented data settings;
+  parent-process values win, and executable overrides, `PATH`/shell controls,
+  runtime loader hooks, and arbitrary project variables are ignored. The file
+  remains active application configuration, so review it before launching an
+  unfamiliar checkout.
 
 ## Known trust decisions (disclosed, not bugs)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -45,6 +45,13 @@ things follow, and they are the whole list:
   browser is confined to the session's workspace, but the agent keeps its own
   tools behind the permission prompts. A secrets directory, a mounted share,
   or a production checkout is a poor first choice.
+- **Use the installed command for an unfamiliar checkout.** `npx`/`npm exec`
+  deliberately put a project's local package executables in `PATH` and may
+  choose a project-local `mirafold` package. `npx mirafold` is therefore only a
+  convenience for a directory you already trust, never a safe first look at
+  someone else's repository. Install globally from a neutral directory, then
+  enter the checkout and run `mirafold`. The official launcher additionally
+  ignores project/npm-bin candidates for its own host chrome and agent lookup.
 - **Keys stay server-side.** Credentials come from the environment or a `.env`
   in the launch directory and are never serialized to the browser. That `.env`
   is the supported place for them; what matters is that the directory is one

--- a/bin/browser-open.d.ts
+++ b/bin/browser-open.d.ts
@@ -1,0 +1,24 @@
+import type { ChildProcess } from "node:child_process";
+
+export type BrowserOpenCommand = { file: string; args: string[] };
+
+export function browserOpenCommand(
+  url: string,
+  platform?: NodeJS.Platform,
+  env?: NodeJS.ProcessEnv,
+  canRun?: (file: string) => boolean,
+): BrowserOpenCommand | undefined;
+
+export function browserOpenEnvironment(
+  source?: NodeJS.ProcessEnv,
+  platform?: NodeJS.Platform,
+): Record<string, string>;
+
+export function openBrowser(
+  url: string,
+  opts?: {
+    platform?: NodeJS.Platform;
+    env?: NodeJS.ProcessEnv;
+    command?: BrowserOpenCommand;
+  },
+): ChildProcess | undefined;

--- a/bin/browser-open.js
+++ b/bin/browser-open.js
@@ -90,8 +90,8 @@ export function browserOpenCommand(
   if (platform === "win32") {
     const root = windowsRoot(env);
     if (!root) return undefined;
-    const file = path.win32.join(root, "System32", "cmd.exe");
-    return canRun(file) ? { file, args: ["/d", "/c", "start", "", url] } : undefined;
+    const file = path.win32.join(root, "explorer.exe");
+    return canRun(file) ? { file, args: [url] } : undefined;
   }
   if (platform === "linux") {
     const file = LINUX_OPENERS.find(canRun);
@@ -118,7 +118,6 @@ export function browserOpenEnvironment(
     safe.PATH = root
       ? [path.win32.join(root, "System32"), root].join(path.win32.delimiter)
       : "";
-    if (root) safe.COMSPEC = path.win32.join(root, "System32", "cmd.exe");
   } else {
     safe.PATH = platform === "darwin" ? MAC_SYSTEM_PATH : LINUX_SYSTEM_PATH;
   }

--- a/bin/browser-open.js
+++ b/bin/browser-open.js
@@ -1,0 +1,145 @@
+// Browser opening is host chrome, not project code. Keep every executable in
+// this chain on an operating-system path and pass only desktop-session state.
+
+import { spawn } from "node:child_process";
+import { accessSync, constants, statSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const LINUX_OPENERS = [
+  "/usr/bin/xdg-open",
+  "/bin/xdg-open",
+  "/run/current-system/sw/bin/xdg-open",
+  "/usr/local/bin/xdg-open",
+];
+const LINUX_SYSTEM_PATH = [
+  "/usr/bin",
+  "/bin",
+  "/run/current-system/sw/bin",
+  "/usr/local/bin",
+  "/usr/sbin",
+  "/sbin",
+  "/snap/bin",
+].join(":");
+const MAC_SYSTEM_PATH = "/usr/bin:/bin:/usr/sbin:/sbin";
+const DESKTOP_ENV_KEYS = new Set([
+  "HOME",
+  "USER",
+  "USERNAME",
+  "LOGNAME",
+  "LANG",
+  "LANGUAGE",
+  "TMPDIR",
+  "TMP",
+  "TEMP",
+  "DISPLAY",
+  "WAYLAND_DISPLAY",
+  "XAUTHORITY",
+  "DBUS_SESSION_BUS_ADDRESS",
+  "XDG_RUNTIME_DIR",
+  "XDG_CURRENT_DESKTOP",
+  "XDG_SESSION_DESKTOP",
+  "XDG_SESSION_TYPE",
+  "XDG_DATA_DIRS",
+  "XDG_CONFIG_DIRS",
+  "XDG_CONFIG_HOME",
+  "DESKTOP_SESSION",
+  "KDE_FULL_SESSION",
+  "KDE_SESSION_VERSION",
+  "__CF_USER_TEXT_ENCODING",
+  "SYSTEMROOT",
+  "WINDIR",
+  "USERPROFILE",
+  "HOMEDRIVE",
+  "HOMEPATH",
+  "APPDATA",
+  "LOCALAPPDATA",
+  "PROGRAMDATA",
+  "SESSIONNAME",
+]);
+
+function envValue(source, name) {
+  return Object.entries(source).find(([key]) => key.toUpperCase() === name)?.[1];
+}
+
+function windowsRoot(env) {
+  const root = envValue(env, "SYSTEMROOT") ?? envValue(env, "WINDIR");
+  return root && path.win32.isAbsolute(root) ? root : undefined;
+}
+
+function runnable(file) {
+  try {
+    if (!statSync(file).isFile()) return false;
+    accessSync(file, process.platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve only fixed operating-system opener locations. PATH is not an input. */
+export function browserOpenCommand(
+  url,
+  platform = process.platform,
+  env = process.env,
+  canRun = runnable,
+) {
+  if (platform === "darwin") {
+    return canRun("/usr/bin/open") ? { file: "/usr/bin/open", args: [url] } : undefined;
+  }
+  if (platform === "win32") {
+    const root = windowsRoot(env);
+    if (!root) return undefined;
+    const file = path.win32.join(root, "System32", "cmd.exe");
+    return canRun(file) ? { file, args: ["/d", "/c", "start", "", url] } : undefined;
+  }
+  if (platform === "linux") {
+    const file = LINUX_OPENERS.find(canRun);
+    return file ? { file, args: [url] } : undefined;
+  }
+  return undefined;
+}
+
+/** Credentials, provider settings, BROWSER command overrides, and loader hooks
+ * have no business crossing into an opener or the browser it launches. */
+export function browserOpenEnvironment(
+  source = process.env,
+  platform = process.platform,
+) {
+  const safe = {};
+  for (const [key, value] of Object.entries(source)) {
+    const upper = key.toUpperCase();
+    if (value !== undefined && (DESKTOP_ENV_KEYS.has(upper) || upper.startsWith("LC_"))) {
+      safe[key] = value;
+    }
+  }
+  if (platform === "win32") {
+    const root = windowsRoot(source);
+    safe.PATH = root
+      ? [path.win32.join(root, "System32"), root].join(path.win32.delimiter)
+      : "";
+    if (root) safe.COMSPEC = path.win32.join(root, "System32", "cmd.exe");
+  } else {
+    safe.PATH = platform === "darwin" ? MAC_SYSTEM_PATH : LINUX_SYSTEM_PATH;
+  }
+  return safe;
+}
+
+/** Best-effort and intentionally injectable only as a direct function argument
+ * for tests; the production launcher never reads an opener path from env. */
+export function openBrowser(url, opts = {}) {
+  const platform = opts.platform ?? process.platform;
+  const sourceEnv = opts.env ?? process.env;
+  const command = opts.command ?? browserOpenCommand(url, platform, sourceEnv);
+  if (!command) return undefined;
+  const child = spawn(command.file, command.args, {
+    cwd: os.homedir(),
+    env: browserOpenEnvironment(sourceEnv, platform),
+    stdio: "ignore",
+    detached: true,
+    windowsHide: true,
+  });
+  child.once("error", () => {});
+  child.unref();
+  return child;
+}

--- a/bin/mirafold.js
+++ b/bin/mirafold.js
@@ -57,7 +57,8 @@ const noOpen = process.argv.includes("--no-open");
 if (process.env.npm_command === "exec" || process.env.npm_lifecycle_event === "npx") {
   console.warn(
     "[mirafold] npx exposes executables from the current project's node_modules; " +
-      "use this convenience only in a project you trust (the global install is the safe default)",
+      "use it only in a project you trust. An installed command avoids package shadowing, " +
+      "but review or rename the checkout's .env before first launch",
   );
 }
 // --verbose rides to the daemon as MIRAFOLD_DEBUG=1 — one debug switch, two spellings.

--- a/bin/mirafold.js
+++ b/bin/mirafold.js
@@ -7,6 +7,7 @@ import { spawn } from "node:child_process";
 import { existsSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { openBrowser } from "./browser-open.js";
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 const daemon = path.resolve(HERE, "..", "dist-server", "index.js");
@@ -53,6 +54,12 @@ if (!existsSync(daemon)) {
 }
 
 const noOpen = process.argv.includes("--no-open");
+if (process.env.npm_command === "exec" || process.env.npm_lifecycle_event === "npx") {
+  console.warn(
+    "[mirafold] npx exposes executables from the current project's node_modules; " +
+      "use this convenience only in a project you trust (the global install is the safe default)",
+  );
+}
 // --verbose rides to the daemon as MIRAFOLD_DEBUG=1 — one debug switch, two spellings.
 const child = spawn(process.execPath, [daemon], {
   stdio: ["inherit", "pipe", "inherit"],
@@ -79,25 +86,19 @@ child.stdout.on("data", (buf) => {
     opened = true;
     bootTail = "";
     if (!noOpen) {
-      // Say it, because the open is often invisible: a compositor won't let a
-      // background process raise a window, so an already-running browser just
-      // gains a tab somewhere behind everything. Without this line a silent
-      // success and a failed opener look identical, and the user reads a
-      // working launch as broken (2026-07-30, Kyle's own first run).
-      console.log("[mirafold] opening it in your browser — check your tabs if no window appears");
-      openBrowser(m[0]);
+      const opener = openBrowser(m[0]);
+      if (!opener) {
+        console.log("[mirafold] no trusted system browser opener found — open the URL above");
+      } else {
+        // Say it, because the open is often invisible: a compositor won't let
+        // a background process raise a window, so an already-running browser
+        // can gain a tab behind everything (2026-07-30, first tester run).
+        console.log("[mirafold] opening it in your browser — check your tabs if no window appears");
+        opener.once("error", () =>
+          console.log("[mirafold] the system browser opener failed — open the URL above"),
+        );
+      }
     }
   }
 });
 child.on("exit", (code, signal) => process.exit(signal ? 1 : (code ?? 0)));
-
-function openBrowser(url) {
-  const [cmd, args] =
-    process.platform === "darwin"
-      ? ["open", [url]]
-      : process.platform === "win32"
-        ? ["cmd", ["/c", "start", "", url]]
-        : ["xdg-open", [url]];
-  // Best-effort: a headless box has no opener — the printed URL is the fallback.
-  spawn(cmd, args, { stdio: "ignore", detached: true }).on("error", () => {});
-}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,13 +17,16 @@ rebuilds on every push to `main`). Flow b keeps them in lockstep by making a
 | --- | --- | --- |
 | `main` | the production mirror — every commit on it is inside some release | required checks (Tier 1, Tier 2+3, DCO), no force-push/delete; repo-admin bypass exists for emergencies but a direct push breaks the flow-b invariant — don't, except as step one of an immediate release |
 | `next` | staging — day-to-day work accumulates here | PR-only for everyone (0 approvals, same required checks), no bypass, no force-push/delete |
-| `feature/*` | working branches, cut from `next` | none — name them anything, force-push freely |
+| `feature/*`, `fix/*`, `refactor/*` | working branches, cut from `next` | none — name them anything, force-push freely |
 | `release/x.y.z` | short-lived release prep, cut from `next` (or from `main` for a hotfix) | none — it exists for hours |
 
 Two mechanics to know:
 
 - **Every commit headed for a PR needs a DCO sign-off** — commit with
   `git commit -s`. The DCO check is required on both protected branches.
+- **An open or green feature PR is not approval to merge it.** Keep the PR
+  open through the requested review and refactor passes. When it appears
+  ready, ask Kyle explicitly whether to merge; merge only after he approves.
 - **A `v*` tag publishes only `main`'s current tip.** The release workflow's
   first step fails any tag pointing elsewhere (a feature branch, an old `main`
   commit). The tag trigger itself is branch-blind by platform design; the
@@ -32,8 +35,11 @@ Two mechanics to know:
 
 ## The release cycle
 
-1. **Feature work**: branch off `next`, commit with `-s`, PR into `next`,
-   merge on green. Repeat until `next` holds the release you want.
+1. **Feature work**: branch off `next`, commit with `-s`, and open a PR into
+   `next`. Keep implementation follow-ups and refactors on that open PR.
+   Once the work and required checks appear ready, ask Kyle explicitly for
+   merge approval; leave the PR open until he gives it. Repeat until `next`
+   holds the release you want.
 2. **Cut the release branch**: `git switch -c release/x.y.z origin/next`.
 3. **Bump the version** in `package.json` to `x.y.z` on that branch — commit
    `release: vx.y.z` (signed off). npm refuses to republish an existing
@@ -64,7 +70,8 @@ Two mechanics to know:
    Push `main`'s tip to a `sync/*` branch first
    (`git push origin main:refs/heads/sync/main-into-next-vx.y.z`) so the PR is
    a fixed snapshot rather than tracking `main`.
-8. Delete the merged `feature/*`, `release/*`, and `sync/*` branches.
+8. Delete the merged work (`feature/*`, `fix/*`, `refactor/*`), `release/*`,
+   and `sync/*` branches.
 
 ## Hotfixes
 

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -641,28 +641,26 @@ function capturedCodexOptions(opts: {
   return captured;
 }
 
-function withOpenAiKey(value: string | undefined, fn: () => void) {
-  const saved = process.env.OPENAI_API_KEY;
+function withEnvVar(name: string, value: string | undefined, fn: () => void) {
+  const saved = process.env[name];
   try {
-    if (value === undefined) delete process.env.OPENAI_API_KEY;
-    else process.env.OPENAI_API_KEY = value;
+    if (value === undefined) delete process.env[name];
+    else process.env[name] = value;
     fn();
   } finally {
-    if (saved === undefined) delete process.env.OPENAI_API_KEY;
-    else process.env.OPENAI_API_KEY = saved;
+    if (saved === undefined) delete process.env[name];
+    else process.env[name] = saved;
   }
 }
 
+const withOpenAiKey = (value: string | undefined, fn: () => void) =>
+  withEnvVar("OPENAI_API_KEY", value, fn);
+
 test("F.10: the installed Codex executable drives the SDK engine", () => {
-  const saved = process.env.MIRAFOLD_CODEX_BIN;
-  try {
-    process.env.MIRAFOLD_CODEX_BIN = "/operator/chosen/codex";
+  withEnvVar("MIRAFOLD_CODEX_BIN", "/operator/chosen/codex", () => {
     const o = capturedCodexOptions({ kind: "subscription" });
     assert.equal(o.codexPathOverride, "/operator/chosen/codex");
-  } finally {
-    if (saved === undefined) delete process.env.MIRAFOLD_CODEX_BIN;
-    else process.env.MIRAFOLD_CODEX_BIN = saved;
-  }
+  });
 });
 
 test("N.5: a subscription choice withholds the env API key — the explicit pick beats env precedence", () => {

--- a/server/adapters/types.test.ts
+++ b/server/adapters/types.test.ts
@@ -8,17 +8,33 @@ import { agentBin, capOutput, installedAgentBin, toolDetail } from "./types";
 // The default cap is 64 KB (TOOL_OUTPUT_CAP_BYTES), read at module load.
 const CAP = 64_000;
 
+function withEnv(patch: NodeJS.ProcessEnv, run: () => void): void {
+  const saved = new Map(Object.keys(patch).map((key) => [key, process.env[key]]));
+  try {
+    for (const [key, value] of Object.entries(patch)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    run();
+  } finally {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+function executable(file: string): void {
+  writeFileSync(file, "");
+  if (process.platform !== "win32") chmodSync(file, 0o755);
+}
+
 test("installedAgentBin honors the explicit operator override", () => {
   const key = "MIRAFOLD_TEST_AGENT_BIN";
-  const saved = process.env[key];
-  try {
-    process.env[key] = "/operator/chosen/agent";
+  withEnv({ [key]: "/operator/chosen/agent" }, () => {
     assert.equal(installedAgentBin(key, "agent"), "/operator/chosen/agent");
     assert.equal(agentBin(key, "agent"), "/operator/chosen/agent");
-  } finally {
-    if (saved === undefined) delete process.env[key];
-    else process.env[key] = saved;
-  }
+  });
 });
 
 test("installedAgentBin finds PATH executables and preserves the non-SDK ENOENT fallback", () => {
@@ -30,22 +46,17 @@ test("installedAgentBin finds PATH executables and preserves the non-SDK ENOENT 
   mkdirSync(path.join(shadowDir, name));
   const dir = mkdtempSync(path.join(os.tmpdir(), "mirafold-agent-bin-"));
   const file = path.join(dir, process.platform === "win32" ? `${name}.cmd` : name);
-  writeFileSync(file, "");
-  if (process.platform !== "win32") chmodSync(file, 0o755);
-  const savedPath = process.env.PATH;
-  const savedOverride = process.env[key];
+  executable(file);
   try {
-    delete process.env[key];
-    process.env.PATH = `${shadowDir}${path.delimiter}${dir}`;
-    assert.equal(installedAgentBin(key, name), realpathSync.native(file));
-    assert.equal(agentBin(key, name), realpathSync.native(file));
-    assert.equal(installedAgentBin(key, `${name}-missing`), undefined);
-    assert.equal(agentBin(key, `${name}-missing`), `${name}-missing`);
+    withEnv({ [key]: undefined, PATH: `${shadowDir}${path.delimiter}${dir}` }, () => {
+      assert.equal(installedAgentBin(key, name), realpathSync.native(file));
+      assert.equal(agentBin(key, name), realpathSync.native(file));
+      assert.equal(installedAgentBin(key, `${name}-missing`), undefined);
+      assert.equal(agentBin(key, `${name}-missing`), `${name}-missing`);
+    });
   } finally {
-    if (savedPath === undefined) delete process.env.PATH;
-    else process.env.PATH = savedPath;
-    if (savedOverride === undefined) delete process.env[key];
-    else process.env[key] = savedOverride;
+    rmSync(shadowDir, { recursive: true, force: true });
+    rmSync(dir, { recursive: true, force: true });
   }
 });
 
@@ -56,20 +67,13 @@ test("installedAgentBin ignores the project-local executables npm adds to PATH",
   const npmBin = path.join(root, "node_modules", ".bin");
   mkdirSync(npmBin, { recursive: true });
   const file = path.join(npmBin, process.platform === "win32" ? `${name}.cmd` : name);
-  writeFileSync(file, "");
-  if (process.platform !== "win32") chmodSync(file, 0o755);
-  const savedPath = process.env.PATH;
-  const savedOverride = process.env[key];
+  executable(file);
   try {
-    delete process.env[key];
-    process.env.PATH = npmBin;
-    assert.equal(installedAgentBin(key, name), undefined);
-    assert.equal(agentBin(key, name), name);
+    withEnv({ [key]: undefined, PATH: npmBin }, () => {
+      assert.equal(installedAgentBin(key, name), undefined);
+      assert.equal(agentBin(key, name), name);
+    });
   } finally {
-    if (savedPath === undefined) delete process.env.PATH;
-    else process.env.PATH = savedPath;
-    if (savedOverride === undefined) delete process.env[key];
-    else process.env[key] = savedOverride;
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/server/adapters/types.test.ts
+++ b/server/adapters/types.test.ts
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { agentBin, capOutput, installedAgentBin, toolDetail } from "./types";
 
 // The default cap is 64 KB (TOOL_OUTPUT_CAP_BYTES), read at module load.
@@ -37,8 +37,8 @@ test("installedAgentBin finds PATH executables and preserves the non-SDK ENOENT 
   try {
     delete process.env[key];
     process.env.PATH = `${shadowDir}${path.delimiter}${dir}`;
-    assert.equal(installedAgentBin(key, name), file);
-    assert.equal(agentBin(key, name), file);
+    assert.equal(installedAgentBin(key, name), realpathSync.native(file));
+    assert.equal(agentBin(key, name), realpathSync.native(file));
     assert.equal(installedAgentBin(key, `${name}-missing`), undefined);
     assert.equal(agentBin(key, `${name}-missing`), `${name}-missing`);
   } finally {
@@ -46,6 +46,31 @@ test("installedAgentBin finds PATH executables and preserves the non-SDK ENOENT 
     else process.env.PATH = savedPath;
     if (savedOverride === undefined) delete process.env[key];
     else process.env[key] = savedOverride;
+  }
+});
+
+test("installedAgentBin ignores the project-local executables npm adds to PATH", () => {
+  const key = "MIRAFOLD_TEST_AGENT_BIN";
+  const name = `mirafold-local-agent-${process.pid}`;
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-agent-project-"));
+  const npmBin = path.join(root, "node_modules", ".bin");
+  mkdirSync(npmBin, { recursive: true });
+  const file = path.join(npmBin, process.platform === "win32" ? `${name}.cmd` : name);
+  writeFileSync(file, "");
+  if (process.platform !== "win32") chmodSync(file, 0o755);
+  const savedPath = process.env.PATH;
+  const savedOverride = process.env[key];
+  try {
+    delete process.env[key];
+    process.env.PATH = npmBin;
+    assert.equal(installedAgentBin(key, name), undefined);
+    assert.equal(agentBin(key, name), name);
+  } finally {
+    if (savedPath === undefined) delete process.env.PATH;
+    else process.env.PATH = savedPath;
+    if (savedOverride === undefined) delete process.env[key];
+    else process.env[key] = savedOverride;
+    rmSync(root, { recursive: true, force: true });
   }
 });
 

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
-import { accessSync, constants, statSync } from "node:fs";
 import type { AgentName, WireMsg } from "../protocol";
 import type { CredentialKind } from "../provider-policy";
+import { locateTrustedExecutable } from "../security/executable-trust";
 
 export type { AgentName } from "../protocol";
 import { envInt } from "../env";
@@ -10,36 +10,15 @@ import { envInt } from "../env";
  *  The env override is explicit operator intent, so return it even when it is
  *  a bare name or currently missing (the eventual spawn then fails honestly).
  *  Otherwise mirror normal command lookup: beside node first (global npm/nvm
- *  installs), then PATH. `undefined` lets an SDK retain its bundled fallback. */
+ *  installs), then filtered PATH. Project files, relative entries, and npm's
+ *  injected node_modules bins are never agent identity. `undefined` lets an
+ *  SDK retain its bundled fallback. */
 export function installedAgentBin(envVar: string, name: string): string | undefined {
   const override = process.env[envVar];
   if (override) return override;
-
-  const names =
-    process.platform === "win32"
-      ? [
-          name,
-          ...(process.env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
-            .split(";")
-            .filter(Boolean)
-            .map((ext) => name + ext.toLowerCase()),
-        ]
-      : [name];
-  const dirs = [path.dirname(process.execPath), ...(process.env.PATH ?? "").split(path.delimiter)];
-  for (const dir of dirs) {
-    if (!dir) continue;
-    for (const file of names) {
-      const candidate = path.join(dir, file);
-      try {
-        if (!statSync(candidate).isFile()) continue;
-        accessSync(candidate, process.platform === "win32" ? constants.F_OK : constants.X_OK);
-        return candidate;
-      } catch {
-        // Not runnable here — continue exactly as normal PATH lookup would.
-      }
-    }
-  }
-  return undefined;
+  return locateTrustedExecutable(name, {
+    directories: [path.dirname(process.execPath)],
+  });
 }
 
 /** Resolve which `name`d agent binary to spawn. Non-SDK adapters need a

--- a/server/env.test.ts
+++ b/server/env.test.ts
@@ -1,6 +1,10 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { envFlag, envInt } from "./env";
+import { loadProjectEnv } from "./project-env";
 
 // 2026-07-29 bughunt: Number(garbage) is NaN, and NaN WIDENED two policies —
 // ws treats maxPayload NaN|0=0 as UNLIMITED, and setInterval(fn, NaN) clamps
@@ -39,4 +43,45 @@ test("envFlag: 0/false/blank are OFF, anything else set is ON", () => {
   assert.equal(envFlag("FALSE"), false);
   assert.equal(envFlag("1"), true);
   assert.equal(envFlag("true"), true);
+});
+
+test("project .env imports supported data but never process identity", () => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "mirafold-project-env-"));
+  const file = path.join(tmp, ".env");
+  writeFileSync(
+    file,
+    [
+      "OPENAI_API_KEY=from-project",
+      "PORT=4321",
+      'MIRAFOLD_TOKEN="x&calc|whoami"',
+      "MIRAFOLD_CODEX_BIN=./repo-codex",
+      "MIRAFOLD_GEMINI_BIN=./repo-gemini",
+      "NODE_OPTIONS=--require=./repo-loader.cjs",
+      "NODE_PATH=./repo-modules",
+      "PATH=./node_modules/.bin",
+      "SHELL=./repo-shell",
+      "UNRELATED_PROJECT_SETTING=untouched",
+    ].join("\n"),
+  );
+  const target: NodeJS.ProcessEnv = {
+    OPENAI_API_KEY: "from-parent",
+    NODE_OPTIONS: "--trace-warnings",
+    MIRAFOLD_CODEX_BIN: "/operator/codex",
+  };
+
+  try {
+    loadProjectEnv(file, target);
+    assert.equal(target.OPENAI_API_KEY, "from-parent", "parent-process values win");
+    assert.equal(target.PORT, "4321");
+    assert.equal(target.MIRAFOLD_TOKEN, "x&calc|whoami");
+    assert.equal(target.MIRAFOLD_CODEX_BIN, "/operator/codex");
+    assert.equal(target.MIRAFOLD_GEMINI_BIN, undefined);
+    assert.equal(target.NODE_OPTIONS, "--trace-warnings", "the file cannot replace a loader hook");
+    assert.equal(target.NODE_PATH, undefined);
+    assert.equal(target.PATH, undefined);
+    assert.equal(target.SHELL, undefined);
+    assert.equal(target.UNRELATED_PROJECT_SETTING, undefined);
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
 });

--- a/server/folder-picker.test.ts
+++ b/server/folder-picker.test.ts
@@ -1,5 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import {
   createFolderPicker,
@@ -7,6 +17,7 @@ import {
   folderPickerCommands,
   folderPickerEnvironment,
   folderPickerStartDir,
+  locateExecutable,
   runFolderPickerCommand,
   type FolderPickerProcessResult,
 } from "./folder-picker";
@@ -22,7 +33,13 @@ test("N2 native recipes: macOS, Windows, and both Linux desktop dialogs", () => 
   assert.equal(win.length, 1);
   assert.equal(
     win[0].file,
-    path.join("C:\\Windows", "System32", "WindowsPowerShell", "v1.0", "powershell.exe"),
+    path.win32.join(
+      "C:\\Windows",
+      "System32",
+      "WindowsPowerShell",
+      "v1.0",
+      "powershell.exe",
+    ),
   );
   assert.deepEqual(win[0].args.slice(0, 3), ["-NoLogo", "-NoProfile", "-STA"]);
   assert.match(win[0].args.at(-1)!, /FolderBrowserDialog/);
@@ -35,32 +52,47 @@ test("N2 native recipes: macOS, Windows, and both Linux desktop dialogs", () => 
   );
   assert.ok(linux[0].args.includes("--directory"));
   assert.ok(linux[1].args.includes("--getexistingdirectory"));
+
+  assert.deepEqual(
+    folderPickerCommands("C:\\work\\project", "win32", {}),
+    [],
+    "Windows never falls back to a PATH-resolved powershell.exe",
+  );
 });
 
 test("native helpers receive desktop state but no daemon credentials or loader hooks", () => {
-  assert.deepEqual(
-    folderPickerEnvironment(
-      {
-        PATH: "/usr/bin",
-        DISPLAY: ":1",
-        LANG: "en_US.UTF-8",
-        OPENAI_API_KEY: "must-not-cross",
-        MIRAFOLD_ENTITLEMENT_TOKEN: "must-not-cross",
-        CUSTOM_PROVIDER_SECRET: "must-not-cross",
-        LD_PRELOAD: "/tmp/must-not-load.so",
-      },
-      {
-        MIRAFOLD_FOLDER_PICKER_START: "/home/kyle/project",
-        ANOTHER_PRIVATE_VALUE: "must-not-cross",
-      },
-    ),
+  const env = folderPickerEnvironment(
     {
-      PATH: "/usr/bin",
+      PATH: "/project/node_modules/.bin:/attacker/bin",
       DISPLAY: ":1",
       LANG: "en_US.UTF-8",
-      MIRAFOLD_FOLDER_PICKER_START: "/home/kyle/project",
+      OPENAI_API_KEY: "must-not-cross",
+      MIRAFOLD_ENTITLEMENT_TOKEN: "must-not-cross",
+      CUSTOM_PROVIDER_SECRET: "must-not-cross",
+      LD_PRELOAD: "/tmp/must-not-load.so",
     },
+    {
+      MIRAFOLD_FOLDER_PICKER_START: "/home/kyle/project",
+      ANOTHER_PRIVATE_VALUE: "must-not-cross",
+    },
+    "linux",
   );
+  assert.equal(env.DISPLAY, ":1");
+  assert.equal(env.LANG, "en_US.UTF-8");
+  assert.equal(env.MIRAFOLD_FOLDER_PICKER_START, "/home/kyle/project");
+  assert.equal(
+    env.PATH,
+    "/usr/bin:/bin:/run/current-system/sw/bin:/usr/local/bin:/snap/bin",
+  );
+  for (const secret of [
+    "OPENAI_API_KEY",
+    "MIRAFOLD_ENTITLEMENT_TOKEN",
+    "CUSTOM_PROVIDER_SECRET",
+    "LD_PRELOAD",
+    "ANOTHER_PRIVATE_VALUE",
+  ]) {
+    assert.equal(secret in env, false, `${secret} crossed into the picker`);
+  }
 });
 
 test("folderPickerAvailable requires a real platform helper", () => {
@@ -77,6 +109,28 @@ test("folderPickerAvailable requires a real platform helper", () => {
     ),
     true,
   );
+});
+
+test("native helper lookup ignores ambient PATH and relative project commands", () => {
+  const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-picker-path-"));
+  const fake = path.join(fixture, "zenity");
+  writeFileSync(fake, "");
+  if (process.platform !== "win32") chmodSync(fake, 0o755);
+  const relativeNode = path.relative(process.cwd(), process.execPath);
+  try {
+    assert.notEqual(
+      locateExecutable("zenity", "linux", { PATH: fixture }),
+      realpathSync.native(fake),
+      "a PATH-prepended fake Zenity must never become host chrome",
+    );
+    assert.equal(locateExecutable(relativeNode, process.platform, process.env), undefined);
+    assert.equal(
+      locateExecutable(process.execPath, process.platform, process.env),
+      realpathSync.native(process.execPath),
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 });
 
 test("folderPickerStartDir expands home and lets a half-typed path fall back", () => {
@@ -142,13 +196,63 @@ test("A picker cannot stack, and a non-directory result is refused", async () =>
   await assert.rejects(first, /not a directory/);
 });
 
-test("Native picker output is capped", async () => {
-  await assert.rejects(
-    runFolderPickerCommand({
-      file: process.execPath,
-      args: ["-e", `process.stdout.write("x".repeat(20000))`],
-      canceled: () => false,
-    }),
-    /too much output/,
-  );
+test("native picker runs from a neutral cwd", async () => {
+  const result = await runFolderPickerCommand({
+    file: process.execPath,
+    args: ["-e", "process.stdout.write(process.cwd())"],
+    canceled: () => false,
+  });
+  assert.equal(result.stdout, os.homedir());
+});
+
+test("picker output overflow force-stops a helper that ignores SIGTERM before rejecting", async () => {
+  const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-picker-overflow-"));
+  const pidFile = path.join(fixture, "pid");
+  try {
+    await assert.rejects(
+      runFolderPickerCommand({
+        file: process.execPath,
+        args: [
+          "-e",
+          `const fs=require("node:fs");process.on("SIGTERM",()=>{});fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));process.stdout.write("x".repeat(20000));setInterval(()=>{},1000)`,
+        ],
+        canceled: () => false,
+      }),
+      /too much output/,
+    );
+    const pid = Number(readFileSync(pidFile, "utf8"));
+    assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
+test("picker abort waits for forced helper exit before rejecting", async () => {
+  const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-picker-abort-"));
+  const pidFile = path.join(fixture, "pid");
+  const controller = new AbortController();
+  try {
+    const pending = runFolderPickerCommand(
+      {
+        file: process.execPath,
+        args: [
+          "-e",
+          `const fs=require("node:fs");process.on("SIGTERM",()=>{});fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));setInterval(()=>{},1000)`,
+        ],
+        canceled: () => false,
+      },
+      controller.signal,
+    );
+    const deadline = Date.now() + 5_000;
+    while (!existsSync(pidFile) && Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    assert.ok(existsSync(pidFile), "helper did not start");
+    controller.abort();
+    await assert.rejects(pending, { name: "AbortError" });
+    const pid = Number(readFileSync(pidFile, "utf8"));
+    assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
 });

--- a/server/folder-picker.test.ts
+++ b/server/folder-picker.test.ts
@@ -22,6 +22,21 @@ import {
   type FolderPickerProcessResult,
 } from "./folder-picker";
 
+function hangingHelperScript(pidFile: string, beforeHang = ""): string {
+  return (
+    `const fs=require("node:fs");` +
+    `process.on("SIGTERM",()=>{});` +
+    `fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));` +
+    beforeHang +
+    `setInterval(()=>{},1000)`
+  );
+}
+
+function assertHelperExited(pidFile: string): void {
+  const pid = Number(readFileSync(pidFile, "utf8"));
+  assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+}
+
 test("N2 native recipes: macOS, Windows, and both Linux desktop dialogs", () => {
   const mac = folderPickerCommands("/Users/kyle/project", "darwin", {});
   assert.equal(mac.length, 1);
@@ -214,14 +229,13 @@ test("picker output overflow force-stops a helper that ignores SIGTERM before re
         file: process.execPath,
         args: [
           "-e",
-          `const fs=require("node:fs");process.on("SIGTERM",()=>{});fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));process.stdout.write("x".repeat(20000));setInterval(()=>{},1000)`,
+          hangingHelperScript(pidFile, `process.stdout.write("x".repeat(20000));`),
         ],
         canceled: () => false,
       }),
       /too much output/,
     );
-    const pid = Number(readFileSync(pidFile, "utf8"));
-    assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+    assertHelperExited(pidFile);
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }
@@ -235,10 +249,7 @@ test("picker abort waits for forced helper exit before rejecting", async () => {
     const pending = runFolderPickerCommand(
       {
         file: process.execPath,
-        args: [
-          "-e",
-          `const fs=require("node:fs");process.on("SIGTERM",()=>{});fs.writeFileSync(${JSON.stringify(pidFile)},String(process.pid));setInterval(()=>{},1000)`,
-        ],
+        args: ["-e", hangingHelperScript(pidFile)],
         canceled: () => false,
       },
       controller.signal,
@@ -250,8 +261,7 @@ test("picker abort waits for forced helper exit before rejecting", async () => {
     assert.ok(existsSync(pidFile), "helper did not start");
     controller.abort();
     await assert.rejects(pending, { name: "AbortError" });
-    const pid = Number(readFileSync(pidFile, "utf8"));
-    assert.throws(() => process.kill(pid, 0), { code: "ESRCH" });
+    assertHelperExited(pidFile);
   } finally {
     rmSync(fixture, { recursive: true, force: true });
   }

--- a/server/folder-picker.ts
+++ b/server/folder-picker.ts
@@ -5,22 +5,30 @@
 // is an argv/env value, never executable text.
 
 import { spawn } from "node:child_process";
-import { accessSync, constants, statSync } from "node:fs";
+import { statSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { locateTrustedExecutable } from "./security/executable-trust";
 
 const PICKER_TITLE = "Choose a Mirafold working directory";
 const PICKER_OUTPUT_MAX_BYTES = 16_384;
+const PICKER_TERMINATE_GRACE_MS = 250;
+const LINUX_SYSTEM_BIN_DIRS = [
+  "/usr/bin",
+  "/bin",
+  "/run/current-system/sw/bin",
+  "/usr/local/bin",
+  "/snap/bin",
+] as const;
 const LINUX_DIALOG_STARTUP_ERROR =
   /failed to open display|cannot open display|could not connect to display|could not load the qt platform plugin|no qt platform plugin/i;
 
 // Native dialogs need the signed-in desktop session, locale, and temporary
 // directory — not the daemon's model-provider keys, relay credentials, or an
 // arbitrary provider's custom env_key. An allowlist makes that true even for
-// credential names Mirafold has never seen before. Loader/plugin overrides are
-// deliberately absent too: these helpers should use their system defaults.
+// credential names Mirafold has never seen before. Loader/search-path overrides
+// are absent; desktop backend/theme selectors remain for native fidelity.
 const PICKER_ENV_KEYS = new Set([
-  "PATH",
   "PATHEXT",
   "HOME",
   "USER",
@@ -71,11 +79,30 @@ const PICKER_ENV_KEYS = new Set([
   "APPDATA",
   "LOCALAPPDATA",
   "PROGRAMDATA",
-  "COMSPEC",
-  "PSMODULEPATH",
   "SESSIONNAME",
   "MIRAFOLD_FOLDER_PICKER_START",
 ]);
+
+function envValue(source: NodeJS.ProcessEnv, name: string): string | undefined {
+  const hit = Object.entries(source).find(([key]) => key.toUpperCase() === name);
+  return hit?.[1];
+}
+
+function windowsRoot(env: NodeJS.ProcessEnv): string | undefined {
+  const root = envValue(env, "SYSTEMROOT") ?? envValue(env, "WINDIR");
+  return root && path.win32.isAbsolute(root) ? root : undefined;
+}
+
+function nativeHelperPath(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+  if (platform === "win32") {
+    const root = windowsRoot(env);
+    return root
+      ? [path.win32.join(root, "System32"), root].join(path.win32.delimiter)
+      : "";
+  }
+  if (platform === "darwin") return "/usr/bin:/bin:/usr/sbin:/sbin";
+  return LINUX_SYSTEM_BIN_DIRS.join(path.posix.delimiter);
+}
 
 const MAC_SCRIPT = [
   'set startFolder to POSIX file (system attribute "MIRAFOLD_FOLDER_PICKER_START")',
@@ -118,6 +145,61 @@ type LocateExecutable = (
   env: NodeJS.ProcessEnv,
 ) => string | undefined;
 
+function macFolderPickerCommand(startDir: string): FolderPickerCommand {
+  return {
+    file: "/usr/bin/osascript",
+    args: ["-e", MAC_SCRIPT],
+    env: { MIRAFOLD_FOLDER_PICKER_START: startDir },
+    // AppleScript's `choose folder` reports user cancellation as -128.
+    canceled: (code, stderr) => code === 1 && /user canceled|-128/i.test(stderr),
+  };
+}
+
+function windowsFolderPickerCommand(
+  startDir: string,
+  env: NodeJS.ProcessEnv,
+): FolderPickerCommand | undefined {
+  const root = windowsRoot(env);
+  if (!root) return undefined;
+  const systemPowerShell = path.win32.join(
+    root,
+    "System32",
+    "WindowsPowerShell",
+    "v1.0",
+    "powershell.exe",
+  );
+  return {
+    file: systemPowerShell,
+    args: ["-NoLogo", "-NoProfile", "-STA", "-Command", WINDOWS_SCRIPT],
+    env: { MIRAFOLD_FOLDER_PICKER_START: startDir },
+    // FolderBrowserDialog writes nothing and exits successfully on Cancel.
+    canceled: () => false,
+  };
+}
+
+function linuxFolderPickerCommands(startDir: string): FolderPickerCommand[] {
+  const initial = startDir.endsWith(path.sep) ? startDir : startDir + path.sep;
+  const canceled = (code: number | null, stderr: string) =>
+    code === 1 && !LINUX_DIALOG_STARTUP_ERROR.test(stderr);
+  return [
+    {
+      file: "zenity",
+      args: [
+        "--file-selection",
+        "--directory",
+        `--title=${PICKER_TITLE}`,
+        `--filename=${initial}`,
+      ],
+      canceled,
+    },
+    {
+      file: "kdialog",
+      args: ["--title", PICKER_TITLE, "--getexistingdirectory", startDir],
+      canceled,
+    },
+  ];
+}
+
 /** Platform recipes, exported so Tier 1 pins the native contract without
  *  opening a real GUI. Linux tries the two desktop-standard helpers in order. */
 export function folderPickerCommands(
@@ -125,90 +207,33 @@ export function folderPickerCommands(
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
 ): FolderPickerCommand[] {
-  const startEnv = { MIRAFOLD_FOLDER_PICKER_START: startDir };
-  if (platform === "darwin") {
-    return [
-      {
-        file: "/usr/bin/osascript",
-        args: ["-e", MAC_SCRIPT],
-        env: startEnv,
-        // AppleScript's `choose folder` reports user cancellation as -128.
-        canceled: (code, stderr) => code === 1 && /user canceled|-128/i.test(stderr),
-      },
-    ];
+  switch (platform) {
+    case "darwin":
+      return [macFolderPickerCommand(startDir)];
+    case "win32": {
+      const command = windowsFolderPickerCommand(startDir, env);
+      return command ? [command] : [];
+    }
+    case "linux":
+      return linuxFolderPickerCommands(startDir);
+    default:
+      return [];
   }
-  if (platform === "win32") {
-    const systemPowerShell = env.SystemRoot
-      ? path.join(
-          env.SystemRoot,
-          "System32",
-          "WindowsPowerShell",
-          "v1.0",
-          "powershell.exe",
-        )
-      : "powershell.exe";
-    return [
-      {
-        file: systemPowerShell,
-        args: ["-NoLogo", "-NoProfile", "-STA", "-Command", WINDOWS_SCRIPT],
-        env: startEnv,
-        // FolderBrowserDialog writes nothing and exits successfully on Cancel.
-        canceled: () => false,
-      },
-    ];
-  }
-  if (platform === "linux") {
-    const initial = startDir.endsWith(path.sep) ? startDir : startDir + path.sep;
-    return [
-      {
-        file: "zenity",
-        args: [
-          "--file-selection",
-          "--directory",
-          `--title=${PICKER_TITLE}`,
-          `--filename=${initial}`,
-        ],
-        canceled: (code, stderr) => code === 1 && !LINUX_DIALOG_STARTUP_ERROR.test(stderr),
-      },
-      {
-        file: "kdialog",
-        args: ["--title", PICKER_TITLE, "--getexistingdirectory", startDir],
-        canceled: (code, stderr) => code === 1 && !LINUX_DIALOG_STARTUP_ERROR.test(stderr),
-      },
-    ];
-  }
-  return [];
 }
 
-/** Resolve a command exactly as a spawn would, but return an absolute file so
- *  a later cwd change cannot reinterpret a relative PATH entry. */
+/** Resolve only operating-system helper locations. Ambient PATH is deliberately
+ * ignored: npm/npx put project executables there, and Browse must never run one. */
 export function locateExecutable(
   file: string,
   platform: NodeJS.Platform = process.platform,
   env: NodeJS.ProcessEnv = process.env,
 ): string | undefined {
-  const names =
-    platform === "win32" && !path.extname(file)
-      ? (env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
-          .split(";")
-          .filter(Boolean)
-          .map((ext) => file + ext.toLowerCase())
-      : [file];
-  const direct = path.isAbsolute(file) || file.includes("/") || file.includes("\\");
-  const dirs = direct ? [""] : (env.PATH ?? "").split(path.delimiter).filter(Boolean);
-  for (const dir of dirs) {
-    for (const name of names) {
-      const candidate = direct ? name : path.resolve(dir, name);
-      try {
-        if (!statSync(candidate).isFile()) continue;
-        accessSync(candidate, platform === "win32" ? constants.F_OK : constants.X_OK);
-        return candidate;
-      } catch {
-        // Missing, a directory, or not executable — normal lookup continues.
-      }
-    }
-  }
-  return undefined;
+  return locateTrustedExecutable(file, {
+    platform,
+    env,
+    directories: platform === "linux" ? LINUX_SYSTEM_BIN_DIRS : [],
+    includePath: false,
+  });
 }
 
 export function folderPickerAvailable(
@@ -229,11 +254,13 @@ export function folderPickerAvailable(
 export function folderPickerEnvironment(
   source: NodeJS.ProcessEnv = process.env,
   additions: NodeJS.ProcessEnv = {},
+  platform: NodeJS.Platform = process.platform,
 ): Record<string, string> {
   const safe: Record<string, string> = {};
   for (const [key, value] of Object.entries({ ...source, ...additions })) {
     if (value !== undefined && PICKER_ENV_KEYS.has(key.toUpperCase())) safe[key] = value;
   }
+  safe.PATH = nativeHelperPath(platform, source);
   return safe;
 }
 
@@ -252,23 +279,63 @@ export function runFolderPickerCommand(
   return new Promise((resolve, reject) => {
     const child = spawn(command.file, command.args, {
       env: folderPickerEnvironment(process.env, command.env),
+      // The selected start directory is already an argv/env value. Keeping the
+      // native program out of an untrusted repository also prevents accidental
+      // project-local config/module discovery inside otherwise trusted helpers.
+      cwd: os.homedir(),
       stdio: ["ignore", "pipe", "pipe"],
-      ...(signal ? { signal } : {}),
+      detached: process.platform !== "win32",
+      windowsHide: true,
     });
     let stdout = Buffer.alloc(0);
     let stderr = Buffer.alloc(0);
-    let settled = false;
-    const finish = (err: Error | null, result?: FolderPickerProcessResult) => {
-      if (settled) return;
-      settled = true;
-      if (err) reject(err);
-      else resolve(result!);
+    let pendingError: Error | undefined;
+    let closing = false;
+    let closed = false;
+    let hardKill: NodeJS.Timeout | undefined;
+
+    const signalChild = (killSignal: NodeJS.Signals) => {
+      if (process.platform !== "win32" && child.pid) {
+        try {
+          process.kill(-child.pid, killSignal);
+          return;
+        } catch {
+          // The child can be signaled before its new process group is visible.
+        }
+      }
+      child.kill(killSignal);
     };
+
+    const requestStop = (err: Error) => {
+      pendingError ??= err;
+      if (closing || closed) return;
+      closing = true;
+      try {
+        signalChild("SIGTERM");
+      } catch {
+        // A natural exit may have won the race; close still settles truthfully.
+      }
+      hardKill = setTimeout(() => {
+        if (closed) return;
+        try {
+          signalChild("SIGKILL");
+        } catch {
+          // As above, close is authoritative; ESRCH means it is already coming.
+        }
+      }, PICKER_TERMINATE_GRACE_MS);
+      hardKill.unref();
+    };
+
+    const onAbort = () => requestStop(abortError());
+    signal?.addEventListener("abort", onAbort, { once: true });
+    // The signal can flip between the pre-spawn guard and listener attachment.
+    if (signal?.aborted) onAbort();
+
     const capture = (which: "stdout" | "stderr", chunk: Buffer) => {
+      if (closing) return;
       const next = Buffer.concat([which === "stdout" ? stdout : stderr, chunk]);
       if (next.byteLength > PICKER_OUTPUT_MAX_BYTES) {
-        child.kill();
-        finish(new Error("The system folder picker returned too much output."));
+        requestStop(new Error("The system folder picker returned too much output."));
         return;
       }
       if (which === "stdout") stdout = next;
@@ -276,14 +343,25 @@ export function runFolderPickerCommand(
     };
     child.stdout.on("data", (chunk: Buffer) => capture("stdout", chunk));
     child.stderr.on("data", (chunk: Buffer) => capture("stderr", chunk));
-    child.once("error", (err) => finish(err));
-    child.once("close", (code) =>
-      finish(null, {
+    child.once("error", (err) => {
+      // Spawn failures have no live child to terminate, but Node still follows
+      // with close; waiting for it keeps one authoritative settlement path.
+      pendingError ??= err;
+    });
+    child.once("close", (code) => {
+      closed = true;
+      if (hardKill) clearTimeout(hardKill);
+      signal?.removeEventListener("abort", onAbort);
+      if (pendingError) {
+        reject(pendingError);
+        return;
+      }
+      resolve({
         code,
         stdout: stdout.toString("utf8"),
         stderr: stderr.toString("utf8"),
-      }),
-    );
+      });
+    });
   });
 }
 
@@ -315,9 +393,7 @@ export type PickHostDirectory = (
   signal?: AbortSignal,
 ) => Promise<string | undefined>;
 
-/** One shared service instance means two tabs cannot stack native dialogs on
- *  the host. Dependencies are injectable so tests never open a real GUI. */
-export function createFolderPicker(opts: {
+type FolderPickerOptions = {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
   locate?: LocateExecutable;
@@ -325,11 +401,30 @@ export function createFolderPicker(opts: {
   fallbackDir?: () => string;
   homeDir?: () => string;
   directoryExists?: (candidate: string) => boolean;
-} = {}): PickHostDirectory {
+};
+
+function resolveSelectedDirectory(
+  output: string,
+  directoryExists: (candidate: string) => boolean,
+): string | undefined {
+  // Windows cancellation is a successful process with empty stdout; all
+  // three platform tools append at most one line ending on success.
+  const selected = output.replace(/\r?\n$/, "");
+  if (!selected) return undefined;
+  const absolute = path.resolve(selected);
+  if (!directoryExists(absolute)) {
+    throw new Error("The system folder picker returned a path that is not a directory.");
+  }
+  return absolute;
+}
+
+/** One shared service instance means two tabs cannot stack native dialogs on
+ *  the host. Dependencies are injectable so tests never open a real GUI. */
+export function createFolderPicker(opts: FolderPickerOptions = {}): PickHostDirectory {
   const platform = opts.platform ?? process.platform;
   const env = opts.env ?? process.env;
-  const locate = opts.locate ?? locateExecutable;
-  const run = opts.run ?? runFolderPickerCommand;
+  const findExecutable = opts.locate ?? locateExecutable;
+  const runCommand = opts.run ?? runFolderPickerCommand;
   const fallbackDir = opts.fallbackDir ?? (() => process.cwd());
   const homeDir = opts.homeDir ?? os.homedir;
   const directoryExists = opts.directoryExists ?? isDirectory;
@@ -349,12 +444,12 @@ export function createFolderPicker(opts: {
       const commands = folderPickerCommands(startDir, platform, env);
       let lastFailure: Error | undefined;
       for (const recipe of commands) {
-        const executable = locate(recipe.file, platform, env);
+        const executable = findExecutable(recipe.file, platform, env);
         if (!executable) continue;
         const command = { ...recipe, file: executable };
         let result: FolderPickerProcessResult;
         try {
-          result = await run(command, signal);
+          result = await runCommand(command, signal);
         } catch (err) {
           if (signal?.aborted || (err instanceof Error && err.name === "AbortError")) throw err;
           if ((err as NodeJS.ErrnoException)?.code === "ENOENT") continue;
@@ -370,15 +465,7 @@ export function createFolderPicker(opts: {
           if (platform === "linux") continue;
           throw lastFailure;
         }
-        // Windows cancellation is a successful process with empty stdout;
-        // all three platform tools append at most one line ending on success.
-        const selected = result.stdout.replace(/\r?\n$/, "");
-        if (!selected) return undefined;
-        const absolute = path.resolve(selected);
-        if (!directoryExists(absolute)) {
-          throw new Error("The system folder picker returned a path that is not a directory.");
-        }
-        return absolute;
+        return resolveSelectedDirectory(result.stdout, directoryExists);
       }
       if (lastFailure) throw lastFailure;
       throw new Error(

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "./project-env-loader";
 import { createServer, type IncomingMessage } from "node:http";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -13,7 +14,15 @@ import { startRelayClient } from "./relay/relay-client";
 import { createEntitlementTokenSource } from "./relay/entitlement";
 import { MIN_PAIRING_CODE_LENGTH, resolvePairingCode } from "./relay/relay-protocol";
 import { resolveRelayPlan } from "./relay/relay-url";
-import { COOKIE_NAME, cookieToken, isAllowedOrigin, safeRedirectPath, tokensMatch, verifyToken } from "./security/auth";
+import {
+  COOKIE_NAME,
+  cookieToken,
+  isAllowedOrigin,
+  safeRedirectPath,
+  startupUrl,
+  tokensMatch,
+  verifyToken,
+} from "./security/auth";
 import { createLogger, logFile, print } from "./log";
 import { envInt } from "./env";
 import { VERSION } from "./version";
@@ -35,22 +44,6 @@ const lastGasp = (kind: string) => (err: unknown) => {
 };
 process.on("uncaughtException", lastGasp("uncaughtException"));
 process.on("unhandledRejection", lastGasp("unhandledRejection"));
-
-// .env is optional — without an API key we fall back to the mock session.
-// On Node < 20.12 loadEnvFile doesn't exist; swallowing that silently
-// strands a valid key in .env in mock mode with no clue why — say so (R.4g).
-if (typeof process.loadEnvFile === "function") {
-  try {
-    process.loadEnvFile();
-  } catch {
-    /* no .env yet */
-  }
-} else {
-  log.warn(
-    `this Node (${process.version}) can't read .env (needs >= 20.12) — ` +
-      "credentials set in .env were NOT loaded; export them in the environment or upgrade Node",
-  );
-}
 
 const app = express();
 
@@ -332,7 +325,7 @@ const listen = (port: number) => {
     server.removeListener("error", onBusy); // later errors stay loud, as before
     // The token rides the URL so the launcher opens an authenticated page; the
     // browser trades it for the cookie on first load (see the auth block above).
-    const url = `http://127.0.0.1:${port}/${AUTH_ENABLED ? `?token=${AUTH_TOKEN}` : ""}`;
+    const url = startupUrl(port, AUTH_TOKEN);
     // print(): the launcher greps this stdout line for the URL, and the token
     // must never reach the log file — its file twin below is sanitized.
     print(`[mirafold] v${VERSION} — server on ${url} (ws at /ws)`);

--- a/server/project-env-loader.ts
+++ b/server/project-env-loader.ts
@@ -1,0 +1,7 @@
+// This must remain index.ts's first import: dependency modules read several
+// settings at module initialization, so the constrained project configuration
+// has to land before those modules execute.
+
+import { loadProjectEnv } from "./project-env";
+
+loadProjectEnv();

--- a/server/project-env.ts
+++ b/server/project-env.ts
@@ -1,0 +1,70 @@
+// A checkout's .env is application data, not parent-process authority.
+// Import only settings Mirafold deliberately supports there; executable
+// overrides, PATH/shell controls, runtime loader hooks, and arbitrary project
+// variables stay available only when the operator supplied them before launch.
+
+import { readFileSync } from "node:fs";
+import { parseEnv } from "node:util";
+
+export const PROJECT_ENV_KEYS: ReadonlySet<string> = new Set([
+  // Agent selection, credentials, endpoints, and model choices.
+  "MIRAFOLD_AGENT",
+  "ANTHROPIC_API_KEY",
+  "ANTHROPIC_AUTH_TOKEN",
+  "ANTHROPIC_BASE_URL",
+  "DEFAULT_MODEL",
+  "OPENAI_API_KEY",
+  "CODEX_MODEL",
+  "GEMINI_API_KEY",
+  "GOOGLE_API_KEY",
+  "GEMINI_MODEL",
+  "MAX_THINKING_TOKENS",
+
+  // Daemon, local-model, logging, and relay configuration.
+  "PORT",
+  "MIRAFOLD_TOKEN",
+  "MIRAFOLD_DEBUG",
+  "MIRAFOLD_LOG_FILE",
+  "MIRAFOLD_LOCAL_ENDPOINTS",
+  "MIRAFOLD_LOCAL_DISCOVERY",
+  "MIRAFOLD_RELAY_URL",
+  "MIRAFOLD_APP_URL",
+  "MIRAFOLD_RELAY_CODE",
+  "MIRAFOLD_LICENSE_KEY",
+  "MIRAFOLD_ENTITLEMENT_URL",
+  "MIRAFOLD_ENTITLEMENT_TOKEN",
+
+  // Documented resource limits.
+  "MAX_WS_PAYLOAD",
+  "SESSION_BUFFER_MAX_BYTES",
+  "SESSION_IDLE_TIMEOUT_MS",
+  "DELTA_COALESCE_MS",
+  "MAX_SESSIONS",
+  "PERMISSION_TIMEOUT_MS",
+  "TOOL_OUTPUT_CAP_BYTES",
+  "BANG_CONTEXT_CAP",
+  "MAX_REMOTE_VIEWPORTS",
+  "RELAY_VIEWPORT_IDLE_MS",
+]);
+
+/** Load supported project settings without letting the checkout modify process
+ *  identity. Existing values win, matching Node's process.loadEnvFile() rule:
+ *  an explicit parent-process value always beats the file. Missing, unreadable,
+ *  or malformed optional files leave the target untouched. */
+export function loadProjectEnv(
+  file = ".env",
+  target: NodeJS.ProcessEnv = process.env,
+): void {
+  let parsed: NodeJS.Dict<string>;
+  try {
+    parsed = parseEnv(readFileSync(file, "utf8"));
+  } catch {
+    return;
+  }
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (value !== undefined && PROJECT_ENV_KEYS.has(key) && target[key] === undefined) {
+      target[key] = value;
+    }
+  }
+}

--- a/server/pty/bang.itest.ts
+++ b/server/pty/bang.itest.ts
@@ -234,12 +234,19 @@ test("bang burst throttle: a too-fast second bang is refused with a clean end (a
   await bd.stop();
 });
 
-test("one bang at a time; bang_kill ends it with a null exit code", async () => {
+test("one bang at a time; bang_kill force-stops even a HUP-ignoring command", async () => {
   // `echo up` first: bang_start alone doesn't prove the child is attached,
   // and killing a PTY before its process fully spawns can surface as a clean
   // exit instead of signal death under CPU load (the C.1 runner flake) —
   // wait for output, which only a live process can produce.
-  c.send({ type: "bang", id: "b2", command: "echo up && sleep 30" } as never);
+  // The PTY library's default kill is SIGHUP. A shell can ignore it, so the
+  // old implementation left this command running and later called its
+  // natural exit "killed" merely because Stop had once been requested.
+  c.send({
+    type: "bang",
+    id: "b2",
+    command: "trap '' HUP; echo up; sleep 30; exit 7",
+  } as never);
   await c.type("bang_start");
   await c.waitFor((m) => m.type === "bang_output" && /up/.test((m as Any).data), "b2 live");
   c.send({ type: "bang", id: "b3", command: "echo nope" } as never);

--- a/server/pty/pty.ts
+++ b/server/pty/pty.ts
@@ -167,24 +167,52 @@ export function spawnBang(
       ...(prefix && cwdFile ? { [CWD_FILE_ENV]: cwdFile } : {}),
     },
   });
+  let killedByUs = false;
   const cleaner = createPtyCleaner();
   proc.onData((d) => {
     const clean = cleaner.clean(d);
     if (clean) onData(clean);
   });
-  // node-pty reports signal deaths as { exitCode: 0, signal: n } — surface
-  // those as null so a killed command isn't mistaken for a clean exit.
+  // The explicit-stop path below records only a kill that the OS/library
+  // accepted. A request that raced a natural exit must keep that real exit
+  // code instead of being relabelled as "killed".
   proc.onExit(({ exitCode, signal }) => {
     const tail = cleaner.flush();
     if (tail) onData(tail);
-    onExit(signal ? null : exitCode);
+    onExit(killedByUs || signal ? null : exitCode);
   });
   return {
     write(data: string) {
       proc.write(data);
     },
     kill() {
-      proc.kill();
+      if (killedByUs) return;
+      try {
+        if (process.platform === "win32") {
+          // ConPTY's kill has no signal parameter and terminates the process
+          // tree. Passing one throws, per node-pty's API contract.
+          proc.kill();
+        } else {
+          // node-pty's default SIGHUP is catchable/ignorable. Stop means stop:
+          // forkpty makes the shell its process-group leader, so SIGKILL the
+          // whole foreground group rather than leaving command children alive.
+          try {
+            process.kill(-proc.pid, "SIGKILL");
+          } catch {
+            // A click can beat the child's setsid/process-group setup. In
+            // that narrow window the group does not exist yet, but the shell
+            // pid does; killing it directly is both confirmed and sufficient
+            // because it has not had time to create descendants.
+            process.kill(proc.pid, "SIGKILL");
+          }
+        }
+        killedByUs = true;
+      } catch {
+        // Most commonly ESRCH: the command exited between the user's click
+        // and this call. Leave killedByUs false so onExit reports the real
+        // result. Unexpected kill failures likewise must not crash the daemon
+        // or manufacture a successful Stop.
+      }
     },
   };
 }

--- a/server/security/auth.test.ts
+++ b/server/security/auth.test.ts
@@ -1,6 +1,15 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { cookieToken, isAllowedOrigin, safeRedirectPath, verifyToken } from "./auth";
+import { cookieToken, isAllowedOrigin, safeRedirectPath, startupUrl, verifyToken } from "./auth";
+
+test("startupUrl percent-encodes a token instead of creating new URL syntax", () => {
+  const token = "x&calc|whoami (proof)";
+  const url = startupUrl(3000, token);
+  assert.equal(new URL(url).searchParams.get("token"), token);
+  assert.equal(url.includes(token), false);
+  assert.match(url, /token=x%26calc%7Cwhoami/);
+  assert.equal(startupUrl(3000, ""), "http://127.0.0.1:3000/");
+});
 
 test("cookieToken extracts the mirafold_token value", () => {
   assert.equal(cookieToken("mirafold_token=abc"), "abc");

--- a/server/security/auth.ts
+++ b/server/security/auth.ts
@@ -7,6 +7,14 @@ import { timingSafeEqual } from "node:crypto";
 
 export const COOKIE_NAME = "mirafold_token";
 
+/** The one startup URL printed for the launcher. URLSearchParams keeps an
+ *  operator-supplied token as data, even when it contains shell metacharacters. */
+export function startupUrl(port: number, token: string): string {
+  const url = new URL(`http://127.0.0.1:${port}/`);
+  if (token !== "") url.searchParams.set("token", token);
+  return url.href;
+}
+
 /**
  * Constant-time token comparison. A plain `===` on a secret can leak it one
  * character at a time via how long the mismatch takes to reject; comparing in

--- a/server/security/executable-trust.test.ts
+++ b/server/security/executable-trust.test.ts
@@ -1,6 +1,14 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { isProjectExecutablePath, locateTrustedExecutable } from "./executable-trust";

--- a/server/security/executable-trust.test.ts
+++ b/server/security/executable-trust.test.ts
@@ -1,0 +1,82 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { chmodSync, mkdirSync, mkdtempSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isProjectExecutablePath, locateTrustedExecutable } from "./executable-trust";
+
+function executable(file: string): void {
+  writeFileSync(file, "");
+  if (process.platform !== "win32") chmodSync(file, 0o755);
+}
+
+test("trusted lookup skips npm bins and keeps the next global executable", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-exec-root-"));
+  const npmBin = path.join(root, "node_modules", ".bin");
+  const globalBin = mkdtempSync(path.join(os.tmpdir(), "mirafold-exec-global-"));
+  const name = `mirafold-helper-${process.pid}`;
+  mkdirSync(npmBin, { recursive: true });
+  executable(path.join(npmBin, name));
+  const trusted = path.join(globalBin, name);
+  executable(trusted);
+  try {
+    assert.equal(
+      locateTrustedExecutable(name, {
+        env: { PATH: `${npmBin}${path.delimiter}${globalBin}` },
+        launchDir: root,
+      }),
+      realpathSync.native(trusted),
+    );
+    assert.equal(
+      locateTrustedExecutable(name, { env: { PATH: npmBin }, launchDir: root }),
+      undefined,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    rmSync(globalBin, { recursive: true, force: true });
+  }
+});
+
+test("trusted lookup refuses project files and relative PATH entries", () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-exec-project-"));
+  const bin = path.join(root, "tools");
+  const name = `mirafold-project-helper-${process.pid}`;
+  mkdirSync(bin);
+  const file = path.join(bin, name);
+  executable(file);
+  try {
+    assert.equal(isProjectExecutablePath(file, root), true);
+    assert.equal(locateTrustedExecutable(file, { launchDir: root }), undefined);
+    assert.equal(
+      locateTrustedExecutable(name, { env: { PATH: "tools" }, launchDir: root }),
+      undefined,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test(
+  "trusted lookup resolves symlinks before applying the project boundary",
+  { skip: process.platform === "win32" && "file symlinks require extra privileges on Windows" },
+  () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-exec-link-root-"));
+    const outside = mkdtempSync(path.join(os.tmpdir(), "mirafold-exec-link-bin-"));
+    const target = path.join(root, "helper");
+    const link = path.join(outside, "helper");
+    executable(target);
+    symlinkSync(target, link);
+    try {
+      assert.equal(
+        locateTrustedExecutable("helper", {
+          env: { PATH: outside },
+          launchDir: root,
+        }),
+        undefined,
+      );
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+      rmSync(outside, { recursive: true, force: true });
+    }
+  },
+);

--- a/server/security/executable-trust.ts
+++ b/server/security/executable-trust.ts
@@ -72,6 +72,17 @@ function runnable(candidate: string, platform: NodeJS.Platform): boolean {
   }
 }
 
+function resolveTrustedCandidate(
+  candidate: string,
+  platform: NodeJS.Platform,
+  launchDir: string,
+): string | undefined {
+  if (!runnable(candidate, platform) || isProjectExecutablePath(candidate, launchDir)) {
+    return undefined;
+  }
+  return canonical(candidate);
+}
+
 /** Resolve an executable without accepting relative PATH entries, npm bins,
  * launch-repository files, or symlinks back into the launch repository.
  * Returned paths are canonical and absolute, closing later cwd reinterpretation. */
@@ -84,8 +95,7 @@ export function locateTrustedExecutable(
   const launchDir = opts.launchDir ?? process.cwd();
 
   if (path.isAbsolute(file)) {
-    if (!runnable(file, platform) || isProjectExecutablePath(file, launchDir)) return undefined;
-    return canonical(file);
+    return resolveTrustedCandidate(file, platform, launchDir);
   }
   // A slash-bearing relative command is explicitly cwd-dependent. Mirafold's
   // daemon-owned launches must either use an absolute file or a filtered name.
@@ -95,6 +105,7 @@ export function locateTrustedExecutable(
     ? []
     : (env.PATH ?? "").split(path.delimiter).filter(Boolean);
   const dirs = [...(opts.directories ?? []), ...pathDirs];
+  const names = namesFor(file, platform, env);
   const seen = new Set<string>();
   for (const rawDir of dirs) {
     // Relative and empty PATH entries mean the current project directory.
@@ -102,10 +113,9 @@ export function locateTrustedExecutable(
     const dir = canonical(rawDir);
     if (seen.has(dir) || isProjectExecutablePath(dir, launchDir)) continue;
     seen.add(dir);
-    for (const name of namesFor(file, platform, env)) {
-      const candidate = path.join(dir, name);
-      if (!runnable(candidate, platform) || isProjectExecutablePath(candidate, launchDir)) continue;
-      return canonical(candidate);
+    for (const name of names) {
+      const resolved = resolveTrustedCandidate(path.join(dir, name), platform, launchDir);
+      if (resolved) return resolved;
     }
   }
   return undefined;

--- a/server/security/executable-trust.ts
+++ b/server/security/executable-trust.ts
@@ -1,0 +1,112 @@
+// Shared executable lookup for daemon-owned child processes. npm/npx prepend
+// project-local `node_modules/.bin` directories to PATH, which is useful for
+// build tools but must not silently decide which host program Mirafold runs.
+
+import { accessSync, constants, realpathSync, statSync } from "node:fs";
+import path from "node:path";
+
+export type TrustedExecutableOptions = {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  /** The directory whose repository must not supply the executable. */
+  launchDir?: string;
+  /** Known directories to search before (or instead of) PATH. */
+  directories?: readonly string[];
+  /** Agent CLIs retain filtered terminal lookup; OS chrome sets this false. */
+  includePath?: boolean;
+};
+
+const NPM_BIN_SEGMENT = /(^|[\\/])node_modules[\\/]\.bin([\\/]|$)/i;
+
+function canonical(candidate: string): string {
+  try {
+    return realpathSync.native(candidate);
+  } catch {
+    return path.resolve(candidate);
+  }
+}
+
+function isWithin(root: string, candidate: string): boolean {
+  const relative = path.relative(root, candidate);
+  return (
+    relative === "" ||
+    (relative !== ".." && !relative.startsWith(`..${path.sep}`) && !path.isAbsolute(relative))
+  );
+}
+
+/** True when npm or the launch repository can control this path. Both the
+ * lexical and canonical forms are checked so an outside symlink cannot point
+ * back into the repository and bypass the boundary. */
+export function isProjectExecutablePath(
+  candidate: string,
+  launchDir = process.cwd(),
+): boolean {
+  if (NPM_BIN_SEGMENT.test(candidate)) return true;
+  const realCandidate = canonical(candidate);
+  if (NPM_BIN_SEGMENT.test(realCandidate)) return true;
+  return isWithin(canonical(launchDir), realCandidate);
+}
+
+function namesFor(
+  file: string,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+): string[] {
+  if (platform !== "win32" || path.extname(file)) return [file];
+  return [
+    file,
+    ...(env.PATHEXT ?? ".COM;.EXE;.BAT;.CMD")
+      .split(";")
+      .filter(Boolean)
+      .map((ext) => file + ext.toLowerCase()),
+  ];
+}
+
+function runnable(candidate: string, platform: NodeJS.Platform): boolean {
+  try {
+    if (!statSync(candidate).isFile()) return false;
+    accessSync(candidate, platform === "win32" ? constants.F_OK : constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Resolve an executable without accepting relative PATH entries, npm bins,
+ * launch-repository files, or symlinks back into the launch repository.
+ * Returned paths are canonical and absolute, closing later cwd reinterpretation. */
+export function locateTrustedExecutable(
+  file: string,
+  opts: TrustedExecutableOptions = {},
+): string | undefined {
+  const platform = opts.platform ?? process.platform;
+  const env = opts.env ?? process.env;
+  const launchDir = opts.launchDir ?? process.cwd();
+
+  if (path.isAbsolute(file)) {
+    if (!runnable(file, platform) || isProjectExecutablePath(file, launchDir)) return undefined;
+    return canonical(file);
+  }
+  // A slash-bearing relative command is explicitly cwd-dependent. Mirafold's
+  // daemon-owned launches must either use an absolute file or a filtered name.
+  if (file.includes("/") || file.includes("\\")) return undefined;
+
+  const pathDirs = opts.includePath === false
+    ? []
+    : (env.PATH ?? "").split(path.delimiter).filter(Boolean);
+  const dirs = [...(opts.directories ?? []), ...pathDirs];
+  const seen = new Set<string>();
+  for (const rawDir of dirs) {
+    // Relative and empty PATH entries mean the current project directory.
+    if (!path.isAbsolute(rawDir)) continue;
+    const dir = canonical(rawDir);
+    if (seen.has(dir) || isProjectExecutablePath(dir, launchDir)) continue;
+    seen.add(dir);
+    for (const name of namesFor(file, platform, env)) {
+      const candidate = path.join(dir, name);
+      if (!runnable(candidate, platform) || isProjectExecutablePath(candidate, launchDir)) continue;
+      return canonical(candidate);
+    }
+  }
+  return undefined;
+}

--- a/server/sessions/folder-picker-handler.ts
+++ b/server/sessions/folder-picker-handler.ts
@@ -8,6 +8,7 @@ import { pickHostDirectory, type PickHostDirectory } from "../folder-picker";
 import { CLIENT_ID_RE } from "./fs-handlers";
 
 type PickFolder = Extract<ClientMsg, { type: "pick_folder" }>;
+type FolderPicked = Extract<WireMsg, { type: "folder_picked" }>;
 
 export type FolderPickerHandler = {
   pick: (msg: PickFolder) => void;
@@ -23,31 +24,28 @@ export function createFolderPickerHandler(opts: {
   const pickDirectory = opts.pickDirectory ?? pickHostDirectory;
   let active: AbortController | null = null;
 
-  const reply = (msg: Extract<WireMsg, { type: "folder_picked" }>) => {
+  const reply = (msg: FolderPicked) => {
     if (!opts.isClosed()) opts.viewport(msg);
+  };
+  const replyError = (id: string, error: string) => {
+    reply({ type: "folder_picked", id, error });
   };
 
   const pick = (msg: PickFolder): void => {
     if (typeof msg.id !== "string" || !CLIENT_ID_RE.test(msg.id)) return;
     if (opts.remote) {
-      reply({
-        type: "folder_picked",
-        id: msg.id,
-        error:
-          "Folder browsing is available only on the computer running Mirafold. Type a path on that computer instead.",
-      });
+      replyError(
+        msg.id,
+        "Folder browsing is available only on the computer running Mirafold. Type a path on that computer instead.",
+      );
       return;
     }
     if (typeof msg.cwd === "string" && msg.cwd.length > 4_096) {
-      reply({ type: "folder_picked", id: msg.id, error: "The working-directory path is too long." });
+      replyError(msg.id, "The working-directory path is too long.");
       return;
     }
     if (active) {
-      reply({
-        type: "folder_picked",
-        id: msg.id,
-        error: "A folder picker is already open. Choose a folder or cancel it first.",
-      });
+      replyError(msg.id, "A folder picker is already open. Choose a folder or cancel it first.");
       return;
     }
 
@@ -63,7 +61,7 @@ export function createFolderPickerHandler(opts: {
       })
       .catch((err) => {
         if (controller.signal.aborted) return;
-        reply({ type: "folder_picked", id: msg.id, error: errText(err) });
+        replyError(msg.id, errText(err));
       })
       .finally(() => {
         if (active === controller) active = null;

--- a/server/sessions/fs-explorer.itest.ts
+++ b/server/sessions/fs-explorer.itest.ts
@@ -245,12 +245,17 @@ test("E2.1: an fs_listdir burst drains the token bucket but is ANSWERED — and 
   for (let i = 0; i < N; i++) c.send({ type: "fs_listdir", id: `q${i}`, path: "" } as ClientMsg);
   const replies: Any[] = [];
   for (let i = 0; i < N; i++) {
-    replies.push(
-      (await c.waitFor((m) => m.type === "fs_dir" && (m as Any).id === `q${i}`, `fs_dir q${i}`)) as Any,
-    );
+    replies.push((await c.type("fs_dir")) as Any);
   }
-  assert.equal(replies[0].error, undefined, "the burst's first request is served");
-  const refused = replies.filter((m) => typeof m.error === "string");
+  const byId = new Map<string, Any>(replies.map((m) => [m.id, m]));
+  assert.deepEqual(
+    [...byId.keys()].sort(),
+    Array.from({ length: N }, (_, i) => `q${i}`),
+    "one correlated reply per burst request",
+  );
+  const ordered = Array.from({ length: N }, (_, i) => byId.get(`q${i}`)!);
+  assert.equal(ordered[0].error, undefined, "the burst's first request is served");
+  const refused = ordered.filter((m) => typeof m.error === "string");
   assert.ok(refused.length >= 1, "a same-instant burst past the bucket is refused, never silently dropped");
   assert.ok(refused.every((m) => /too fast/.test(String(m.error))));
   await settle(1_000); // one full refill window

--- a/server/sessions/git.test.ts
+++ b/server/sessions/git.test.ts
@@ -1,6 +1,6 @@
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { cleanRelPath, decorateGitDir, findRepoRoot, parseStatusIgnoredZ, parseStatusZ } from "./git";
@@ -165,6 +165,11 @@ test("decorateGitDir: a nested dir keys repo-root-relative — same names, diffe
 test("findRepoRoot: nearest .git wins; no .git anywhere is null", () => {
   const base = mkdtempSync(path.join(os.tmpdir(), "gitfind-"));
   after(() => rmSync(base, { recursive: true, force: true }));
+  // The host running the suite may itself have an ancestor marker (for
+  // example a sandbox-owned /tmp/.git). This probe keeps the fixture's
+  // filesystem real while making its declared root the test boundary.
+  const fixtureExists = (candidate: string) =>
+    candidate.startsWith(`${base}${path.sep}`) && existsSync(candidate);
   mkdirSync(path.join(base, "outer", ".git"), { recursive: true });
   mkdirSync(path.join(base, "outer", "src", "deep"), { recursive: true });
   mkdirSync(path.join(base, "outer", "inner", ".git"), { recursive: true });
@@ -172,13 +177,20 @@ test("findRepoRoot: nearest .git wins; no .git anywhere is null", () => {
   mkdirSync(path.join(base, "plain", "sub"), { recursive: true });
   const outer = path.join(base, "outer");
   const inner = path.join(outer, "inner");
-  assert.equal(findRepoRoot(outer), outer);
-  assert.equal(findRepoRoot(path.join(outer, "src", "deep")), outer);
-  assert.equal(findRepoRoot(inner), inner, "a repo nested in a repo resolves to ITS OWN root");
-  assert.equal(findRepoRoot(path.join(inner, "lib")), inner);
-  assert.equal(findRepoRoot(path.join(base, "plain", "sub")), null);
+  assert.equal(findRepoRoot(outer, fixtureExists), outer);
+  assert.equal(findRepoRoot(path.join(outer, "src", "deep"), fixtureExists), outer);
+  assert.equal(
+    findRepoRoot(inner, fixtureExists),
+    inner,
+    "a repo nested in a repo resolves to ITS OWN root",
+  );
+  assert.equal(findRepoRoot(path.join(inner, "lib"), fixtureExists), inner);
+  assert.equal(findRepoRoot(path.join(base, "plain", "sub"), fixtureExists), null);
   // A .git FILE (worktree/submodule form) marks a boundary too.
   mkdirSync(path.join(base, "worktree"));
   writeFileSync(path.join(base, "worktree", ".git"), "gitdir: /elsewhere\n");
-  assert.equal(findRepoRoot(path.join(base, "worktree")), path.join(base, "worktree"));
+  assert.equal(
+    findRepoRoot(path.join(base, "worktree"), fixtureExists),
+    path.join(base, "worktree"),
+  );
 });

--- a/server/sessions/git.ts
+++ b/server/sessions/git.ts
@@ -229,10 +229,13 @@ const gitErr = (op: string, r: { code: number | null; stderr: string }): string 
  * rooted at a SUBDIRECTORY of a repo (the Phase E trap) finds its repo
  * above the jail — same discovery rule git itself uses.
  */
-export const findRepoRoot = (realDir: string): string | null => {
+export const findRepoRoot = (
+  realDir: string,
+  entryExists: (candidate: string) => boolean = existsSync,
+): string | null => {
   let dir = realDir;
   for (;;) {
-    if (existsSync(path.join(dir, ".git"))) return dir;
+    if (entryExists(path.join(dir, ".git"))) return dir;
     const parent = path.dirname(dir);
     if (parent === dir) return null;
     dir = parent;

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -2433,35 +2433,41 @@ test("W.2: the live tree — a write behind the UI's back appears with zero clic
 });
 
 test("a notice in the engine's own words is badged; the shell's own words aren't", async () => {
-  await page.locator("textarea").click();
-  await page.keyboard.type("show me a notice");
-  await page.keyboard.press("Enter");
-  await page.waitForSelector(".notice-line[data-source]", { timeout: 15_000 });
+  // Own the session whose output is under test. The shared page has just
+  // navigated through two Explorer fixtures; under runner load its attach /
+  // replay can still be settling when this prompt is typed, so a timeout can
+  // happen before the notice path runs and say nothing about attribution.
+  await withFreshMockSession("e2e-notice-attribution-9c2f", async (page2) => {
+    await page2.waitForSelector("textarea");
+    await page2.locator("textarea").fill("show me a notice");
+    await page2.keyboard.press("Enter");
+    await page2.waitForSelector(".notice-line[data-source]", { timeout: 15_000 });
 
-  // The engine's line carries its name and no shell glyph…
-  const engine = page.locator(".notice-line[data-source]").last();
-  assert.equal(await engine.getAttribute("data-source"), "mock-engine");
-  assert.equal(await engine.locator(".notice-source").innerText(), "mock-engine");
-  assert.equal(await engine.locator(".notice-glyph").count(), 0);
-  assert.match(await engine.innerText(), /re-enter your API key/);
+    // The engine's line carries its name and no shell glyph…
+    const engine = page2.locator(".notice-line[data-source]").last();
+    assert.equal(await engine.getAttribute("data-source"), "mock-engine");
+    assert.equal(await engine.locator(".notice-source").innerText(), "mock-engine");
+    assert.equal(await engine.locator(".notice-glyph").count(), 0);
+    assert.match(await engine.innerText(), /re-enter your API key/);
 
-  // …and Mirafold's own line carries the glyph and no badge, so the two can't
-  // be confused: an engine string can't render as the shell speaking (2026-07-20).
-  const shell = page
-    .locator(".notice-line:not([data-source])")
-    .filter({ hasText: "context compacted" })
-    .last();
-  assert.equal(await shell.locator(".notice-source").count(), 0);
-  assert.equal(await shell.locator(".notice-glyph").count(), 1);
-  // The difference is visible, not just structural.
-  assert.equal(
-    await engine.evaluate((el) => getComputedStyle(el).borderLeftStyle),
-    "dashed",
-  );
-  assert.equal(
-    await shell.evaluate((el) => getComputedStyle(el).borderLeftStyle),
-    "solid",
-  );
+    // …and Mirafold's own line carries the glyph and no badge, so the two can't
+    // be confused: an engine string can't render as the shell speaking (2026-07-20).
+    const shell = page2
+      .locator(".notice-line:not([data-source])")
+      .filter({ hasText: "context compacted" })
+      .last();
+    assert.equal(await shell.locator(".notice-source").count(), 0);
+    assert.equal(await shell.locator(".notice-glyph").count(), 1);
+    // The difference is visible, not just structural.
+    assert.equal(
+      await engine.evaluate((el) => getComputedStyle(el).borderLeftStyle),
+      "dashed",
+    );
+    assert.equal(
+      await shell.evaluate((el) => getComputedStyle(el).borderLeftStyle),
+      "solid",
+    );
+  });
 });
 
 // C.2 — the automated Phase-A regression guard; assertAxeClean (scope, tags,

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -51,6 +51,76 @@ const installFsRecorder = (p: Page) =>
 const fsSent = (p: Page) =>
   p.evaluate(() => (window as unknown as { __fsSent: { type: string; path?: string }[] }).__fsSent);
 
+type FolderPickerStubWindow = Window & {
+  __pickerSocket?: WebSocket;
+  __pickerAgents?: Record<string, unknown>;
+  __pickerChoice?: string;
+};
+
+// The operating-system service has injected-process coverage in Tier 1. This
+// stub keeps the browser proof on the real SocketClient -> Onboarding path
+// while replacing only the native dialog's correlated reply.
+const installFolderPickerWireStub = (p: Page) =>
+  p.addInitScript(() => {
+    const w = window as FolderPickerStubWindow;
+    const NativeWebSocket = window.WebSocket;
+    const nativeSend = NativeWebSocket.prototype.send;
+
+    window.WebSocket = new Proxy(NativeWebSocket, {
+      construct(Target, args) {
+        const socket = Reflect.construct(Target, args) as WebSocket;
+        w.__pickerSocket = socket;
+        socket.addEventListener("message", (event) => {
+          try {
+            const message = JSON.parse(String(event.data)) as Record<string, unknown>;
+            if (message.type === "agents") w.__pickerAgents = message;
+          } catch {
+            // Non-JSON frames are unrelated to this local plain-wire test.
+          }
+        });
+        return socket;
+      },
+    }) as typeof WebSocket;
+
+    NativeWebSocket.prototype.send = function (data: Parameters<WebSocket["send"]>[0]) {
+      try {
+        const message = JSON.parse(String(data)) as { type?: string; id?: string };
+        if (message.type === "pick_folder" && message.id && w.__pickerChoice) {
+          queueMicrotask(() =>
+            this.dispatchEvent(
+              new MessageEvent("message", {
+                data: JSON.stringify({
+                  type: "folder_picked",
+                  id: message.id,
+                  path: w.__pickerChoice,
+                }),
+              }),
+            ),
+          );
+          return;
+        }
+      } catch {
+        // Preserve every ordinary frame unchanged.
+      }
+      nativeSend.call(this, data);
+    };
+  });
+
+async function advertiseStubbedFolderPicker(p: Page, choice: string): Promise<void> {
+  await p.waitForFunction(
+    () => Boolean((window as FolderPickerStubWindow).__pickerAgents),
+  );
+  await p.evaluate((selected) => {
+    const w = window as FolderPickerStubWindow;
+    w.__pickerChoice = selected;
+    w.__pickerSocket!.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({ ...w.__pickerAgents, folderPicker: true }),
+      }),
+    );
+  }, choice);
+}
+
 before(async () => {
   // MIRAFOLD_DEBUG makes the registry log every WireMsg it broadcasts, per
   // session (registry.ts). That is the SERVER's half of the flake-watch
@@ -159,30 +229,87 @@ test("the agent picker flexes to the window — no internal scrollbar through th
 });
 
 test(
-  "N2: replacing a rejected cwd clears its stale error and creates there",
+  "N2: a picked long cwd keeps its leaf visible, remains editable, and creates there",
   async () => {
     const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-folder-picker-e2e-"));
-    const picked = path.join(fixture, "picked project");
+    const picked = path.join(
+      fixture,
+      "a deliberately long parent directory",
+      "picked leaf project",
+    );
     const missing = path.join(fixture, "does not exist");
-    mkdirSync(picked);
+    mkdirSync(picked, { recursive: true });
     const token = "e2e-folder-picker-9c2f";
     const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
     const page2 = await browser.newPage();
     try {
+      await installFolderPickerWireStub(page2);
       await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
       await page2.setViewportSize({ width: 390, height: 844 });
       await noSideScroll(page2);
       await assertAxeClean(page2, "onboarding working directory");
 
+      await advertiseStubbedFolderPicker(page2, picked);
+
+      const cwdInput = page2.locator("#onb-cwd");
+      await page2.locator(".onb-cwd-browse").click();
+      await page2.waitForFunction(
+        (expected) =>
+          (document.querySelector("#onb-cwd") as HTMLInputElement | null)?.value === expected,
+        picked,
+      );
+      const chosenView = await cwdInput.evaluate((element) => {
+        const input = element as HTMLInputElement;
+        return {
+          value: input.value,
+          left: input.scrollLeft,
+          max: input.scrollWidth - input.clientWidth,
+          focused: document.activeElement === input,
+        };
+      });
+      assert.equal(chosenView.value, picked, "leaf reveal must not shorten the actual cwd");
+      assert.ok(chosenView.max > 40, `fixture did not overflow the input (${chosenView.max}px)`);
+      assert.equal(chosenView.focused, false, "browse button should retain focus after the pick");
+      assert.ok(
+        chosenView.left >= chosenView.max - 1,
+        `picked cwd showed its root (scrollLeft ${chosenView.left}px of ${chosenView.max}px)`,
+      );
+
+      // Focusing restores ordinary caret control: editing at the root must
+      // not be dragged back to the leaf by the controlled-state update.
+      await cwdInput.focus();
+      await page2.keyboard.press("Home");
+      await page2.keyboard.type("x");
+      const editingView = await cwdInput.evaluate((element) => {
+        const input = element as HTMLInputElement;
+        return { value: input.value, left: input.scrollLeft, caret: input.selectionStart };
+      });
+      assert.equal(editingView.value, `x${picked}`);
+      assert.equal(editingView.caret, 1);
+      assert.ok(
+        editingView.left <= 1,
+        `active root edit was forced ${editingView.left}px to the leaf`,
+      );
+
+      await cwdInput.evaluate((element) => (element as HTMLInputElement).blur());
+      const blurredView = await cwdInput.evaluate((element) => {
+        const input = element as HTMLInputElement;
+        return { left: input.scrollLeft, max: input.scrollWidth - input.clientWidth };
+      });
+      assert.ok(
+        blurredView.left >= blurredView.max - 1,
+        `blurred cwd did not return to its leaf (${blurredView.left}px of ${blurredView.max}px)`,
+      );
+
       // A rejected cwd belongs to the value that was submitted. Replacing the
       // value must remove that stale error before the user retries creation.
-      await page2.locator("#onb-cwd").fill(missing);
+      await cwdInput.fill(missing);
       await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
       await page2.waitForSelector(".onb-error");
       assert.match(await page2.locator(".onb-error").innerText(), /no such directory/i);
 
-      await page2.locator("#onb-cwd").fill(picked);
-      assert.equal(await page2.locator("#onb-cwd").inputValue(), picked);
+      await cwdInput.fill(picked);
+      assert.equal(await cwdInput.inputValue(), picked);
       await page2.locator(".onb-error").waitFor({ state: "detached" });
 
       await page2.setViewportSize({ width: 1100, height: 800 });

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1,6 +1,6 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { type Browser, type Page } from "playwright-core";
@@ -65,6 +65,27 @@ after(async () => {
   await browser?.close();
   await d?.stop();
 });
+
+async function withFreshMockSession(
+  token: string,
+  run: (isolatedPage: Page) => Promise<void>,
+): Promise<void> {
+  const daemon = await startDaemon({ MIRAFOLD_TOKEN: token });
+  let isolatedPage: Page | undefined;
+  try {
+    isolatedPage = await browser.newPage();
+    await isolatedPage.goto(`http://127.0.0.1:${daemon.port}/?token=${token}`);
+    await isolatedPage.locator(".onb-agent", { hasText: "Claude Code" }).click();
+    await isolatedPage.waitForURL(/\/s\/[\w-]+/);
+    await run(isolatedPage);
+  } finally {
+    try {
+      await isolatedPage?.close();
+    } finally {
+      await daemon.stop();
+    }
+  }
+}
 
 test("no token → 403, nothing served", async () => {
   const lockedOut = await browser.newPage();
@@ -138,45 +159,31 @@ test("the agent picker flexes to the window — no internal scrollbar through th
 });
 
 test(
-  "N2: browse opens the host picker, fills cwd, and creates the session there",
-  { skip: process.platform !== "linux" && "the harmless Zenity fixture is Linux-specific" },
+  "N2: replacing a rejected cwd clears its stale error and creates there",
   async () => {
-    // Substitute Zenity at the ordinary PATH seam: production still invokes
-    // the real platform helper, while this child prints one known directory
-    // and opens no GUI. The browser + daemon + WebSocket path remain real.
     const fixture = mkdtempSync(path.join(os.tmpdir(), "mirafold-folder-picker-e2e-"));
     const picked = path.join(fixture, "picked project");
-    const zenity = path.join(fixture, "zenity");
+    const missing = path.join(fixture, "does not exist");
     mkdirSync(picked);
-    writeFileSync(
-      zenity,
-      `#!/usr/bin/env node\n` +
-        `if ("OPENAI_API_KEY" in process.env || "MIRAFOLD_TEST_PICKER_SECRET" in process.env) process.exit(9);\n` +
-        `process.stdout.write(${JSON.stringify(picked)});\n`,
-    );
-    chmodSync(zenity, 0o755);
     const token = "e2e-folder-picker-9c2f";
-    const d2 = await startDaemon({
-      MIRAFOLD_TOKEN: token,
-      MIRAFOLD_TEST_PICKER_SECRET: "must-not-cross",
-      DISPLAY: ":99",
-      PATH: `${fixture}${path.delimiter}${process.env.PATH ?? ""}`,
-    });
+    const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
     const page2 = await browser.newPage();
     try {
       await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
-      await page2.waitForSelector(".onb-cwd-browse");
       await page2.setViewportSize({ width: 390, height: 844 });
       await noSideScroll(page2);
-      await assertAxeClean(page2, "onboarding folder picker");
+      await assertAxeClean(page2, "onboarding working directory");
 
-      await page2.locator(".onb-cwd-browse").click();
-      await page2.waitForFunction(
-        (expected) =>
-          (document.querySelector("#onb-cwd") as HTMLInputElement | null)?.value === expected,
-        picked,
-      );
+      // A rejected cwd belongs to the value that was submitted. Replacing the
+      // value must remove that stale error before the user retries creation.
+      await page2.locator("#onb-cwd").fill(missing);
+      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
+      await page2.waitForSelector(".onb-error");
+      assert.match(await page2.locator(".onb-error").innerText(), /no such directory/i);
+
+      await page2.locator("#onb-cwd").fill(picked);
       assert.equal(await page2.locator("#onb-cwd").inputValue(), picked);
+      await page2.locator(".onb-error").waitFor({ state: "detached" });
 
       await page2.setViewportSize({ width: 1100, height: 800 });
       await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
@@ -453,44 +460,32 @@ test("diagram component: mermaid renders as SVG inside the sandbox; broken sourc
   // Own a session so this test reaches the renderer or fails for a renderer
   // reason; the actual lazy chunk, iframe, CSP, postMessage, and parse error
   // paths below remain production-real.
-  const token = "e2e-diagram-9c2f";
-  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
-  try {
-    const page2 = await browser.newPage();
-    try {
-      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
-      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
-      await page2.waitForURL(/\/s\/[\w-]+/);
-      await page2.waitForSelector("textarea");
-      await page2.locator("textarea").fill("diagram demo");
-      await page2.keyboard.press("Enter");
+  await withFreshMockSession("e2e-diagram-9c2f", async (page2) => {
+    await page2.waitForSelector("textarea");
+    await page2.locator("textarea").fill("diagram demo");
+    await page2.keyboard.press("Enter");
 
-      const block = page2.locator(".rc-diagram", { hasText: "Relay pairing flow" });
-      await block.waitFor({ timeout: 20_000 });
-      // The runtime is a lazy ~3.6 MB chunk — give the first render room.
-      const frame = block.locator("iframe.rc-diagram-frame");
-      await frame.waitFor({ timeout: 20_000 });
-      const svg = page2
-        .frameLocator(".rc-diagram:has-text('Relay pairing flow') iframe")
-        .locator("#host svg");
-      await svg.waitFor({ timeout: 20_000 });
-      // The frame reported its measured height back — the host sized to fit.
-      const h = await frame.evaluate((el) => el.getBoundingClientRect().height);
-      assert.ok(h > 130, `frame did not grow to the diagram (h=${h})`);
-      // The shell-drawn chrome badges the sandbox, outside the frame.
-      assert.match(await block.locator(".rc-diagram-badge").innerText(), /sandboxed/);
+    const block = page2.locator(".rc-diagram", { hasText: "Relay pairing flow" });
+    await block.waitFor({ timeout: 20_000 });
+    // The runtime is a lazy ~3.6 MB chunk — give the first render room.
+    const frame = block.locator("iframe.rc-diagram-frame");
+    await frame.waitFor({ timeout: 20_000 });
+    const svg = page2
+      .frameLocator(".rc-diagram:has-text('Relay pairing flow') iframe")
+      .locator("#host svg");
+    await svg.waitFor({ timeout: 20_000 });
+    // The frame reported its measured height back — the host sized to fit.
+    const h = await frame.evaluate((el) => el.getBoundingClientRect().height);
+    assert.ok(h > 130, `frame did not grow to the diagram (h=${h})`);
+    // The shell-drawn chrome badges the sandbox, outside the frame.
+    assert.match(await block.locator(".rc-diagram-badge").innerText(), /sandboxed/);
 
-      // Broken source: the failure state carries the message AND the source text.
-      const failed = page2.locator(".rc-diagram-failed", { hasText: "broken diagram" });
-      await failed.waitFor({ timeout: 20_000 });
-      assert.match(await failed.innerText(), /diagram didn't render/);
-      assert.ok((await failed.locator(".rc-diagram-source").innerText()).includes("nope"));
-    } finally {
-      await page2.close();
-    }
-  } finally {
-    await d2.stop();
-  }
+    // Broken source: the failure state carries the message AND the source text.
+    const failed = page2.locator(".rc-diagram-failed", { hasText: "broken diagram" });
+    await failed.waitFor({ timeout: 20_000 });
+    assert.match(await failed.innerText(), /diagram didn't render/);
+    assert.ok((await failed.locator(".rc-diagram-source").innerText()).includes("nope"));
+  });
 });
 
 test("image component: a resolved shot renders as a real <img>; a refused one says why", async () => {
@@ -1365,185 +1360,274 @@ test("streaming holds a scrolled-up reader in place, and re-follows once back at
   // version borrowed 40 prior tests' worth of content, then jumped to the
   // bottom programmatically and sampled once; neither is a user's re-arm
   // path, and the delayed scroll event raced the next streamed paint.
-  const token = "e2e-follow-tail-9c2f";
-  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
-  try {
-    const page2 = await browser.newPage();
-    try {
-      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
-      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
-      await page2.waitForURL(/\/s\/[\w-]+/);
-      await page2.setViewportSize({ width: 900, height: 520 });
-      await page2.waitForSelector("textarea");
+  await withFreshMockSession("e2e-follow-tail-9c2f", async (page2) => {
+    await page2.setViewportSize({ width: 900, height: 520 });
+    await page2.waitForSelector("textarea");
 
-      const zone = page2.locator(".render-zone");
-      const geom = () =>
-        zone.evaluate((el) => ({ top: el.scrollTop, h: el.scrollHeight, view: el.clientHeight }));
-      const sendPlan = async () => {
-        const before = await page2.locator(".turn-user", { hasText: "plan it step by step" }).count();
-        await page2.locator("textarea").fill("plan it step by step");
-        await page2.keyboard.press("Enter");
-        await page2.waitForFunction(
-          (n) =>
-            [...document.querySelectorAll(".turn-user")].filter((el) =>
-              el.textContent?.includes("plan it step by step"),
-            ).length > n,
-          before,
-          { timeout: 15_000 },
-        );
-      };
-
-      // Two completed turns supply deterministic scrollback; the next is the
-      // live stream under test. One turn measured only 28px taller than this
-      // fixed viewport, too little for a meaningful 100px upward-wheel proof.
-      for (let i = 0; i < 2; i++) {
-        const completeBefore = await page2
-          .locator(".turn-assistant", { hasText: "Plan complete — all four steps done." })
-          .count();
-        await sendPlan();
-        await page2.waitForFunction(
-          (n) =>
-            [...document.querySelectorAll(".turn-assistant")].filter((el) =>
-              el.textContent?.includes("Plan complete — all four steps done."),
-            ).length > n,
-          completeBefore,
-          { timeout: 30_000 },
-        );
-        await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
-          timeout: 15_000,
-        });
-      }
-      const seeded = await geom();
-      assert.ok(
-        seeded.h - seeded.view > 300,
-        `seed turn did not make scrollback (content ${seeded.h}px, viewport ${seeded.view}px)`,
+    const zone = page2.locator(".render-zone");
+    const geom = () =>
+      zone.evaluate((el) => ({ top: el.scrollTop, h: el.scrollHeight, view: el.clientHeight }));
+    const sendPlan = async () => {
+      const before = await page2.locator(".turn-user", { hasText: "plan it step by step" }).count();
+      await page2.locator("textarea").fill("plan it step by step");
+      await page2.keyboard.press("Enter");
+      await page2.waitForFunction(
+        (n) =>
+          [...document.querySelectorAll(".turn-user")].filter((el) =>
+            el.textContent?.includes("plan it step by step"),
+          ).length > n,
+        before,
+        { timeout: 15_000 },
       );
+    };
 
-      const todoBefore = await page2.locator(".rc-todos").count();
-      const finalBefore = await page2
+    // Two completed turns supply deterministic scrollback; the next is the
+    // live stream under test. One turn measured only 28px taller than this
+    // fixed viewport, too little for a meaningful 100px upward-wheel proof.
+    for (let i = 0; i < 2; i++) {
+      const completeBefore = await page2
         .locator(".turn-assistant", { hasText: "Plan complete — all four steps done." })
         .count();
       await sendPlan();
-      await page2.waitForFunction(
-        (n) => document.querySelectorAll(".rc-todos").length > n,
-        todoBefore,
-        { timeout: 15_000 },
-      );
-
-      // A real wheel up over the transcript: the reader is steering into
-      // scrollback while the agent is still producing output.
-      await zone.hover();
-      const atWheel = await geom();
-      await page2.mouse.wheel(0, -1_000);
-      await page2.waitForFunction(
-        ({ top }) => {
-          const el = document.querySelector(".render-zone");
-          return Boolean(
-            el &&
-              el.scrollTop < top - 100 &&
-              el.scrollHeight - el.scrollTop - el.clientHeight > 200,
-          );
-        },
-        atWheel,
-        { timeout: 5_000 },
-      );
-      const before = await geom();
-
-      // New output must grow below without moving the scrolled-up reader.
-      await page2.waitForFunction(
-        ({ top, h }) => {
-          const el = document.querySelector(".render-zone");
-          return Boolean(el && el.scrollHeight > h && Math.abs(el.scrollTop - top) <= 1);
-        },
-        before,
-        { timeout: 5_000 },
-      );
-
-      // Let that timed turn finish, then use a permission request as a latch
-      // for the re-arm half. Sending the request legitimately returns to the
-      // tail; scroll up once more while the engine is guaranteed to remain
-      // busy until this test answers.
       await page2.waitForFunction(
         (n) =>
           [...document.querySelectorAll(".turn-assistant")].filter((el) =>
             el.textContent?.includes("Plan complete — all four steps done."),
           ).length > n,
-        finalBefore,
+        completeBefore,
         { timeout: 30_000 },
       );
       await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
         timeout: 15_000,
       });
-      await page2.locator("textarea").fill("run something dangerous");
+    }
+    const seeded = await geom();
+    assert.ok(
+      seeded.h - seeded.view > 300,
+      `seed turn did not make scrollback (content ${seeded.h}px, viewport ${seeded.view}px)`,
+    );
+
+    const todoBefore = await page2.locator(".rc-todos").count();
+    const finalBefore = await page2
+      .locator(".turn-assistant", { hasText: "Plan complete — all four steps done." })
+      .count();
+    await sendPlan();
+    await page2.waitForFunction(
+      (n) => document.querySelectorAll(".rc-todos").length > n,
+      todoBefore,
+      { timeout: 15_000 },
+    );
+
+    // A real wheel up over the transcript: the reader is steering into
+    // scrollback while the agent is still producing output.
+    await zone.hover();
+    const atWheel = await geom();
+    await page2.mouse.wheel(0, -1_000);
+    await page2.waitForFunction(
+      ({ top }) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            el.scrollTop < top - 100 &&
+            el.scrollHeight - el.scrollTop - el.clientHeight > 200,
+        );
+      },
+      atWheel,
+      { timeout: 5_000 },
+    );
+    const before = await geom();
+
+    // New output must grow below without moving the scrolled-up reader.
+    await page2.waitForFunction(
+      ({ top, h }) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(el && el.scrollHeight > h && Math.abs(el.scrollTop - top) <= 1);
+      },
+      before,
+      { timeout: 5_000 },
+    );
+
+    // Let that timed turn finish, then use a permission request as a latch
+    // for the re-arm half. Sending the request legitimately returns to the
+    // tail; scroll up once more while the engine is guaranteed to remain
+    // busy until this test answers.
+    await page2.waitForFunction(
+      (n) =>
+        [...document.querySelectorAll(".turn-assistant")].filter((el) =>
+          el.textContent?.includes("Plan complete — all four steps done."),
+        ).length > n,
+      finalBefore,
+      { timeout: 30_000 },
+    );
+    await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+      timeout: 15_000,
+    });
+    await page2.locator("textarea").fill("run something dangerous");
+    await page2.keyboard.press("Enter");
+    await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
+
+    await zone.hover();
+    const latchedAtWheel = await geom();
+    await page2.mouse.wheel(0, -1_000);
+    await page2.waitForFunction(
+      ({ top }) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            el.scrollTop < top - 100 &&
+            el.scrollHeight - el.scrollTop - el.clientHeight > 200,
+        );
+      },
+      latchedAtWheel,
+      { timeout: 5_000 },
+    );
+
+    // A real downward gesture that reaches the current tail arms from its
+    // pre-input geometry. The unanswered permission keeps the premise
+    // stable; no timer can end the turn between the gesture and assertion.
+    const beforeReturn = await geom();
+    await page2.mouse.wheel(0, beforeReturn.h + beforeReturn.view);
+    await page2.waitForFunction(
+      () => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            document.querySelector(".stop-btn") &&
+            document.querySelector(".perm-bar") &&
+            el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
+        );
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+    const rearmed = await geom();
+
+    // Allowing resolves the latch and starts tool/output frames without a
+    // new user prompt (which would arm following independently). Do not
+    // merely prove one scroll landed: that later content must carry the
+    // viewport with it.
+    await page2.locator(".perm-allow").click();
+    await page2.waitForFunction(
+      (h) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            el.scrollHeight > h &&
+            el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
+        );
+      },
+      rearmed.h,
+      { timeout: 5_000 },
+    );
+    await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+      timeout: 15_000,
+    });
+    await page2.waitForFunction(() => {
+      const el = document.querySelector(".render-zone");
+      return Boolean(el && el.scrollHeight - el.scrollTop - el.clientHeight <= 60);
+    });
+  });
+});
+
+test("an overflowing prose transcript supports keyboard scrolling and End re-arms following", async () => {
+  await withFreshMockSession("e2e-transcript-keyboard-9c2f", async (page2) => {
+    await page2.setViewportSize({ width: 900, height: 520 });
+    await page2.waitForSelector("textarea");
+    const zone = page2.locator(".render-zone");
+    const geom = () =>
+      zone.evaluate((el) => ({ top: el.scrollTop, h: el.scrollHeight, view: el.clientHeight }));
+
+    // Make deterministic overflow out of inert prose only. With no link or
+    // button inside the log, the scroller itself is the keyboard access path
+    // axe's scrollable-region-focusable rule requires.
+    for (let i = 0; i < 8; i++) {
+      const before = await page2.locator(".notice-line[data-source]").count();
+      await page2.locator("textarea").fill(`notice attribution ${i}`);
       await page2.keyboard.press("Enter");
-      await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
-
-      await zone.hover();
-      const latchedAtWheel = await geom();
-      await page2.mouse.wheel(0, -1_000);
       await page2.waitForFunction(
-        ({ top }) => {
-          const el = document.querySelector(".render-zone");
-          return Boolean(
-            el &&
-              el.scrollTop < top - 100 &&
-              el.scrollHeight - el.scrollTop - el.clientHeight > 200,
-          );
-        },
-        latchedAtWheel,
-        { timeout: 5_000 },
-      );
-
-      // A real downward gesture that reaches the current tail arms from its
-      // pre-input geometry. The unanswered permission keeps the premise
-      // stable; no timer can end the turn between the gesture and assertion.
-      const beforeReturn = await geom();
-      await page2.mouse.wheel(0, beforeReturn.h + beforeReturn.view);
-      await page2.waitForFunction(
-        () => {
-          const el = document.querySelector(".render-zone");
-          return Boolean(
-            el &&
-              document.querySelector(".stop-btn") &&
-              document.querySelector(".perm-bar") &&
-              el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
-          );
-        },
-        undefined,
-        { timeout: 5_000 },
-      );
-      const rearmed = await geom();
-
-      // Allowing resolves the latch and starts tool/output frames without a
-      // new user prompt (which would arm following independently). Do not
-      // merely prove one scroll landed: that later content must carry the
-      // viewport with it.
-      await page2.locator(".perm-allow").click();
-      await page2.waitForFunction(
-        (h) => {
-          const el = document.querySelector(".render-zone");
-          return Boolean(
-            el &&
-              el.scrollHeight > h &&
-              el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
-          );
-        },
-        rearmed.h,
-        { timeout: 5_000 },
+        (n) => document.querySelectorAll(".notice-line[data-source]").length > n,
+        before,
+        { timeout: 15_000 },
       );
       await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
         timeout: 15_000,
       });
-      await page2.waitForFunction(() => {
+    }
+    const seeded = await geom();
+    assert.ok(
+      seeded.h - seeded.view > 300,
+      `notice turns did not make scrollback (content ${seeded.h}px, viewport ${seeded.view}px)`,
+    );
+    assert.equal(await zone.getAttribute("tabindex"), "0");
+    assert.equal(
+      await zone.locator("a, button, input, select, textarea, [tabindex]").count(),
+      0,
+      "fixture unexpectedly gained a focusable transcript descendant",
+    );
+    await assertAxeClean(page2, "overflowing prose-only transcript");
+
+    // Hold a turn open so output after End can prove follow-tail was re-armed,
+    // not just that the browser performed one isolated scroll.
+    await page2.locator("textarea").fill("run something dangerous");
+    await page2.keyboard.press("Enter");
+    await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
+
+    await zone.focus();
+    const focus = await zone.evaluate((el) => {
+      const style = getComputedStyle(el);
+      return {
+        active: document.activeElement === el,
+        visible: el.matches(":focus-visible"),
+        outline: style.outlineStyle,
+      };
+    });
+    assert.ok(focus.active, "transcript did not accept focus");
+    assert.ok(focus.visible, "transcript focus ring was not keyboard-visible");
+    assert.notEqual(focus.outline, "none", "transcript has no visible focus outline");
+
+    const atBottom = await geom();
+    await page2.keyboard.press("PageUp");
+    await page2.waitForFunction(
+      ({ top }) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            el.scrollTop < top - 100 &&
+            el.scrollHeight - el.scrollTop - el.clientHeight > 200,
+        );
+      },
+      atBottom,
+      { timeout: 5_000 },
+    );
+
+    await page2.keyboard.press("End");
+    await page2.waitForFunction(
+      () => {
         const el = document.querySelector(".render-zone");
         return Boolean(el && el.scrollHeight - el.scrollTop - el.clientHeight <= 60);
-      });
-    } finally {
-      await page2.close();
-    }
-  } finally {
-    await d2.stop();
-  }
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
+    const rearmed = await geom();
+
+    await page2.locator(".perm-allow").click();
+    await page2.waitForFunction(
+      (h) => {
+        const el = document.querySelector(".render-zone");
+        return Boolean(
+          el &&
+            el.scrollHeight > h &&
+            el.scrollHeight - el.scrollTop - el.clientHeight <= 60,
+        );
+      },
+      rearmed.h,
+      { timeout: 5_000 },
+    );
+    await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+      timeout: 15_000,
+    });
+  });
 });
 
 // The frame sampler's in-page globals (armed before the prompt, read after).
@@ -1572,92 +1656,80 @@ test("a busy turn never looks idle: the indicator is up, moving, and on screen w
   // correctly remove the line, and make textContent() wait 30 seconds for an
   // element that was supposed to stay gone. A permission request is the
   // mock's deterministic latch: the turn cannot end until this test answers.
-  const token = "e2e-busy-indicator-9c2f";
-  const d2 = await startDaemon({ MIRAFOLD_TOKEN: token });
-  try {
-    const page2 = await browser.newPage();
-    try {
-      await page2.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
-      await page2.locator(".onb-agent", { hasText: "Claude Code" }).click();
-      await page2.waitForURL(/\/s\/[\w-]+/);
-      await page2.waitForSelector("textarea");
+  await withFreshMockSession("e2e-busy-indicator-9c2f", async (page2) => {
+    await page2.waitForSelector("textarea");
 
-      // Frame-by-frame watcher, armed BEFORE the prompt goes out: any frame
-      // where the turn is in flight (stop button present) but no activity line
-      // is painted is the 2026-07-28 bug — work happening with nothing showing.
-      // It also counts glyph frame CHANGES: a present-but-frozen line is the
-      // 2026-07-29 bug. The callback stays anonymous because tsx's keepNames
-      // wrapper does not exist inside the page.
-      await page2.evaluate(() => {
-        const w = window as unknown as BusyWatch;
-        w.__busyFrames = 0;
-        w.__blankFrames = 0;
-        w.__glyphFlips = 0;
-        w.__lastGlyph = "";
-        w.__watch = window.setInterval(() => {
-          if (document.querySelector(".stop-btn")) {
-            w.__busyFrames++;
-            const glyph = document.querySelector(".activity-glyph")?.textContent;
-            if (glyph === undefined) w.__blankFrames++;
-            else if (glyph !== w.__lastGlyph) {
-              if (w.__lastGlyph !== "") w.__glyphFlips++;
-              w.__lastGlyph = glyph;
-            }
+    // Frame-by-frame watcher, armed BEFORE the prompt goes out: any frame
+    // where the turn is in flight (stop button present) but no activity line
+    // is painted is the 2026-07-28 bug — work happening with nothing showing.
+    // It also counts glyph frame CHANGES: a present-but-frozen line is the
+    // 2026-07-29 bug. The callback stays anonymous because tsx's keepNames
+    // wrapper does not exist inside the page.
+    await page2.evaluate(() => {
+      const w = window as unknown as BusyWatch;
+      w.__busyFrames = 0;
+      w.__blankFrames = 0;
+      w.__glyphFlips = 0;
+      w.__lastGlyph = "";
+      w.__watch = window.setInterval(() => {
+        if (document.querySelector(".stop-btn")) {
+          w.__busyFrames++;
+          const glyph = document.querySelector(".activity-glyph")?.textContent;
+          if (glyph === undefined) w.__blankFrames++;
+          else if (glyph !== w.__lastGlyph) {
+            if (w.__lastGlyph !== "") w.__glyphFlips++;
+            w.__lastGlyph = glyph;
           }
-        }, 16);
-      });
+        }
+      }, 16);
+    });
 
-      await page2.locator("textarea").fill("run something dangerous");
-      await page2.keyboard.press("Enter");
-      await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
-      // The permission bar holds the busy state open, so this waits for real
-      // movement rather than betting that a timed mock reply stays alive long
-      // enough for two browser round-trips.
-      await page2.waitForFunction(
-        () => (window as unknown as BusyWatch).__glyphFlips >= 3,
-        undefined,
-        { timeout: 5_000 },
-      );
+    await page2.locator("textarea").fill("run something dangerous");
+    await page2.keyboard.press("Enter");
+    await page2.waitForSelector(".perm-bar", { timeout: 15_000 });
+    // The permission bar holds the busy state open, so this waits for real
+    // movement rather than betting that a timed mock reply stays alive long
+    // enough for two browser round-trips.
+    await page2.waitForFunction(
+      () => (window as unknown as BusyWatch).__glyphFlips >= 3,
+      undefined,
+      { timeout: 5_000 },
+    );
 
-      // Scroll and snapshot in one page task while the latch is still held.
-      // The elapsed text and viewport placement cannot disappear between two
-      // Playwright calls now.
-      const held = await page2.evaluate(() => {
-        document.querySelector(".render-zone")!.scrollTop = 0;
-        const line = document.querySelector(".activity-line");
-        const r = line?.getBoundingClientRect();
-        return {
-          text: line?.textContent ?? "",
-          visible: Boolean(r && r.height > 0 && r.top >= 0 && r.bottom <= window.innerHeight),
-        };
-      });
-      assert.match(held.text, /\(\d+s\)/, "no elapsed counter in the activity line");
-      assert.ok(held.visible, "indicator off screen while the transcript is scrolled up");
+    // Scroll and snapshot in one page task while the latch is still held.
+    // The elapsed text and viewport placement cannot disappear between two
+    // Playwright calls now.
+    const held = await page2.evaluate(() => {
+      document.querySelector(".render-zone")!.scrollTop = 0;
+      const line = document.querySelector(".activity-line");
+      const r = line?.getBoundingClientRect();
+      return {
+        text: line?.textContent ?? "",
+        visible: Boolean(r && r.height > 0 && r.top >= 0 && r.bottom <= window.innerHeight),
+      };
+    });
+    assert.match(held.text, /\(\d+s\)/, "no elapsed counter in the activity line");
+    assert.ok(held.visible, "indicator off screen while the transcript is scrolled up");
 
-      await page2.locator(".perm-deny").click();
-      await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
-        timeout: 15_000,
-      });
-      await page2.waitForSelector(".activity-line", { state: "detached", timeout: 5_000 });
-      const frames = await page2.evaluate(() => {
-        const w = window as unknown as BusyWatch;
-        window.clearInterval(w.__watch);
-        return { busy: w.__busyFrames, blank: w.__blankFrames, flips: w.__glyphFlips };
-      });
-      assert.ok(frames.busy > 0, "the sampler never saw the turn in flight");
-      assert.equal(
-        frames.blank,
-        0,
-        `${frames.blank} frame(s) had a turn in flight with no activity line painted`,
-      );
-      assert.ok(frames.flips >= 3, `the glyph moved only ${frames.flips} time(s) while held busy`);
-      assert.equal(await page2.locator(".activity-line").count(), 0);
-    } finally {
-      await page2.close();
-    }
-  } finally {
-    await d2.stop();
-  }
+    await page2.locator(".perm-deny").click();
+    await page2.waitForFunction(() => !document.querySelector(".stop-btn"), undefined, {
+      timeout: 15_000,
+    });
+    await page2.waitForSelector(".activity-line", { state: "detached", timeout: 5_000 });
+    const frames = await page2.evaluate(() => {
+      const w = window as unknown as BusyWatch;
+      window.clearInterval(w.__watch);
+      return { busy: w.__busyFrames, blank: w.__blankFrames, flips: w.__glyphFlips };
+    });
+    assert.ok(frames.busy > 0, "the sampler never saw the turn in flight");
+    assert.equal(
+      frames.blank,
+      0,
+      `${frames.blank} frame(s) had a turn in flight with no activity line painted`,
+    );
+    assert.ok(frames.flips >= 3, `the glyph moved only ${frames.flips} time(s) while held busy`);
+    assert.equal(await page2.locator(".activity-line").count(), 0);
+  });
 });
 
 // In-page globals for the queued-follow-up sampler below.

--- a/server/testing/launcher.e2e.ts
+++ b/server/testing/launcher.e2e.ts
@@ -15,89 +15,154 @@ import {
 import os from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  browserOpenCommand,
+  browserOpenEnvironment,
+  openBrowser,
+} from "../../bin/browser-open.js";
 import { SCRUBBED_CREDENTIAL_ENV } from "./itest-harness";
 
-// Tier-3 (`yarn test:e2e`, needs a fresh `yarn build`): the launcher's browser
-// open must never tie the browser to the user's terminal. If the opener were
-// spawned with inherited stdio and no browser is running yet, the opener
-// BECOMES the browser and chatters into that terminal for its whole lifetime
-// (Chrome's `[pid:pid:…] ERROR:…` / TensorFlow Lite lines — seen in user
-// testing 2026-07-10, from a Chrome launched outside Mirafold). So this
-// asserts the guarantee from inside the opener itself: a stub `xdg-open`
-// first on PATH records where its stdio really points and whether it was
-// detached into its own session.
+// Tier-3 (`yarn test:e2e`, needs a fresh `yarn build`): host browser opening
+// must use OS identity, never npm's project-local PATH; it also must not tie the
+// browser to the user's terminal or leak the daemon's credential environment.
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
 const LAUNCHER = path.join(ROOT, "bin", "mirafold.js");
 const DAEMON = path.join(ROOT, "dist-server", "index.js");
 
-// /proc + xdg-open: the guarantee is per-platform code in openBrowser; this
-// exercises the linux arm (the only one CI runs).
+// /proc: the process-state guarantee is exercised on Linux, the CI platform.
 const linuxOnly = { skip: process.platform !== "linux" };
 
-test("launcher opens the browser detached, stdio → /dev/null", linuxOnly, async () => {
-  assert.ok(existsSync(DAEMON), "dist-server missing — test:e2e must run `yarn build` first");
+test("launcher ignores project PATH when resolving host browser chrome", () => {
+  const inspected: string[] = [];
+  const fakePath = "/hostile/project/node_modules/.bin";
+  const url = "http://127.0.0.1:3000/?token=test";
+  const command = browserOpenCommand(
+    url,
+    "linux",
+    { PATH: fakePath },
+    (file) => {
+      inspected.push(file);
+      return file === "/usr/bin/xdg-open";
+    },
+  );
+  assert.deepEqual(command, {
+    file: "/usr/bin/xdg-open",
+    args: [url],
+  });
+  assert.ok(inspected.every((file) => path.isAbsolute(file)));
+  assert.ok(inspected.every((file) => !file.startsWith(fakePath)));
+  assert.deepEqual(browserOpenCommand(url, "darwin", { PATH: fakePath }, () => true), {
+    file: "/usr/bin/open",
+    args: [url],
+  });
+  assert.deepEqual(
+    browserOpenCommand(url, "win32", { PATH: fakePath, SystemRoot: "C:\\Windows" }, () => true),
+    {
+      file: "C:\\Windows\\System32\\cmd.exe",
+      args: ["/d", "/c", "start", "", url],
+    },
+  );
+  assert.equal(browserOpenCommand(url, "win32", { PATH: fakePath }, () => true), undefined);
+});
 
-  // cwd is a scratch dir: no .env, no sessions created — boot + open only.
-  const tmp = mkdtempSync(path.join(os.tmpdir(), "genui-launcher-"));
+test("browser opener is detached, neutral-cwd, and credential-scrubbed", linuxOnly, async () => {
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "genui-browser-open-"));
   const record = path.join(tmp, "opener-record");
-  // Vars captured BEFORE the redirect, which would remap fd1 for the block.
+  const opener = path.join(tmp, "trusted-test-opener");
   writeFileSync(
-    path.join(tmp, "xdg-open"),
-    `#!/usr/bin/env bash
+    opener,
+    `#!/bin/bash
 fd0=$(readlink /proc/$$/fd/0)
 fd1=$(readlink /proc/$$/fd/1)
 fd2=$(readlink /proc/$$/fd/2)
 sid=$(ps -o sid= -p $$ | tr -d " ")
-printf 'args=%s\\nfd0=%s\\nfd1=%s\\nfd2=%s\\npid=%s\\nsid=%s\\n' \\
-  "$*" "$fd0" "$fd1" "$fd2" "$$" "$sid" > "$MIRAFOLD_TEST_RECORD"
+if [[ -v OPENAI_API_KEY || -v MIRAFOLD_TEST_BROWSER_SECRET ]]; then secret=present; else secret=absent; fi
+printf 'args=%s\\nfd0=%s\\nfd1=%s\\nfd2=%s\\npid=%s\\nsid=%s\\nsecret=%s\\ncwd=%s\\n' \\
+  "$*" "$fd0" "$fd1" "$fd2" "$$" "$sid" "$secret" "$PWD" > ${JSON.stringify(record)}
 `,
   );
-  chmodSync(path.join(tmp, "xdg-open"), 0o755);
+  chmodSync(opener, 0o755);
+  const url = "http://127.0.0.1:3000/?token=browser-open-test";
+  openBrowser(url, {
+    platform: "linux",
+    env: {
+      ...process.env,
+      PATH: `${tmp}${path.delimiter}${process.env.PATH ?? ""}`,
+      OPENAI_API_KEY: "must-not-cross",
+      MIRAFOLD_TEST_BROWSER_SECRET: "must-not-cross",
+    },
+    command: { file: opener, args: [url] },
+  });
 
-  // detached: the launcher leads its own process group, so cleanup can kill
-  // the daemon it spawns (the launcher's exit alone would orphan it).
-  const child = spawn(process.execPath, [LAUNCHER], {
+  try {
+    const deadline = Date.now() + 5_000;
+    while (Date.now() < deadline && !existsSync(record)) {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+    assert.ok(existsSync(record), "opener never ran");
+    const got = Object.fromEntries(
+      readFileSync(record, "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => line.split(/=(.*)/s).slice(0, 2) as [string, string]),
+    );
+    assert.equal(got.args, url);
+    assert.equal(got.fd0, "/dev/null");
+    assert.equal(got.fd1, "/dev/null");
+    assert.equal(got.fd2, "/dev/null");
+    assert.equal(got.sid, got.pid, "opener is its own session leader (detached)");
+    assert.equal(got.secret, "absent");
+    assert.equal(got.cwd, os.homedir());
+  } finally {
+    rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("browser opener environment never carries PATH overrides or credentials", () => {
+  const env = browserOpenEnvironment(
+    {
+      PATH: "/project/node_modules/.bin:/attacker/bin",
+      DISPLAY: ":1",
+      OPENAI_API_KEY: "must-not-cross",
+      BROWSER: "/project/browser",
+      LD_PRELOAD: "/project/hook.so",
+    },
+    "linux",
+  );
+  assert.equal(env.DISPLAY, ":1");
+  assert.match(env.PATH, /^\/usr\/bin:/);
+  assert.equal("OPENAI_API_KEY" in env, false);
+  assert.equal("BROWSER" in env, false);
+  assert.equal("LD_PRELOAD" in env, false);
+});
+
+test("the official launcher warns when npm exec supplies project binaries", async () => {
+  assert.ok(existsSync(DAEMON), "dist-server missing — test:e2e must run `yarn build` first");
+  const tmp = mkdtempSync(path.join(os.tmpdir(), "genui-npx-warning-"));
+  const child = spawn(process.execPath, [LAUNCHER, "--no-open"], {
     cwd: tmp,
     detached: true,
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
-      PATH: `${tmp}:${process.env.PATH}`,
-      MIRAFOLD_TEST_RECORD: record,
-      // Same forced-empty credentials as the Tier-2 harness: no test may ever
-      // reach a metered engine, even though this one never creates a session.
       ...SCRUBBED_CREDENTIAL_ENV,
-      PORT: String(3900 + Math.floor(Math.random() * 90)),
+      npm_command: "exec",
+      npm_lifecycle_event: "npx",
+      PORT: String(3910 + Math.floor(Math.random() * 70)),
     },
   });
   let log = "";
-  child.stdout.on("data", (d: Buffer) => (log += d));
-  child.stderr.on("data", (d: Buffer) => (log += d));
-
+  child.stdout.on("data", (data: Buffer) => (log += data));
+  child.stderr.on("data", (data: Buffer) => (log += data));
   try {
     const deadline = Date.now() + 20_000;
-    let url: string | undefined;
-    while (Date.now() < deadline && !existsSync(record)) {
-      url ??= log.match(/http:\/\/127\.0\.0\.1:\d+\/\S*/)?.[0];
-      await new Promise((r) => setTimeout(r, 50));
+    while (Date.now() < deadline && !/http:\/\/127\.0\.0\.1:\d+\//.test(log)) {
+      await new Promise((resolve) => setTimeout(resolve, 25));
     }
-    assert.ok(existsSync(record), `opener never ran; launcher log:\n${log}`);
-    url ??= log.match(/http:\/\/127\.0\.0\.1:\d+\/\S*/)?.[0];
-
-    const got = Object.fromEntries(
-      readFileSync(record, "utf8")
-        .trim()
-        .split("\n")
-        .map((l) => l.split(/=(.*)/s).slice(0, 2) as [string, string]),
-    );
-    assert.equal(got.args, url, "opener called with the daemon's printed URL");
-    // The guarantee itself: nothing the opener (or the browser it may become)
-    // writes can reach the terminal, and it survives the launcher's exit.
-    assert.equal(got.fd0, "/dev/null");
-    assert.equal(got.fd1, "/dev/null");
-    assert.equal(got.fd2, "/dev/null");
-    assert.equal(got.sid, got.pid, "opener is its own session leader (detached)");
+    assert.match(log, /npx exposes executables from the current project's node_modules/i);
+    assert.match(log, /global install is the safe default/i);
+    assert.match(log, /http:\/\/127\.0\.0\.1:\d+\//);
   } finally {
     try {
       process.kill(-child.pid!, "SIGTERM");

--- a/server/testing/launcher.e2e.ts
+++ b/server/testing/launcher.e2e.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { spawn } from "node:child_process";
+import { spawn, type ChildProcess } from "node:child_process";
 import {
   chmodSync,
   cpSync,
@@ -33,6 +33,24 @@ const DAEMON = path.join(ROOT, "dist-server", "index.js");
 // /proc: the process-state guarantee is exercised on Linux, the CI platform.
 const linuxOnly = { skip: process.platform !== "linux" };
 
+async function stopProcessGroup(child: ChildProcess): Promise<void> {
+  try {
+    process.kill(-child.pid!, "SIGTERM");
+  } catch {}
+  await new Promise<void>((done) => {
+    const hard = setTimeout(() => {
+      try {
+        process.kill(-child.pid!, "SIGKILL");
+      } catch {}
+      done();
+    }, 3_000);
+    child.once("exit", () => {
+      clearTimeout(hard);
+      done();
+    });
+  });
+}
+
 test("launcher ignores project PATH when resolving host browser chrome", () => {
   const inspected: string[] = [];
   const fakePath = "/hostile/project/node_modules/.bin";
@@ -57,10 +75,15 @@ test("launcher ignores project PATH when resolving host browser chrome", () => {
     args: [url],
   });
   assert.deepEqual(
-    browserOpenCommand(url, "win32", { PATH: fakePath, SystemRoot: "C:\\Windows" }, () => true),
+    browserOpenCommand(
+      `${url}&calc|whoami`,
+      "win32",
+      { PATH: fakePath, SystemRoot: "C:\\Windows" },
+      () => true,
+    ),
     {
-      file: "C:\\Windows\\System32\\cmd.exe",
-      args: ["/d", "/c", "start", "", url],
+      file: "C:\\Windows\\explorer.exe",
+      args: [`${url}&calc|whoami`],
     },
   );
   assert.equal(browserOpenCommand(url, "win32", { PATH: fakePath }, () => true), undefined);
@@ -161,24 +184,11 @@ test("the official launcher warns when npm exec supplies project binaries", asyn
       await new Promise((resolve) => setTimeout(resolve, 25));
     }
     assert.match(log, /npx exposes executables from the current project's node_modules/i);
-    assert.match(log, /global install is the safe default/i);
+    assert.match(log, /installed command avoids package shadowing/i);
+    assert.match(log, /review or rename the checkout's \.env/i);
     assert.match(log, /http:\/\/127\.0\.0\.1:\d+\//);
   } finally {
-    try {
-      process.kill(-child.pid!, "SIGTERM");
-    } catch {}
-    await new Promise<void>((done) => {
-      const hard = setTimeout(() => {
-        try {
-          process.kill(-child.pid!, "SIGKILL");
-        } catch {}
-        done();
-      }, 3_000);
-      child.once("exit", () => {
-        clearTimeout(hard);
-        done();
-      });
-    });
+    await stopProcessGroup(child);
     rmSync(tmp, { recursive: true, force: true });
   }
 });
@@ -235,21 +245,7 @@ test("SPA fallback serves from an install path containing a dot-directory", asyn
     assert.equal(res.status, 200, `SPA fallback 404s from a dot-path install:\n${log}`);
     assert.match(body, /<div id="root">/, "served the real app shell, not an error page");
   } finally {
-    try {
-      process.kill(-child.pid!, "SIGTERM");
-    } catch {}
-    await new Promise<void>((done) => {
-      const hard = setTimeout(() => {
-        try {
-          process.kill(-child.pid!, "SIGKILL");
-        } catch {}
-        done();
-      }, 3_000);
-      child.once("exit", () => {
-        clearTimeout(hard);
-        done();
-      });
-    });
+    await stopProcessGroup(child);
     rmSync(tmp, { recursive: true, force: true });
   }
 });

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -237,6 +237,7 @@ export function FleetView() {
           agents={agents}
           defaultCwd={tildify(daemon.cwd, daemon.home)}
           error={onbError}
+          onCwdChange={() => setOnbError(null)}
           onBrowse={daemon.folderPicker ? browseFolder : undefined}
           onPick={(agent, cwd, backend) => {
             setOnbError(null);

--- a/web/src/components/Onboarding.tsx
+++ b/web/src/components/Onboarding.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import type { AgentBackend, AgentInfo, AgentName, BackendChoice } from "@protocol";
 import {
   agentLabel,
@@ -36,6 +36,10 @@ const REFRESH_POLL_MS = 3_000;
 // Names the dialog for a screen reader (A.2b). A constant is safe: only one
 // onboarding card is ever mounted.
 const TITLE_ID = "onb-card-title";
+
+function revealPathEnd(input: HTMLInputElement | null): void {
+  if (input) input.scrollLeft = input.scrollWidth;
+}
 
 /** A second step only when there's a genuine choice: more than one usable way
  *  to run, or a discovered server whose model must be picked. A single usable
@@ -226,6 +230,7 @@ export function Onboarding({
   const [cwd, setCwd] = useState("");
   const [browsing, setBrowsing] = useState(false);
   const [browseError, setBrowseError] = useState<string | null>(null);
+  const cwdInput = useRef<HTMLInputElement>(null);
   // Which agent's backend menu is open (the second step), if any.
   const [picking, setPicking] = useState<AgentName | null>(null);
   // Which discovered server's model catalog is open (the third step) — its
@@ -236,6 +241,16 @@ export function Onboarding({
   useEffect(() => {
     if (defaultCwd) setCwd((c) => c || defaultCwd);
   }, [defaultCwd]);
+
+  // A native pick replaces this controlled input while focus remains on the
+  // browse button. With no caret to reveal, browsers otherwise leave the
+  // input at scrollLeft 0 and show the filesystem root instead of the folder
+  // that identifies the project. Keep caret-driven scrolling while editing;
+  // whenever an unfocused value lands (or editing ends), reveal its leaf.
+  useLayoutEffect(() => {
+    const input = cwdInput.current;
+    if (document.activeElement !== input) revealPathEnd(input);
+  }, [cwd]);
 
   // The live "it will show here" promise: poll while open. The hello is
   // re-sent whole, so rows update in place (including mid-second-step).
@@ -258,16 +273,18 @@ export function Onboarding({
   const pickingRow = picking ? agents?.find((a) => a.agent === picking) : undefined;
   const pick = (agent: AgentName, backend?: BackendChoice) =>
     onPick(agent, cwd.trim() || undefined, backend);
+  const updateCwd = (next: string) => {
+    setCwd(next);
+    setBrowseError(null);
+    onCwdChange?.();
+  };
   const browseForDirectory = async () => {
     if (!onBrowse || browsing) return;
     setBrowseError(null);
     setBrowsing(true);
     try {
       const selected = await onBrowse(cwd.trim() || undefined);
-      if (selected) {
-        setCwd(selected);
-        onCwdChange?.();
-      }
+      if (selected) updateCwd(selected);
     } catch (err) {
       setBrowseError(err instanceof Error ? err.message : String(err));
     } finally {
@@ -297,6 +314,7 @@ export function Onboarding({
       </label>
       <div className="onb-cwd-row">
         <input
+          ref={cwdInput}
           id="onb-cwd"
           className="onb-cwd"
           type="text"
@@ -304,11 +322,8 @@ export function Onboarding({
           spellCheck={false}
           placeholder={defaultCwd ?? "~/path/to/project"}
           aria-describedby={currentError ? "onb-cwd-error" : undefined}
-          onChange={(e) => {
-            setCwd(e.target.value);
-            setBrowseError(null);
-            onCwdChange?.();
-          }}
+          onChange={(e) => updateCwd(e.target.value)}
+          onBlur={(e) => revealPathEnd(e.currentTarget)}
         />
         {onBrowse && (
           <button

--- a/web/src/components/Onboarding.tsx
+++ b/web/src/components/Onboarding.tsx
@@ -192,19 +192,14 @@ function BackendMenu({
   );
 }
 
-export function Onboarding({
-  agents,
-  defaultCwd,
-  error,
-  onPick,
-  onBrowse,
-  onRefresh,
-  onDismiss,
-}: {
+type OnboardingProps = {
   agents: AgentInfo[] | null;
   defaultCwd?: string;
   error?: string | null;
   onPick: (agent: AgentName, cwd?: string, backend?: BackendChoice) => void;
+  // A create error describes the cwd that was submitted. Once the user
+  // edits or replaces that cwd, its owner must discard the stale error.
+  onCwdChange?: () => void;
   // Present only when this LOCAL daemon advertised a host-native picker.
   // Cancel resolves undefined; errors reject and stay inside this card.
   onBrowse?: (cwd?: string) => Promise<string | undefined>;
@@ -216,7 +211,18 @@ export function Onboarding({
   // Absent on first run / a sessionless shell, where dismissing would leave
   // a dead page.
   onDismiss?: () => void;
-}) {
+};
+
+export function Onboarding({
+  agents,
+  defaultCwd,
+  error,
+  onPick,
+  onCwdChange,
+  onBrowse,
+  onRefresh,
+  onDismiss,
+}: OnboardingProps) {
   const [cwd, setCwd] = useState("");
   const [browsing, setBrowsing] = useState(false);
   const [browseError, setBrowseError] = useState<string | null>(null);
@@ -252,20 +258,23 @@ export function Onboarding({
   const pickingRow = picking ? agents?.find((a) => a.agent === picking) : undefined;
   const pick = (agent: AgentName, backend?: BackendChoice) =>
     onPick(agent, cwd.trim() || undefined, backend);
-  const browse = async () => {
+  const browseForDirectory = async () => {
     if (!onBrowse || browsing) return;
     setBrowseError(null);
     setBrowsing(true);
     try {
       const selected = await onBrowse(cwd.trim() || undefined);
-      if (selected) setCwd(selected);
+      if (selected) {
+        setCwd(selected);
+        onCwdChange?.();
+      }
     } catch (err) {
       setBrowseError(err instanceof Error ? err.message : String(err));
     } finally {
       setBrowsing(false);
     }
   };
-  const shownError = browseError ?? error;
+  const currentError = browseError ?? error;
 
   return (
     // Esc/backdrop walk back the same steps (stepBack above), so the modal's
@@ -294,10 +303,11 @@ export function Onboarding({
           value={cwd}
           spellCheck={false}
           placeholder={defaultCwd ?? "~/path/to/project"}
-          aria-describedby={shownError ? "onb-cwd-error" : undefined}
+          aria-describedby={currentError ? "onb-cwd-error" : undefined}
           onChange={(e) => {
             setCwd(e.target.value);
             setBrowseError(null);
+            onCwdChange?.();
           }}
         />
         {onBrowse && (
@@ -305,15 +315,15 @@ export function Onboarding({
             type="button"
             className="onb-cwd-browse"
             disabled={browsing}
-            onClick={() => void browse()}
+            onClick={() => void browseForDirectory()}
           >
             {browsing ? "choosing…" : "browse…"}
           </button>
         )}
       </div>
-      {shownError && (
+      {currentError && (
         <div className="onb-error" id="onb-cwd-error">
-          {shownError}
+          {currentError}
         </div>
       )}
       {pickingRow ? (

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -549,6 +549,10 @@ export function RenderZone({
         role="log"
         aria-live="off"
         aria-label="Conversation transcript"
+        // An overflowing transcript can contain only inert prose. Keep the
+        // scroller itself in the tab order so keyboard users can PageUp/End;
+        // the global :focus-visible rule supplies its visible focus ring.
+        tabIndex={0}
         ref={tail.scrollerRef}
         onScroll={tail.onScroll}
         onWheel={tail.onWheel}

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -392,6 +392,7 @@ export function Shell() {
           agents={daemonInfo.agents}
           defaultCwd={tildify(daemonInfo.cwd, daemonInfo.home)}
           error={notices.onboarding}
+          onCwdChange={() => setNotices((n) => ({ ...n, onboarding: null }))}
           onBrowse={daemonInfo.folderPicker ? bus.pickFolder : undefined}
           onPick={(agent, cwd, backend) => {
             setNotices((n) => ({ ...n, onboarding: null }));

--- a/web/src/folder-picker-requests.ts
+++ b/web/src/folder-picker-requests.ts
@@ -1,7 +1,10 @@
 import type { ClientMsg, WireMsg } from "@protocol";
 
-type FolderPicked = Extract<WireMsg, { type: "folder_picked" }>;
 type PickFolder = Extract<ClientMsg, { type: "pick_folder" }>;
+type PendingRequest = {
+  resolve: (path: string | undefined) => void;
+  reject: (err: Error) => void;
+};
 
 /** Correlated client half of N2's folder-picker request/reply. Shared by the
  *  session shell and mission control: both surfaces own an Onboarding card. */
@@ -9,10 +12,7 @@ export function createFolderPickerRequests(
   send: (msg: PickFolder) => void | boolean,
   mintId: () => string = () => `fp-${Math.random().toString(36).slice(2, 10)}`,
 ) {
-  const pending = new Map<
-    string,
-    { resolve: (path: string | undefined) => void; reject: (err: Error) => void }
-  >();
+  const pending = new Map<string, PendingRequest>();
 
   return {
     request(cwd?: string): Promise<string | undefined> {
@@ -34,12 +34,11 @@ export function createFolderPickerRequests(
     /** True means this frame belonged to the picker and should not fan out. */
     handle(msg: WireMsg): boolean {
       if (msg.type !== "folder_picked") return false;
-      const reply = msg as FolderPicked;
-      const waiting = pending.get(reply.id);
+      const waiting = pending.get(msg.id);
       if (!waiting) return true;
-      pending.delete(reply.id);
-      if (reply.error) waiting.reject(new Error(reply.error));
-      else waiting.resolve(reply.path);
+      pending.delete(msg.id);
+      if (msg.error) waiting.reject(new Error(msg.error));
+      else waiting.resolve(msg.path);
       return true;
     },
     disconnect(): void {

--- a/web/src/use-follow-tail.ts
+++ b/web/src/use-follow-tail.ts
@@ -44,6 +44,15 @@ type WheelIntent = { deltaY: number; deltaMode?: number };
 
 const bottomGap = (el: ScrollGeometry) => el.scrollHeight - el.scrollTop - el.clientHeight;
 
+const intentReachesBottom = (el: ScrollGeometry, deltaPx: number) =>
+  deltaPx > 0 && bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
+
+function wheelDeltaPixels(el: ScrollGeometry, e: WheelIntent): number {
+  if (e.deltaMode === 1) return e.deltaY * WHEEL_LINE_PX;
+  if (e.deltaMode === 2) return e.deltaY * el.clientHeight;
+  return e.deltaY;
+}
+
 /**
  * Decide from the geometry that existed when the user steered, before the
  * browser dispatches a later scroll event and before streamed output can move
@@ -51,14 +60,7 @@ const bottomGap = (el: ScrollGeometry) => el.scrollHeight - el.scrollTop - el.cl
  * test harness.
  */
 export function wheelIntentReachesBottom(el: ScrollGeometry, e: WheelIntent): boolean {
-  if (e.deltaY <= 0) return false;
-  const deltaPx =
-    e.deltaMode === 1
-      ? e.deltaY * WHEEL_LINE_PX
-      : e.deltaMode === 2
-        ? e.deltaY * el.clientHeight
-        : e.deltaY;
-  return bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
+  return intentReachesBottom(el, wheelDeltaPixels(el, e));
 }
 
 /** Finger moving up scrolls the transcript toward its tail. */
@@ -67,8 +69,7 @@ export function touchIntentReachesBottom(
   previousY: number,
   nextY: number,
 ): boolean {
-  const deltaPx = previousY - nextY;
-  return deltaPx > 0 && bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
+  return intentReachesBottom(el, previousY - nextY);
 }
 
 export function useFollowTail() {

--- a/web/src/use-follow-tail.ts
+++ b/web/src/use-follow-tail.ts
@@ -41,8 +41,10 @@ const WHEEL_LINE_PX = 16;
 
 type ScrollGeometry = Pick<HTMLElement, "scrollHeight" | "scrollTop" | "clientHeight">;
 type WheelIntent = { deltaY: number; deltaMode?: number };
+type TouchIntent = { touches: ArrayLike<{ clientY: number }> };
 
 const bottomGap = (el: ScrollGeometry) => el.scrollHeight - el.scrollTop - el.clientHeight;
+const firstTouchY = (event: TouchIntent) => event.touches[0]?.clientY;
 
 const intentReachesBottom = (el: ScrollGeometry, deltaPx: number) =>
   deltaPx > 0 && bottomGap(el) <= deltaPx + BOTTOM_SLACK_PX;
@@ -101,8 +103,8 @@ export function useFollowTail() {
     if (el && wheelIntentReachesBottom(el, e)) following.current = true;
   };
 
-  const onTouchStart = (e: { touches: { clientY: number }[] | ArrayLike<{ clientY: number }> }) => {
-    touchY.current = e.touches[0]?.clientY ?? null;
+  const onTouchStart = (e: TouchIntent) => {
+    touchY.current = firstTouchY(e) ?? null;
   };
 
   // Dragging the content DOWN scrolls the transcript up — the touch equivalent
@@ -114,8 +116,8 @@ export function useFollowTail() {
   // wheel was (Chrome/Linux, 2026-07-20). Kept as a guard for the platform
   // that can't be tested here — iOS Safari, which the relay's phone viewport
   // actually targets, and whose momentum scrolling is a different animal.
-  const onTouchMove = (e: { touches: ArrayLike<{ clientY: number }> }) => {
-    const y = e.touches[0]?.clientY;
+  const onTouchMove = (e: TouchIntent) => {
+    const y = firstTouchY(e);
     if (y === undefined) return;
     const previousY = touchY.current;
     if (previousY !== null && y > previousY) following.current = false;

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -401,19 +401,22 @@ export class SocketClient {
       : msg;
   }
 
+  private transmitIfOpen(msg: ClientMsg): boolean {
+    if (!this.ready || this.ws?.readyState !== WebSocket.OPEN) return false;
+    this.transmit(msg);
+    return true;
+  }
+
   send(msg: ClientMsg) {
     msg = this.stamp(msg);
-    if (this.ready && this.ws?.readyState === WebSocket.OPEN) this.transmit(msg);
-    else this.pending.push(msg);
+    if (!this.transmitIfOpen(msg)) this.pending.push(msg);
   }
 
   /** Send a user-gesture side effect only while the channel is usable. Unlike
    *  send(), this never queues a click to run after a later reconnect. The
    *  native folder dialog is local-only, so transmit is synchronous here. */
   sendIfOpen(msg: ClientMsg): boolean {
-    if (!this.ready || this.ws?.readyState !== WebSocket.OPEN) return false;
-    this.transmit(this.stamp(msg));
-    return true;
+    return this.transmitIfOpen(this.stamp(msg));
   }
 
   close() {


### PR DESCRIPTION
## Summary
- refactor and harden native folder-picker and agent executable lookup
- keep long selected paths scrolled to the leaf folder
- constrain checkout .env authority and remove Windows command-shell URL opening

## Verification
- yarn test: 563/563
- yarn test:server: 143/143
- yarn test:e2e: 82/82
- yarn typecheck
- yarn build
- production dependency audit: 0 vulnerabilities