### PR TITLE
Release v0.3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,13 @@ name: CI
 # it when the repo goes public (R.7).
 #
 # ONE cross-repo arrangement: server/relay/relay-service.itest.ts imports the
-# relay under test from the SIBLING ../genui-relay checkout (README §"sibling
-# itest"). Both jobs therefore check this repo out into genui-shell/ and
-# mirafold-relay into genui-relay/, making them siblings under the workspace
+# relay under test from the SIBLING ../mirafold-relay checkout (README §"sibling
+# itest"). Both jobs therefore check this repo out into mirafold/ and
+# mirafold-relay into mirafold-relay/, making them siblings under the workspace
 # exactly as they are on a dev machine, and run with working-directory
-# genui-shell. The relay is public since 2026-07-31, so the checkout needs no
+# mirafold. The relay is public since 2026-07-31, so the checkout needs no
 # secret. It tracks the relay's default branch on purpose: the itest carries the
-# contract guard that fails on drift between genui-relay/src/contract.ts and
+# contract guard that fails on drift between mirafold-relay/src/contract.ts and
 # server/relay/relay-protocol.ts, and pinning a ref would blind it to exactly
 # the drift it exists to catch. Consequence, accepted: a contract-breaking push
 # to the relay turns this repo's CI red, which is the intended alarm.
@@ -52,28 +52,29 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: genui-shell
+        working-directory: mirafold
     steps:
       - uses: actions/checkout@v5
         with:
-          path: genui-shell
+          path: mirafold
       # The sibling the itest imports from. Public since 2026-07-31 — the
       # default GITHUB_TOKEN reads it without any added secret.
       - uses: actions/checkout@v5
         with:
           repository: mirafold/mirafold-relay
-          path: genui-relay
+          path: mirafold-relay
       - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: yarn
-          cache-dependency-path: genui-shell/yarn.lock
+          cache-dependency-path: mirafold/yarn.lock
       # The relay's own install: the typecheck follows the itest's imports into
-      # genui-relay/src, which resolves `ws` and its types from genui-relay's
+      # mirafold-relay/src, which resolves `ws` and its types from
+      # mirafold-relay's
       # node_modules — module resolution walks up from that file and never
       # reaches this repo's node_modules, so the sibling needs its own install.
       - run: npm ci
-        working-directory: genui-relay
+        working-directory: mirafold-relay
       - run: yarn install --frozen-lockfile
       # Full tsconfig.json now — the sibling is present, so nothing is excluded.
       - run: yarn typecheck
@@ -87,22 +88,22 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: genui-shell
+        working-directory: mirafold
     steps:
       - uses: actions/checkout@v5
         with:
-          path: genui-shell
+          path: mirafold
       - uses: actions/checkout@v5
         with:
           repository: mirafold/mirafold-relay
-          path: genui-relay
+          path: mirafold-relay
       - uses: actions/setup-node@v5
         with:
           node-version: 22
           cache: yarn
-          cache-dependency-path: genui-shell/yarn.lock
+          cache-dependency-path: mirafold/yarn.lock
       - run: npm ci
-        working-directory: genui-relay
+        working-directory: mirafold-relay
       - run: yarn install --frozen-lockfile
       # Tier 3 drives real headless Chrome via playwright-core; the harness
       # reads CHROME_BIN (default /usr/bin/google-chrome). ubuntu-latest ships

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -1150,8 +1150,8 @@ verbatim, full dated status notes included.
 ## Phase G — Collapse the relay duplication (do before Phase H)
 
 Origin: same 2026-07-14 review. The relay's shared source is vendored
-byte-identically in TWO places — `genui-shell/relay-service/` and
-`genui-relay/src/` — held in lockstep by a sync script; Kyle called the
+byte-identically in TWO places — `mirafold/relay-service/` and
+`mirafold-relay/src/` — held in lockstep by a sync script; Kyle called the
 "keep two copies consistent" arrangement a maintainability wart. It was always
 explicitly temporary: `relay-service/` was the dev source of truth *only until
 the relay's first deploy* (the umbrella `genui/CLAUDE.md` + DEPLOY.md §5),
@@ -1180,7 +1180,7 @@ detail, not this phase's concern.
   becomes the single source of truth**
   - Goal: one home for the relay service. No more byte-identical second copy
     kept in lockstep; the maintainability burden is gone.
-  - Build: make `genui-relay/src/` the canonical source. In `genui-shell`,
+  - Build: make `mirafold-relay/src/` the canonical source. In `genui-shell`,
     reduce the top-level `relay-service/` from a full vendored copy to a thin
     pointer (a short README stating the relay now lives in the `genui-relay`
     repo and how the local itest sources it) — keeping NO duplicated `src/`,
