### PR TITLE
docs: close Phase UX handoff and isolate CI

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -98,6 +98,13 @@ recovery, and the approved transcript-click prompt return behavior.
 - PR #31 passed every reported merge check: DCO, Cloudflare Pages, Tier 1
   typecheck/unit, and combined Tier 2/Tier 3 integration/browser. GitHub then
   merged it into `next` as `9e833849`.
+- The first PR #32 wrapup check exposed a pre-existing Tier 2 hermeticity
+  flake after every `backend-choice.itest.ts` assertion passed: session
+  activation had started the host Codex prompt-catalog process, which could
+  still write into its temporary `CODEX_HOME` while the suite removed that
+  directory. The backend-routing test now points catalog discovery at a
+  deliberately missing binary, so no host process can outlive daemon cleanup;
+  the focused file passed 10/10 unchanged repetitions after the fix.
 - Tier 4 remains intentionally red rather than hidden: the real local
   Codex/Ollama turn timed out in three of four unchanged attempts and passed
   once after 145.5 seconds. Its timeout cleanup is fixed and forced-abort

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,7 +1,8 @@
-# Session handoff — Phase UX / agent-session-continuity
+# Session handoff — Phase UX integrated / next work
 
-This handoff is current as of 2026-08-10. It becomes stale when the feature
-branch is integrated, replaced, or receives later Phase UX changes.
+This handoff is current as of 2026-08-10 after Phase UX was integrated into
+`next`. It becomes stale when `next` receives later work or the roadmap priority
+changes.
 
 **Project**: Mirafold, a browser re-skin of Claude Code, Codex, and Gemini CLI.
 Phase UX and its UX.6/UX.7/UX.8/UX.9 follow-ups are complete: faithful pre-submit
@@ -69,11 +70,13 @@ recovery, and the approved transcript-click prompt return behavior.
 
 **Current state**
 
-- Branch: `feature/agent-session-continuity`, based on `next`.
-- The 2026-08-09 Phase UX implementation is committed and pushed. The UX.6
-  implementation/refactor, UX.7/UX.8 fixes, and UX.9 test repairs and records
-  from 2026-08-10 are in the working tree and have not been committed or
-  pushed; neither action was requested in this pass.
+- Phase UX and its UX.6–UX.9 follow-ups are committed, pushed, and integrated
+  into `next` through PR #31 (`9e833849`). All implementation, test, and
+  product-documentation changes from the completed feature work are integrated;
+  this documentation-only wrapup corrects the stale plan and handoff metadata.
+- PR #31 carried the same product tree as closed draft PR #30, replacing that
+  draft only so the final follow-up commit could carry the repository's
+  required DCO sign-off.
 - Main seams: `server/sessions/session-store.ts`, transcript repair in
   `server/sessions/session-recovery.ts`, lifecycle in `server/sessions/registry.ts`,
   provider plumbing under `server/adapters/`, `web/src/prompt-completions.ts`,
@@ -92,6 +95,9 @@ recovery, and the approved transcript-click prompt return behavior.
   final guarded gates passed at 583/583 unit, 131/131 server integration, and
   70/70 browser, plus TypeScript checking, fresh client/server production
   builds, focused mutation reruns, and `git diff --check`.
+- PR #31 passed every reported merge check: DCO, Cloudflare Pages, Tier 1
+  typecheck/unit, and combined Tier 2/Tier 3 integration/browser. GitHub then
+  merged it into `next` as `9e833849`.
 - Tier 4 remains intentionally red rather than hidden: the real local
   Codex/Ollama turn timed out in three of four unchanged attempts and passed
   once after 145.5 seconds. Its timeout cleanup is fixed and forced-abort

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -7358,3 +7358,11 @@ UX.6 refactor, UX.7 correctness repairs, UX.8 security hardening, and UX.9
 test-audit repairs landed in `next` through PR #31 at merge commit `9e833849`.
 DCO, Cloudflare Pages, Tier 1 typecheck/unit, and combined Tier 2/Tier 3
 integration/browser checks all passed before merge.
+
+The documentation wrapup PR #32 then exposed one test-only hermeticity flake:
+all backend-choice assertions passed, but the suite's real host Codex
+prompt-catalog process could outlive the daemon and race removal of its
+temporary `CODEX_HOME` (`ENOTEMPTY`). The backend-routing integration test now
+uses a deliberately missing Codex binary for catalog discovery; it never drives
+a provider process, retains the exact backend-choice assertions, and passed
+10/10 unchanged focused repetitions after the fix.

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -7352,3 +7352,9 @@ Step L.4 and was not changed during this test-audit workflow.
 `server/testing/launcher.e2e.ts`, and the Explorer/global-axe browser cases
 whose fixtures enter the same forbidden filename class. No dotenv file was
 inspected. No dependency, commit, or push was added.
