### PR TITLE
test: await relay handshake completion

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -652,7 +652,15 @@ notifications are **not** part of the launch and are not sold until built.
     `genui-relay` / `genui-relay-staging`, and the `genui-relay v1`
     key-derivation salt remains frozen as a protocol contract. Verified after
     the rename: Mirafold typecheck; Tier 1 563/563, Tier 2 143/143, Tier 3
-    82/82; relay typecheck and 38/38 relay tests.
+    82/82; relay typecheck and 38/38 relay tests. **Release-gate follow-up
+    (2026-08-09):** release PR #27 exposed a pre-existing test-only race: the
+    relay-handshake helper waited a fixed number of event-loop turns before
+    closing its healthy socket, so delayed WebCrypto work could miss the
+    backoff reset. The helper now waits for `SocketClient.onOpen()` — the
+    product state transition the assertion actually depends on. The exact
+    test went from 4/20 failures under concurrent load before the fix to 0/20
+    after it; the containing file passed 32/32, Tier 1 passed 563/563, and
+    typecheck passed.
   - Done when: a phone on cellular (not the home wifi) drives a home
     session through the deployed relay, and the relay's logs show it
     learned nothing but connection metadata.

--- a/web/src/ws.test.ts
+++ b/web/src/ws.test.ts
@@ -624,15 +624,24 @@ function setupRelay(t: TestContext) {
   return { dom, client, sock: () => FakeWS.instances.at(-1)! };
 }
 
-/** Complete the daemon half of the handshake on `s`; returns the daemon-side
- *  cipher so tests can open the client's subsequent ciphertext frames. */
-async function answerHandshake(s: FakeWS) {
+/** Complete the daemon half of the handshake on `s`, waiting for the client's
+ *  public open signal rather than a fixed number of event-loop turns; returns
+ *  the daemon-side cipher for opening subsequent client ciphertext frames. */
+async function answerHandshake(s: FakeWS, client: SocketClient) {
   const pair = await derivePair(PAIR_CODE);
   await drainUntil(() => s.sent.length >= 1, "client handshake frame sent");
   const clientNonce = await openHandshake(pair, "c", s.sent[0]);
   const daemonNonce = randomBytes(32);
-  s.receiveRaw(await sealHandshake(pair, "d", daemonNonce));
-  await drain();
+  let opened = false;
+  const stopWatchingOpen = client.onOpen(() => {
+    opened = true;
+  });
+  try {
+    s.receiveRaw(await sealHandshake(pair, "d", daemonNonce));
+    await drainUntil(() => opened, "client handshake completed");
+  } finally {
+    stopWatchingOpen();
+  }
   return frameCiphers(pair, clientNonce, daemonNonce, "d");
 }
 
@@ -675,7 +684,7 @@ test("relay path: a completed handshake resets the ladder (health = usable chann
   // …then a healthy handshaken connect resets it.
   const healthy = sock();
   healthy.open();
-  await answerHandshake(healthy);
+  await answerHandshake(healthy, client);
   healthy.finishClose(); // ordinary drop after a healthy session
   const before = FakeWS.instances.length;
   let waited = 0;
@@ -729,7 +738,7 @@ test("relay path: a handshake completion racing a close keeps the pending queue 
   const two = sock();
   assert.notEqual(two, one);
   two.open();
-  const daemonCipher = await answerHandshake(two);
+  const daemonCipher = await answerHandshake(two, client);
   await drainUntil(() => two.sent.length >= 2, "queued prompt re-sent on the new life");
   const first = JSON.parse(await daemonCipher.open(two.sent[1])) as { type: string; text?: string };
   assert.equal(first.type, "prompt");


### PR DESCRIPTION
## Cause
The relay-handshake test helper waited a fixed 25 event-loop turns after delivering the daemon handshake. Under concurrent WebCrypto load, SocketClient could still be processing that frame when the test closed the socket. The close then won before finishOpen reset the reconnect backoff, producing the observed 2000 ms assertion failure.

This is a test synchronization race only; runtime code is unchanged.

## Fix
Wait for the public SocketClient.onOpen signal, which occurs after finishOpen resets the backoff, before the helper returns.

## Reproduction and verification
- before: exact targeted test failed 4/20 concurrent runs
- after: exact targeted test passed 20/20 under the same load
- containing WebSocket file: 32/32
- Tier 1: 563/563
- yarn typecheck: passed

This pull request unblocks release PR #27. Per docs/RELEASING.md, it must merge into next before the release branch is updated.