### PR TITLE
sync: main into next after v0.3.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
## Purpose
Close the v0.3.6 release loop by syncing the fixed main release snapshot back into next, as required by docs/RELEASING.md.

The content diff is only the package.json version change from 0.3.5 to 0.3.6; the merge also carries the release history so the next release will not conflict.

## Verified release
- signed v0.3.6 tag targets main commit bdecc7c4096cf0da23e391ac254ca630bb223809
- guarded provenance release workflow succeeded
- npm reports mirafold 0.3.6
- registry tarball SHA-256 matches the signed tag: c4398ed0a21bfa5580673a59c14499377a3167bbfa2d69ff9ef1c82dc63d46dc