@@ -1188,7 +1188,7 @@ detail, not this phase's concern.
     test `server/relay-service.itest.ts` to obtain the relay under test from
     the canonical sibling `genui-relay` (the sibling-directory relationship the
     umbrella already relies on) instead of the vendored copy. Retire the now-
-    unnecessary sync machinery: `genui-relay/scripts/sync-from-genui-shell.sh`
+    unnecessary sync machinery: `mirafold-relay/scripts/sync-from-genui-shell.sh`
     and the `sync` / `sync:check` npm scripts (nothing to keep in sync once
     there is a single copy). Update every doc that describes the sync
     arrangement (this repo's README + DEPLOY.md §5, `genui-relay`'s README +
@@ -1199,9 +1199,9 @@ detail, not this phase's concern.
     `relay-service.itest.ts` still verifies the relay against a REAL daemon, now
     sourced from the sibling. `npm run smoke` (against the deployed relay) still
     passes.
-  - Files: `genui-shell/relay-service/` (collapsed to a pointer),
+  - Files: `mirafold/relay-service/` (collapsed to a pointer),
     `server/relay-service.itest.ts` (rewired), `README.md`, `DEPLOY.md`;
-    `genui-relay/scripts/`, its `package.json`, README + ARCHITECTURE.md; the
+    `mirafold-relay/scripts/`, its `package.json`, README + ARCHITECTURE.md; the
     umbrella `genui/CLAUDE.md`.
   - Done when: no byte-identical relay duplication remains (a diff confirms
     `genui-shell` holds no second copy of the relay `src/`), `genui-relay` is
@@ -1212,7 +1212,7 @@ detail, not this phase's concern.
     `src/` trees byte-identical, then `relay-service/` was collapsed to a
     pointer README (src/, Dockerfile, fly.toml, package/tsconfig all removed);
     `relay-service.itest.ts` now imports `startRelay` + the contract from the
-    sibling `../../genui-relay/src/`, and the sync script + `sync`/`sync:check`
+    sibling `../../mirafold-relay/src/`, and the sync script + `sync`/`sync:check`
     npm scripts are deleted. Docs updated in the same pass: this repo's README
     (§tree + §8), `genui-relay`'s README/ARCHITECTURE §6/DEPLOY §5, and the
     umbrella CLAUDE.md (sync section → sibling-itest section). Verified both
@@ -1726,13 +1726,13 @@ hits named in the step.
     the pointer as current state: README §10's R.2 narrative, two stale
     bullets in `docs/RENAME.md` (the dev copy's package name + the retired
     sync scripts), the umbrella `CLAUDE.md` sibling-itest paragraph, and
-    `genui-relay/DEPLOY.md` §5's dated bullet (amended in its own repo).
+    `mirafold-relay/DEPLOY.md` §5's dated bullet (amended in its own repo).
     Dated history (PLAN/PLAN-ARCHIVE/ROADMAP records, the relay repo's
     past-tense README/ARCHITECTURE notes) stays verbatim; the itest KEEPS
     its `relay-service.itest.ts` name (it tests the relay service — the
     name describes the subject, not a path).
   - Files: `relay-service/` (deleted), `README.md`, `docs/RENAME.md`,
-    `../CLAUDE.md`, `../ROADMAP.md`, `../genui-relay/DEPLOY.md`.
+    `../CLAUDE.md`, `../ROADMAP.md`, `../mirafold-relay/DEPLOY.md`.
   - Done when: the directory is gone, no live doc claims it exists, the
     sibling-itest instructions survive in README §4, and typecheck + Tier 1
     pass (docs + deletion only).
@@ -2385,7 +2385,7 @@ order. Nothing was dropped — only relocated.
     free-LOCAL-only; the relay is sold as BYO-API-key remote access; name the
     day-one-user shift (was "the Pro/Max subscriber," now "the API-key holder")
     and revisit any pricing/reach copy that assumed subscription users.
-    (3) `genui-shell/CLAUDE.md` + umbrella `genui/CLAUDE.md`: add a short
+    (3) `mirafold/CLAUDE.md` + umbrella `genui/CLAUDE.md`: add a short
     non-negotiable — "genui-shell must not enable prohibited subscription use;
     the dated, revisit-able matrix lives in `server/provider-policy.ts`."
     (4) `.env.example`: Claude presents the **API key** as the live path again
@@ -2397,7 +2397,7 @@ order. Nothing was dropped — only relocated.
     BYO-endpoint escape hatch). (6) One line in the relay/DEPLOY story: the
     relay admits only api-key/local sessions — subscription pairings are refused
     by the DAEMON (R.4i), independent of Stripe entitlement (R.5).
