### PR TITLE
sync: main → next after v0.3.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Closing step per docs/RELEASING.md: next absorbs the 0.3.5 version bump and release merge commit. The head branch is a fixed snapshot of main at signed release commit c19d325.