+
+**Integration closure (2026-08-10):** the complete Phase UX implementation,
+UX.6 refactor, UX.7 correctness repairs, UX.8 security hardening, and UX.9
+test-audit repairs landed in `next` through PR #31 at merge commit `9e833849`.
+DCO, Cloudflare Pages, Tier 1 typecheck/unit, and combined Tier 2/Tier 3
+integration/browser checks all passed before merge.

--- a/PLAN.md
+++ b/PLAN.md
@@ -168,7 +168,9 @@ investigation, the CI-flake breakdown, and finished stretch-goal specs) ·
   follow-up correctness findings and every security-audit item—including the
   hardening-only and theoretical findings—are closed with direct regressions. Full
   specification, implementation/refactor/correctness/security record, and proof live in
-  **PLAN-ARCHIVE.md** under “Moved 2026-08-09.”
+  **PLAN-ARCHIVE.md** under “Moved 2026-08-09.” The complete phase and its
+  UX.6–UX.9 follow-ups landed in `next` through PR #31 (`9e833849`) after DCO,
+  Cloudflare Pages, Tier 1, and combined Tier 2/Tier 3 all passed.
 - [x] **Step UX.6 — Settle prompt return behavior, then refactor Phase UX** —
   done 2026-08-10; accepted desktop transcript-click behavior replaced the
   provisional binding, and the full Phase UX diff received a verified

--- a/server/sessions/backend-choice.itest.ts
+++ b/server/sessions/backend-choice.itest.ts
@@ -11,8 +11,11 @@ import type { ClientMsg, WireMsg } from "../protocol";
 // names the resolved backend without exposing its URL; a local pick's model label reaches
 // session_created on the wire) and NEVER trusted (a prohibited or stale
 // choice refuses with an error frame, no session). Codex only on the live
-// paths — its engine constructs lazily (no process, no network until a turn),
-// so creating sessions here stays hermetic; claude exercises refusal only.
+// paths. Engine turns remain lazy, but session activation also starts Codex's
+// provider-owned prompt catalog. This backend-routing suite points that catalog
+// at a deliberately missing binary so it never launches the host Codex process;
+// catalog process behavior is covered separately and this suite stays hermetic.
+// Claude exercises refusal only.
 
 let fixture: OllamaFixture;
 let origin = "";
@@ -30,6 +33,7 @@ before(async () => {
   daemon = await startDaemon({
     OPENAI_API_KEY: "sk-dummy",
     CODEX_HOME: codexDir,
+    MIRAFOLD_CODEX_BIN: path.join(codexDir, "missing-codex"),
     CLAUDE_CONFIG_DIR: claudeDir,
     MIRAFOLD_LOCAL_ENDPOINTS: origin,
     REFRESH_MIN_INTERVAL_MS: "50",


### PR DESCRIPTION
## Summary

- record that Phase UX and UX.6 through UX.9 merged into next through PR #31
- replace the stale feature-branch and uncommitted-work state in HANDOFF.md
- add the successful merge-check record to the active plan and archived Phase UX history
- preserve Step L.4 as the open live Codex/Ollama follow-up without changing roadmap priority
- keep the backend-choice integration test hermetic by preventing prompt catalog discovery from launching the installed host Codex process

## Flake diagnosis and fix

The first combined Tier 2/Tier 3 run passed every backend-choice assertion, then failed its after hook with ENOTEMPTY while removing the temporary CODEX_HOME. Registry activation now starts the Codex skills catalog before a model turn; the test had therefore launched a real host codex app-server, which could outlive the daemon and race temporary-directory cleanup.

This backend-routing suite now points MIRAFOLD_CODEX_BIN at a deliberately missing path inside its throwaway directory. Catalog discovery fails harmlessly, no provider process is launched, and the backend-choice behavior under test is unchanged.

## Scope

HANDOFF.md, PLAN.md, PLAN-ARCHIVE.md, and server/sessions/backend-choice.itest.ts. No product runtime, configuration contract, dependency, or product-documentation contract changed.

## Verification

- focused backend-choice integration file passed 10 / 10 consecutive stress runs after the fix, plus one final focused run
- TypeScript checking passed under the dotenv-denial guard
- working-tree and staged diff checks passed
- both commits include the required DCO sign-off
- no session-owned process remains running