-  - Files: `PLAN.md` (Locked decisions), `BUSINESS.md`, `genui-shell/CLAUDE.md`,
+  - Files: `PLAN.md` (Locked decisions), `BUSINESS.md`, `mirafold/CLAUDE.md`,
     `../CLAUDE.md` (umbrella), `.env.example`, `README.md`, relevant `docs/`.
   - Done when: no shipped doc or example offers a Claude/Gemini subscription as
     a way to run genui-shell; BUSINESS.md names the BYOK day-one user and the
@@ -2422,7 +2422,7 @@ order. Nothing was dropped — only relocated.
     the "to go live" section states closed-models-are-API-key with the local/BYO
     escape hatch, the R.4b changelog line's reversed half is marked, and a new
     2026-07-10 changelog entry summarizes R.4i/R.4j. (6) The private
-    `genui-relay/README.md` "deliberately does not" list gained a line: the
+    `mirafold-relay/README.md` "deliberately does not" list gained a line: the
     relay enforces no credential policy — the daemon refuses subscription
     sessions before any frame, independent of entitlement. `provider-policy.ts`
     is now cited as the source of truth in all six places. **The 2026-07-10
@@ -5199,7 +5199,7 @@ rule]] in memory):
 ## Phase C — CI/CD (opened 2026-07-20; pre-launch)
 
 Kyle is standing up CI/CD shortly. As of 2026-07-20 there is **none** in any
-of the three repos: `genui-shell/.github/` holds only an issue template, there
+of the three repos: `mirafold/.github/` holds only an issue template, there
 are no workflows and no git hooks, and neither `genui-relay` nor
 `mirafold-site` has a `.github/` at all. Verification today is Kyle running
 `yarn test` / `test:server` / `test:e2e` by hand — a good habit, but a habit.
@@ -5260,7 +5260,7 @@ uncharacterized sighting of the Tier-2 per-pair viewport-cap test.
       today).
   - **The one thing CI surfaced (a real cross-repo finding):** the shell's
     first run went red because `server/relay/relay-service.itest.ts` imports
-    the relay under test from the **sibling `../genui-relay` checkout**, which
+    the relay under test from the **sibling `../mirafold-relay` checkout**, which
     a single-repo CI job doesn't have — and the relay repo is private
     pre-launch, so cloning it in CI would need a secret (contradicting this
     phase's no-secrets sizing). This tripped BOTH typecheck (tsconfig includes
@@ -5365,7 +5365,7 @@ uncharacterized sighting of the Tier-2 per-pair viewport-cap test.
       work in every repo** (his job's `on-prod.yml` pattern: a human clicks
       Run workflow and picks the ref; nothing ever deploys on push, merge,
       or schedule). Scaffolded for the relay same day:
-      `genui-relay/.github/workflows/deploy.yml` (`9162fa1`), inert until a
+      `mirafold-relay/.github/workflows/deploy.yml` (`9162fa1`), inert until a
       `FLY_API_TOKEN` secret exists; the one-time deploy-day steps stay
       manual per that repo's `DEPLOY.md`.
 
@@ -6216,7 +6216,7 @@ server sends no timers.
     there), so it idles at near-zero cost. The `*.fly.dev` URL is fine:
     the own-domain rule exists so installed daemons never depend on the
     platform's name, and nothing installed ever points at staging. The
-    `Deploy` workflow (`genui-relay/.github/workflows/deploy.yml`) grows an
+    `Deploy` workflow (`mirafold-relay/.github/workflows/deploy.yml`) grows an
     environment input on the dispatch form — staging or production, each a
     GitHub Environment with its own Fly deploy token — same manual-click
     pattern, one more dropdown. Fly-side one-time steps (app create, token)
@@ -6226,7 +6226,7 @@ server sends no timers.
     check → dispatch the same ref to production.
   - Done when: deploying any ref to staging is one workflow dispatch, a
     smoke run (`npm run smoke`) against the staging URL passes, and the
-    staging half is documented in `genui-relay/DEPLOY.md` alongside the
+    staging half is documented in `mirafold-relay/DEPLOY.md` alongside the
     production runbook.
 
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -652,7 +652,15 @@ notifications are **not** part of the launch and are not sold until built.
     `genui-relay` / `genui-relay-staging`, and the `genui-relay v1`
     key-derivation salt remains frozen as a protocol contract. Verified after
     the rename: Mirafold typecheck; Tier 1 563/563, Tier 2 143/143, Tier 3
-    82/82; relay typecheck and 38/38 relay tests.
+    82/82; relay typecheck and 38/38 relay tests. **Release-gate follow-up
+    (2026-08-09):** release PR #27 exposed a pre-existing test-only race: the
+    relay-handshake helper waited a fixed number of event-loop turns before
+    closing its healthy socket, so delayed WebCrypto work could miss the
+    backoff reset. The helper now waits for `SocketClient.onOpen()` — the
+    product state transition the assertion actually depends on. The exact
+    test went from 4/20 failures under concurrent load before the fix to 0/20
+    after it; the containing file passed 32/32, Tier 1 passed 563/563, and
+    typecheck passed.
   - Done when: a phone on cellular (not the home wifi) drives a home
     session through the deployed relay, and the relay's logs show it
     learned nothing but connection metadata.

--- a/PLAN.md
+++ b/PLAN.md
@@ -600,10 +600,10 @@ notifications are **not** part of the launch and are not sold until built.
 
 - [x] **Step R.1 — Relay envelope + daemon dial-out** — done 2026-07-07; the relay envelope + outbound WSS dial-out, remote viewports multiplexed as ordinary Connections, verified across all tiers against the in-repo stub. Full status → PLAN-ARCHIVE.md.
 
-- [ ] **Step R.2 — The relay service, deployed**
+- [x] **Step R.2 — The relay service, deployed** — completed 2026-08-09.
   - Goal: the dumb forwarder, running in the world.
   - Status: **DEPLOYED and verified in production.** The standalone
-    `genui-relay` repo (single source of truth since G.1) is a
+    `mirafold-relay` repo (single source of truth since G.1) is a
     dependency-light (`ws` only) portable Node process — a PURE forwarder:
     parses no frames, stores nothing, serves NO app bundle (the phone app
     loads from the separate static origin, then opens the encrypted
@@ -616,7 +616,7 @@ notifications are **not** part of the launch and are not sold until built.
     in production). Full build/deploy/rename history (incl. the GENUI® →
     Mirafold naming story) → PLAN-ARCHIVE.md ("Step R.2 — status history"
     + the 2026-07-17 move).
-  - Open to close the box: (1) the **cellular-phone pass** — ✅ **FIRST HALF
+  - Closure record: (1) the **cellular-phone pass** — ✅ **FIRST HALF
     DONE 2026-07-30**: Kyle paired his phone and ran a session over
     **cellular with wifi off**, on the fixed 0.3.0 build. Notable because
     his house is rural with near-unusable data — he found one spot with
@@ -644,9 +644,15 @@ notifications are **not** part of the launch and are not sold until built.
     earns only the "paired" log; the backoff decision moved to close (a
     refusal never resets, a confirmed ordinary drop still does).
     Mutation-tested pin + live-verified against production: gaps double
-    1s→16s+ toward the 30s ceiling.* (3) The codebase/npm/GitHub **rename**
-    genui-shell → mirafold rides this step (domains bought 2026-07-11;
-    the Fly app name stays `genui-relay`, internal rename optional).
+    1s→16s+ toward the 30s ceiling.* (3) ✅ **Rename completed 2026-08-09:**
+    the product package and GitHub repositories already carried the Mirafold
+    name; the local repositories are now `mirafold/` and `mirafold-relay/`,
+    with the sibling integration test, CI checkout layout, and current
+    workspace paths updated to match. The deployed Fly app names remain
+    `genui-relay` / `genui-relay-staging`, and the `genui-relay v1`
+    key-derivation salt remains frozen as a protocol contract. Verified after
+    the rename: Mirafold typecheck; Tier 1 563/563, Tier 2 143/143, Tier 3
+    82/82; relay typecheck and 38/38 relay tests.
   - Done when: a phone on cellular (not the home wifi) drives a home
     session through the deployed relay, and the relay's logs show it
     learned nothing but connection metadata.
@@ -715,7 +721,7 @@ with it. Both sequence BEFORE R.5.**
 
 - [x] **Step R.4i — Per-provider credential policy** — done 2026-07-10; `server/provider-policy.ts` is the one source of truth: Claude/Gemini subscription blocked, no subscription over the relay, tri-state onboarding (`live`/`blocked`/`none`), the relay gate in `connection.ts`. Verified all three tiers. → PLAN-ARCHIVE.md.
 
-- [x] **Step R.4j — Reconcile docs & business to the provider policy** — done 2026-07-10 (prose-only); PLAN Auth decision, BUSINESS.md §2/§7/§8.5, both CLAUDE.md files, `.env.example`, README, and the private `genui-relay/README` all cite `provider-policy.ts`. → PLAN-ARCHIVE.md.
+- [x] **Step R.4j — Reconcile docs & business to the provider policy** — done 2026-07-10 (prose-only); PLAN Auth decision, BUSINESS.md §2/§7/§8.5, both CLAUDE.md files, `.env.example`, README, and the private `mirafold-relay/README` all cite `provider-policy.ts`. → PLAN-ARCHIVE.md.
 
 - [x] **Step R.4k — Onboarding honesty + local-model discoverability** — done 2026-07-10; live-row endpoint/model `detail`, a named local-model signpost under the picker, where-to-get-it credential links, and the Codex subscription "could change" disclosure. Verified Tier 1 + Tier 3. → PLAN-ARCHIVE.md.
 
@@ -1048,7 +1054,7 @@ with it. Both sequence BEFORE R.5.**
     (+ `npm deprecate` on the bad one), never an unpublish (npm barely
     permits it and installed users aren't affected either way); for the
     relay it's `fly deploy --image <prev>` (already in
-    `genui-relay/DEPLOY.md`); for the site it's the Pages one-click
+    `mirafold-relay/DEPLOY.md`); for the site it's the Pages one-click
     deployment rollback (KV does NOT roll back with it — see R.6's KV note)*; (d) how the codebase/npm/GitHub rename (R.2) is
     sequenced into all of the above; (e) *already decided 2026-07-15
     (K.9): contributor policy is **DCO**, not CLA* — `Signed-off-by` per
@@ -1592,7 +1598,7 @@ with it. Both sequence BEFORE R.5.**
     carries that work rather than trusting the pack. ⬜ **Kyle still owes the
     replace-in-place upload to Drive.**
   - **Where the version lives, for whenever it IS bumped (swept
-    2026-07-25):** `genui-shell/package.json` is the single source of truth —
+    2026-07-25):** `mirafold/package.json` is the single source of truth —
     `bin/mirafold.js` reads it at runtime for `--version` and the boot banner,
     `web/src/version.ts` imports it at build time for the version the browser
     announces, and `npm pack` names the tarball from it. Since 2026-07-29
@@ -1646,7 +1652,7 @@ with it. Both sequence BEFORE R.5.**
       `/api/entitlement` is the only public surface doing per-request work
       on attacker-suppliable input; the rule is the throttle in front of it.
     - [x] **DDoS acceptance + exit path — DOCUMENTED 2026-07-23** in
-      `genui-relay/DEPLOY.md` §8: the accepted-risk position (stateless,
+      `mirafold-relay/DEPLOY.md` §8: the accepted-risk position (stateless,
       E2E-blind relay; local sessions untouched; blast radius = remote
       uptime) plus the ready-to-execute Cloudflare-fronting shelf plan —
       DNS proxied to the Fly origin, `RELAY_CLIENT_IP_HEADER` →
@@ -1687,7 +1693,7 @@ with it. Both sequence BEFORE R.5.**
     `PADDLE_WEBHOOK_SECRET`) are in `mirafold-site/PLAN.md` "Standing-secrets
     rotation runbook"; the deploy-side two (`FLY_API_TOKEN` per environment,
     and the relay's `RELAY_ENTITLEMENT_PUBLIC_KEY` half of the coupled
-    entitlement-keypair cutover) are in `genui-relay/DEPLOY.md` §7. Key
+    entitlement-keypair cutover) are in `mirafold-relay/DEPLOY.md` §7. Key
     findings captured: the webhook-secret rotation is zero-downtime (Paddle
     allows multiple active `h1=` and `verifyWebhookSignature` already loops
     them); the entitlement-keypair cutover has no overlap window (the relay
@@ -1832,7 +1838,7 @@ with it. Both sequence BEFORE R.5.**
       `connections()`); a client-side harness was unreliable for the
       refuse-after-handshake pattern (relay `close(4004)`s just after the WS
       `open`, so the client briefly sees "open"). **That harness now exists and
-      handles exactly that pattern — `genui-relay/scripts/load.mjs`, added
+      handles exactly that pattern — `mirafold-relay/scripts/load.mjs`, added
       2026-07-28 (`npm run load -- <staging-url>`).** It reads a refusal by
       waiting out a grace window after `open` instead of racing it, so an
       "open" that is about to be closed is counted correctly; four phases
@@ -1841,7 +1847,7 @@ with it. Both sequence BEFORE R.5.**
       phase hits NO cap. Validated against a deliberately tiny-capped local
       relay — reported thresholds matched the configured caps exactly, and the
       no-cap-fired path was confirmed to FAIL rather than pass. Run it on
-      STAGING, never production (runbook: `genui-relay/DEPLOY.md` §6), after any
+      STAGING, never production (runbook: `mirafold-relay/DEPLOY.md` §6), after any
       cap retune or machine resize, and compare the numbers. The client can't
       tell the three capacity caps apart (all close 4004), so read the relay's
       own log line alongside it. Side effect: the live relay
@@ -2359,16 +2365,16 @@ bodies + dated history → PLAN-ARCHIVE.md ("Moved 2026-07-24").
   governs all future CD work in every repo (his job's `on-prod.yml` pattern: a
   human clicks *Run workflow* and picks the ref; nothing deploys on
   push/merge/schedule). Scaffolded for the relay in
-  `genui-relay/.github/workflows/deploy.yml` (`9162fa1`), with the R.5d
+  `mirafold-relay/.github/workflows/deploy.yml` (`9162fa1`), with the R.5d
   staging/production environment dropdown on it.
 - ~~**Owed at the public flip (carried in R.5b):** re-enable the cross-repo
   relay itest.~~ ✅ **DONE 2026-08-02.** Both exclusions are gone from `ci.yml`:
-  its two jobs check this repo out to `genui-shell/` and
-  `mirafold/mirafold-relay` to `genui-relay/` — siblings under the workspace,
+  its two jobs check this repo out to `mirafold/` and
+  `mirafold/mirafold-relay` to `mirafold-relay/` — siblings under the workspace,
   the same shape as a dev machine — then `npm ci` the relay, typecheck the
   **full** `tsconfig.json`, and run Tier 2 as plain `yarn test:server`. The
   relay needs its own install because module resolution walks up from
-  `genui-relay/src/` and never reaches this repo's `node_modules`. The relay is
+  `mirafold-relay/src/` and never reaches this repo's `node_modules`. The relay is
   public since 2026-07-31, so the default `GITHUB_TOKEN` reads it with no added
   secret.
   - **The checkout tracks the relay's default branch on purpose.** Pinning a
@@ -3425,7 +3431,7 @@ refusals → restored). Tier-1 443/443, Tier-2 137/137 with the gate in.
    exposure is harmless by construction (E2E keys derive from the code
    the relay never sees; ids die on daemon restart) — hiding the id
    better is defense-in-depth on a denial-only vector.
-3. **Stale `genui-relay/dist/` — deleted**, and `npm start` now runs a
+3. **Stale `mirafold-relay/dist/` — deleted**, and `npm start` now runs a
    `prestart` build, so a local run can never again execute months-old
    code (verified: `npm start` rebuilt dist with the new limits in it).
 

--- a/README.md
+++ b/README.md
@@ -541,11 +541,11 @@ server/            the local daemon (Node, run with tsx)
                        the encrypted relay channel) used by relay.itest.ts and
                        relay-service.itest.ts
                      NOTE: the hosted relay itself lives in the SIBLING repo
-                     `genui-relay` (its single source of truth; MIT since K.1,
-                     private until the R.5b/R.7 flip). relay-service.itest.ts
+                     `mirafold-relay` (its single source of truth; MIT since K.1,
+                     public since 2026-07-31). relay-service.itest.ts
                      (Tier 2) imports the relay under test from
-                     ../genui-relay/src/ and guards the routing contract
-                     against relay-protocol.ts — clone genui-relay next to
+                     ../mirafold-relay/src/ and guards the routing contract
+                     against relay-protocol.ts — clone mirafold-relay next to
                      this repo + `npm install` inside it to run that test;
                      without the sibling, the rest of Tier 2 is unaffected
   testing/           cross-cutting test infrastructure (H.8): itest-harness.ts
@@ -1319,7 +1319,7 @@ stub's ack contract over a real MCP handshake, the relay path over the
 in-repo stub: byte-for-byte local/remote mirror, a ciphertext-only tap audit
 of what the relay can observe, fail-closed tamper/wrong-code, daemon re-dial,
 and — against the actual DEPLOYED relay's code, imported from the sibling
-`genui-relay` checkout (not just the stub) — its own caps/rate-limit/
+`mirafold-relay` checkout (not just the stub) — its own caps/rate-limit/
 health-check hardening and a routing-contract guard), and `*.e2e.ts` (Tier 3 — token→cookie boot, a full turn
 rendering in the DOM, the artifact iframe executing under the CSP with a
 hostile-artifact containment proof (each defense verified by flipping it),
@@ -1467,7 +1467,7 @@ Read PLAN.md for the real thing; the shape in one breath:
   no longer leaves a fake "still working" state (R.4c); and the artifact
   sandbox's containment properties are now proven by tests that fail when
   each defense is flipped (R.4e). Also: **R.2's code half** — the
-  deployable relay service (the sibling `genui-relay` repo), hardened (caps,
+  deployable relay service (the sibling `mirafold-relay` repo), hardened (caps,
   rate limit, health
   check) and verified against the real daemon, with the "no app bundle
   served" trust decision made and documented; and three **Phase F** fidelity
@@ -1484,10 +1484,10 @@ Read PLAN.md for the real thing; the shape in one breath:
   tiers; docs + BUSINESS.md reconciled to match.
 - **Also shipped (2026-07-12):** **R.2's deploy** — the relay runs hosted
   on Fly.io (`relay.mirafold.sh`), and a real daemon has driven a full turn
-  through it; the box stays open only on a cellular-phone pass and baking
-  the default relay URL.
+  through it. The cellular and wifi→LTE passes plus the default relay URL
+  closed 2026-07-30; the local repository/path rename closed 2026-08-09.
 - **Also shipped (2026-07-14 → 17):** the **maintainability restructure**
-  (Phases G/H/H2 — the sibling `genui-relay` repo became the relay's single
+  (Phases G/H/H2 — the sibling `mirafold-relay` repo became the relay's single
   source of truth, and the server/web layout §4 describes is H's work);
   **Phase S** — the launch theme set on one-file-per-theme plumbing (§7,
   seven themes after V.1's Standard pair + light consolidation);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",

--- a/server/pty/pty.test.ts
+++ b/server/pty/pty.test.ts
@@ -175,7 +175,7 @@ test("spawnBang throws the same clean error for a bare missing shell name", () =
 });
 
 test("shellFound walks PATH for bare names and PATHEXT on win32", () => {
-  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "genui-shellfound-"));
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mirafold-shellfound-"));
   try {
     fs.writeFileSync(path.join(dir, "myshell"), "#!/bin/sh\n");
     fs.writeFileSync(path.join(dir, "wshell.EXE"), "");

--- a/server/relay/relay-service.itest.ts
+++ b/server/relay/relay-service.itest.ts
@@ -17,8 +17,8 @@ import {
   MIN_PAIR_ID_LENGTH,
 } from "./relay-protocol";
 import { MAX_ENVELOPE } from "./relay-client";
-import { startRelay, type Relay } from "../../../genui-relay/src/relay";
-import { LIMITS as SERVICE_LIMITS } from "../../../genui-relay/src/limits";
+import { startRelay, type Relay } from "../../../mirafold-relay/src/relay";
+import { LIMITS as SERVICE_LIMITS } from "../../../mirafold-relay/src/limits";
 import {
   CLOSE_FORBIDDEN_ORIGIN as SERVICE_CLOSE_FORBIDDEN_ORIGIN,
   CLOSE_OVERLOADED,
@@ -26,7 +26,7 @@ import {
   CLOSE_UNENTITLED,
   SHARED_CONTRACT,
   MIN_PAIR_ID_LENGTH as SERVICE_MIN_PAIR_ID_LENGTH,
-} from "../../../genui-relay/src/contract";
+} from "../../../mirafold-relay/src/contract";
 import { viewportRefusalReason } from "../../web/src/ws";
 
 // Mints a token the exact way the R.5 billing backend does — the compact
@@ -38,7 +38,7 @@ const mintToken = (priv: KeyObject, expSeconds: number): string => {
 };
 
 // The DEPLOYED relay service, verified against the real daemon locally —
-// sourced from the sibling `genui-relay` repo, the relay's single home since
+// sourced from the sibling `mirafold-relay` repo, the relay's single home since
 // Phase G retired the vendored `relay-service/` copy. The R.3 crypto path and
 // byte-for-byte parity are already proven against the stub (relay.itest.ts);
 // here we prove the grown-up service is a faithful forwarder AND that its

--- a/server/relay/relay.itest.ts
+++ b/server/relay/relay.itest.ts
@@ -237,7 +237,7 @@ test("a weak pinned MIRAFOLD_RELAY_CODE is refused: the daemon mints and the wea
 
 test("R.5: a gated relay refuses a token-less daemon (actionable line) and admits one with MIRAFOLD_ENTITLEMENT_TOKEN", async () => {
   // The stub's exact-match gate models the real relay's refusal shape (the
-  // real signature check is pinned in genui-relay's own suite + the sibling
+  // real signature check is pinned in mirafold-relay's own suite + the sibling
   // service itest). This is the CI-runnable proof of the daemon's SEND path.
   const TOKEN = "itest-beta-token";
   const GATED_CODE = "itest-gated-code-8c2e1b";

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1972,7 +1972,7 @@ const eventually = async (check: () => boolean, message: string, timeout = 10_00
 };
 
 test("E.3: the files panel lists the working tree, opens a file beside the transcript, drills back", async () => {
-  // The e2e daemon runs in the genui-shell repo itself — a real git repo — so
+  // The e2e daemon runs in the Mirafold repo itself — a real git repo — so
   // the tree is live git data. package.json is always tracked and top-level.
   await page.locator(".ab-files").click();
   await page.waitForSelector(".files-panel");

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -1,7 +1,7 @@
 {
   // Single-repo typecheck config. Identical to tsconfig.json except it excludes
   // the one cross-repo file: server/relay/relay-service.itest.ts imports the
-  // relay under test from the SIBLING ../genui-relay checkout (README §"sibling
+  // relay under test from the SIBLING ../mirafold-relay checkout (README §"sibling
   // itest"), which a lone checkout of this repo doesn't have.
   //
   // Used by .github/workflows/release.yml ONLY, and now for a different reason

--- a/web/src/components/files/files-panel.test.ts
+++ b/web/src/components/files/files-panel.test.ts
@@ -12,7 +12,7 @@ test("isCurrentReply: only the awaited id is accepted", () => {
 });
 
 test("rootNameOf: the root row carries the folder's name, not the path", () => {
-  assert.equal(rootNameOf("~/Projects/mirafold/genui-shell"), "genui-shell");
+  assert.equal(rootNameOf("~/Projects/mirafold/mirafold"), "mirafold");
   assert.equal(rootNameOf("~/Projects/x/"), "x", "trailing slash is ignored");
   assert.equal(rootNameOf("~"), "~", "home itself keeps the tilde");
   assert.equal(rootNameOf("/"), "/", "filesystem root stays legible");

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -624,15 +624,24 @@ function setupRelay(t: TestContext) {
   return { dom, client, sock: () => FakeWS.instances.at(-1)! };
 }
 
-/** Complete the daemon half of the handshake on `s`; returns the daemon-side
- *  cipher so tests can open the client's subsequent ciphertext frames. */
-async function answerHandshake(s: FakeWS) {
+/** Complete the daemon half of the handshake on `s`, waiting for the client's
+ *  public open signal rather than a fixed number of event-loop turns; returns
+ *  the daemon-side cipher for opening subsequent client ciphertext frames. */
+async function answerHandshake(s: FakeWS, client: SocketClient) {
   const pair = await derivePair(PAIR_CODE);
   await drainUntil(() => s.sent.length >= 1, "client handshake frame sent");
   const clientNonce = await openHandshake(pair, "c", s.sent[0]);
   const daemonNonce = randomBytes(32);
-  s.receiveRaw(await sealHandshake(pair, "d", daemonNonce));
-  await drain();
+  let opened = false;
+  const stopWatchingOpen = client.onOpen(() => {
+    opened = true;
+  });
+  try {
+    s.receiveRaw(await sealHandshake(pair, "d", daemonNonce));
+    await drainUntil(() => opened, "client handshake completed");
+  } finally {
+    stopWatchingOpen();
+  }
   return frameCiphers(pair, clientNonce, daemonNonce, "d");
 }
 
@@ -675,7 +684,7 @@ test("relay path: a completed handshake resets the ladder (health = usable chann
   // …then a healthy handshaken connect resets it.
   const healthy = sock();
   healthy.open();
-  await answerHandshake(healthy);
+  await answerHandshake(healthy, client);
   healthy.finishClose(); // ordinary drop after a healthy session
   const before = FakeWS.instances.length;
   let waited = 0;
@@ -729,7 +738,7 @@ test("relay path: a handshake completion racing a close keeps the pending queue 
   const two = sock();
   assert.notEqual(two, one);
   two.open();
-  const daemonCipher = await answerHandshake(two);
+  const daemonCipher = await answerHandshake(two, client);
   await drainUntil(() => two.sent.length >= 2, "queued prompt re-sent on the new life");
   const first = JSON.parse(await daemonCipher.open(two.sent[1])) as { type: string; text?: string };
   assert.equal(first.type, "prompt");

--- a/web/src/ws.ts
+++ b/web/src/ws.ts
@@ -14,7 +14,7 @@ import {
 type Listener = (msg: WireMsg) => void;
 
 // The relay's stable close codes a VIEWPORT can be refused with. A small
-// hand-mirror of the relay's contract (genui-relay contract.ts — 4006 has no
+// hand-mirror of the relay's contract (mirafold-relay contract.ts — 4006 has no
 // constant in relay-protocol.ts at all) — relay-protocol.ts pulls in
 // node:crypto and can't cross into the web bundle, so these three codes are
 // duplicated. Pinned DIRECTLY against contract.ts by relay-service.itest.ts,


### PR DESCRIPTION
## Summary
- ship the completed local repository rename from genui-shell to mirafold
- update sibling integration paths, CI checkout layout, current documentation, and test fixtures
- preserve the deployed Fly app identifiers and the frozen genui-relay v1 protocol salt
- bump the Mirafold package version from 0.3.5 to 0.3.6

## Verification
- feature PR #26: DCO, Cloudflare Pages, Tier 1, and combined Tier 2 + Tier 3 all passed
- local yarn typecheck passed on the release branch
- local feature verification passed: Tier 1 563/563, Tier 2 143/143, Tier 3 82/82

## Release behavior
Merging this pull request advances the production mirror on main. It does not publish npm by itself; publishing begins only when the human-signed v0.3.6 tag is pushed according to docs/RELEASING.md.