### PR TITLE
feat(explorer): polish file tree visuals

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,8 +1,9 @@
-# Session handoff — Phase UX integrated / Codex local-turn diagnosis complete
+# Session handoff — Codex local-turn fix integrated / Explorer polish complete
 
-This handoff is current as of 2026-08-11 after Step L.4 was completed on branch
-`fix/codex-ollama-turn-stall`. It becomes stale when that work is integrated,
-`next` receives later work, or the roadmap priority changes.
+This handoff is current as of 2026-08-11 after PR #33 integrated Step L.4 and
+Phase E3 was completed on branch `feature/explorer-visual-polish`. It becomes
+stale when that branch is integrated, `next` receives other work, or the
+roadmap priority changes.
 
 **Project**: Mirafold, a browser re-skin of Claude Code, Codex, and Gemini CLI.
 Phase UX and its UX.6/UX.7/UX.8/UX.9 follow-ups are complete: faithful pre-submit
@@ -76,14 +77,22 @@ recovery, and the approved transcript-click prompt return behavior.
   selects only an explicitly 32K-configured model in stable order, preventing
   both recency drift and silent 4K prompt truncation from producing a false
   green; a real closed-port case pins unavailable-engine behavior.
+- Completed Phase E3's Explorer visual polish. The existing read-only tree now
+  has an inset workbench surface, compact rows and hierarchy guides, matching
+  SVG disclosure controls, and small decorative open/closed-folder, symlink,
+  and broad file-family glyphs immediately after names. The glyph set is
+  dependency-free and theme-token driven; tree data, Git status, fetching,
+  sorting, drill-in/lightbox, refresh, and phone navigation are unchanged.
 
 **Current state**
 
-- Phase UX and its UX.6–UX.9 follow-ups are committed, pushed, and integrated
-  into `next` through PR #31 (`9e833849`), with the documentation wrapup in PR
-  #32. Step L.4 is complete in the current working tree on
-  `fix/codex-ollama-turn-stall`; this `$next` pass did not commit, push, or open
-  a pull request.
+- Phase UX and its UX.6–UX.9 follow-ups are integrated into `next` through PR
+  #31 (`9e833849`), with the documentation wrapup in PR #32. Step L.4 is
+  integrated through PR #33 (`843f9f2c`). Local `next` is at that exact merge.
+- Phase E3 is complete on `feature/explorer-visual-polish`, cut from
+  `843f9f2c`. Its destination is one focused PR into `next`; Kyle explicitly
+  wants that PR held unmerged until a new instruction, and no roadmap `$next`
+  chunk should start before then.
 - PR #31 carried the same product tree as closed draft PR #30, replacing that
   draft only so the final follow-up commit could carry the repository's
   required DCO sign-off.
@@ -93,11 +102,11 @@ recovery, and the approved transcript-click prompt return behavior.
   `web/src/transcript-focus.ts`, prompt UI in `web/src/components/PromptBox.tsx`,
   and settled activity in `web/src/tool-visibility.ts` /
   `web/src/components/RenderZone.tsx`.
-- `PLAN.md` marks UX.6 through UX.9 and L.4 complete. The earlier open roadmap
-  pointer in document order remains Step 4.7, expanded into Phase R; Phase R's
-  remaining steps include Kyle-led/manual release work, so the next executable
-  chunk must be selected from current prerequisites rather than inferred from
-  checkbox order alone.
+- `PLAN.md` marks UX.6 through UX.9, L.4, and E3 complete. The earlier open
+  roadmap pointer in document order remains Step 4.7, expanded into Phase R;
+  Phase R's remaining steps include Kyle-led/manual release work, so a later
+  executable chunk must be selected from current prerequisites rather than
+  inferred from checkbox order alone.
 
 **Verification**
 
@@ -109,6 +118,8 @@ recovery, and the approved transcript-click prompt return behavior.
 - PR #31 passed every reported merge check: DCO, Cloudflare Pages, Tier 1
   typecheck/unit, and combined Tier 2/Tier 3 integration/browser. GitHub then
   merged it into `next` as `9e833849`.
+- PR #33 passed DCO, Cloudflare Pages, Tier 1, and combined Tier 2/Tier 3;
+  GitHub merged it into `next` as `843f9f2c` under Kyle's explicit approval.
 - The first PR #32 wrapup check exposed a pre-existing Tier 2 hermeticity
   flake after every `backend-choice.itest.ts` assertion passed: session
   activation had started the host Codex prompt-catalog process, which could
@@ -123,6 +134,11 @@ recovery, and the approved transcript-click prompt return behavior.
   Tier 4 wrapper passed 3, skipped the credential-required OpenRouter case, and
   failed 0; Tier 1 passed 615/615, and TypeScript, production build, and diff
   whitespace checks passed.
+- Phase E3 passed all 162 front-end unit tests, TypeScript checking, and the
+  client/server production build. A controlled no-dotenv fixture rendered the
+  correct glyph families at desktop and phone widths; the 390px phone frame
+  had no side-scroll; dark and light theme-token rendering passed; and focused
+  desktop/phone browser assertions plus axe serious/critical sweeps passed.
 - Two unit files and one integration file that deliberately manufacture dotenv
   fixtures were excluded under the account-wide opacity rule. The launcher
   browser file and Explorer/global-axe cases that handle that configuration
@@ -151,5 +167,9 @@ recovery, and the approved transcript-click prompt return behavior.
   `num_ctx >= 32768` proof, stable sorting, real text/no-error assertion, and
   abort cleanup. `/effort none` must remain an explicit local choice—not a
   silent override of inherited Codex behavior.
+- Keep Explorer glyphs decorative and bounded to broad families. Do not turn
+  `ExplorerNodeGlyph.tsx` into a claimed exhaustive language detector or add an
+  icon dependency for this small local surface; filename text and tree
+  semantics remain the accessible source of truth.
 - Preserve dotenv opacity: never inspect `.env`, `*.env`, `.env.*`, or
   `*.env.*`, and explicitly exclude them from recursive searches/listings.

--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,11 @@
-# Session handoff — Codex local-turn fix integrated / Explorer polish complete
+# Session handoff — Explorer approved; Codex refactor uncommitted
 
-This handoff is current as of 2026-08-11 after PR #33 integrated Step L.4 and
-Phase E3 was completed on branch `feature/explorer-visual-polish`. It becomes
-stale when that branch is integrated, `next` receives other work, or the
-roadmap priority changes.
+This handoff is current as of 2026-08-11 after Kyle approved the second
+Explorer visual pass and requested the large `$refactor` pass. Both the
+accepted Explorer revision and the Codex decomposition remain uncommitted on
+the open PR #34 branch. It becomes stale when those changes are committed or
+revised, the branch is integrated, `next` receives other work, or the roadmap
+priority changes.
 
 **Project**: Mirafold, a browser re-skin of Claude Code, Codex, and Gemini CLI.
 Phase UX and its UX.6/UX.7/UX.8/UX.9 follow-ups are complete: faithful pre-submit
@@ -77,22 +79,50 @@ recovery, and the approved transcript-click prompt return behavior.
   selects only an explicitly 32K-configured model in stable order, preventing
   both recency drift and silent 4K prompt truncation from producing a false
   green; a real closed-port case pins unavailable-engine behavior.
-- Completed Phase E3's Explorer visual polish. The existing read-only tree now
+- Completed the committed E3.1 Explorer pass. The existing read-only tree now
   has an inset workbench surface, compact rows and hierarchy guides, matching
   SVG disclosure controls, and small decorative open/closed-folder, symlink,
   and broad file-family glyphs immediately after names. The glyph set is
   dependency-free and theme-token driven; tree data, Git status, fetching,
   sorting, drill-in/lightbox, refresh, and phone navigation are unchanged.
+- Completed and visually approved E3.2 locally. Decorative node glyphs now sit
+  in the conventional position left of names; the Explorer has a stable dock,
+  compact Files toolbar, workspace-root strip, inset row rhythm, and quiet
+  aligned Git markers consistent with the rest of the workbench. Refresh and
+  phone close moved into the toolbar without changing their behavior.
+
+**In progress — accepted/refactored locally, still uncommitted**
+
+- The repository-wide refactor recon selected existing Step D.1 rather than
+  inventing a new abstraction target. `server/adapters/codex.ts` fell from
+  1,004 to 382 lines and now contains `CodexSession` state/lifecycle only.
+  New `codex-binding.ts`, `codex-commands.ts`, `codex-diagnostics.ts`,
+  `codex-events.ts`, `codex-prompt.ts`, and `codex-rollout.ts` own the existing
+  provider/runtime, command/prompt-discovery, diagnostic, event-normalization,
+  prompt-constant, and rollout seams. Public `codex.ts` re-exports and the
+  `AgentSession`/wire/config behavior are unchanged; this refactor added or
+  changed no dependency, feature, validation, logging, test assertion, or test
+  file. The working tree's separate E3.2 browser-test edits predate D.1.
+- D.1's local code target is met, but its roadmap checkbox remains open because
+  the full Tier 2/Tier 3/Tier 4 gates and manual subscription/OpenRouter turns
+  were not claimed or run. Keep the state-mutating thread wrappers in
+  `CodexSession`; moving them behind a new controller would disturb fields the
+  existing regression suite deliberately observes and was held back as an
+  unproven abstraction.
+- Kyle approved the Explorer visual result but did not request a commit, push,
+  or PR update. The refactor skill also forbids those without approval. Do not
+  commit, push, or merge PR #34 until he gives explicit Git direction.
 
 **Current state**
 
 - Phase UX and its UX.6–UX.9 follow-ups are integrated into `next` through PR
   #31 (`9e833849`), with the documentation wrapup in PR #32. Step L.4 is
   integrated through PR #33 (`843f9f2c`). Local `next` is at that exact merge.
-- Phase E3 is complete on `feature/explorer-visual-polish`, cut from
-  `843f9f2c`. Its destination is one focused PR into `next`; Kyle explicitly
-  wants that PR held unmerged until a new instruction, and no roadmap `$next`
-  chunk should start before then.
+- The committed E3.1 pass is at `0652425a` on
+  `feature/explorer-visual-polish`, cut from `843f9f2c`, and is published as
+  open PR #34 into `next`. The approved E3.2 revision and D.1 refactor are
+  present only in the uncommitted working tree described above. PR #34 remains
+  held open and unmerged.
 - PR #31 carried the same product tree as closed draft PR #30, replacing that
   draft only so the final follow-up commit could carry the repository's
   required DCO sign-off.
@@ -102,8 +132,10 @@ recovery, and the approved transcript-click prompt return behavior.
   `web/src/transcript-focus.ts`, prompt UI in `web/src/components/PromptBox.tsx`,
   and settled activity in `web/src/tool-visibility.ts` /
   `web/src/components/RenderZone.tsx`.
-- `PLAN.md` marks UX.6 through UX.9, L.4, and E3 complete. The earlier open
-  roadmap pointer in document order remains Step 4.7, expanded into Phase R;
+- `PLAN.md` marks UX.6 through UX.9, L.4, and E3 complete; D.1 records its
+  locally complete implementation while retaining its unchecked live/higher-
+  tier closure. The earlier open roadmap pointer in document order remains
+  Step 4.7, expanded into Phase R;
   Phase R's remaining steps include Kyle-led/manual release work, so a later
   executable chunk must be selected from current prerequisites rather than
   inferred from checkbox order alone.
@@ -139,6 +171,12 @@ recovery, and the approved transcript-click prompt return behavior.
   correct glyph families at desktop and phone widths; the 390px phone frame
   had no side-scroll; dark and light theme-token rendering passed; and focused
   desktop/phone browser assertions plus axe serious/critical sweeps passed.
+- The Codex refactor passed 603 safe unit tests (178 adapter/session tests, the
+  9 Codex and 4 Gemini catalog tests independently, 4 version tests, 246 other
+  server tests, and 162 web tests), TypeScript, the production client/server
+  build, and `git diff --check`. The aggregate runner's previously characterized
+  catalog/version interaction was not treated as a product failure: each of
+  those unchanged files passed alone. No live or metered provider was called.
 - Two unit files and one integration file that deliberately manufacture dotenv
   fixtures were excluded under the account-wide opacity rule. The launcher
   browser file and Explorer/global-axe cases that handle that configuration
@@ -167,7 +205,8 @@ recovery, and the approved transcript-click prompt return behavior.
   `num_ctx >= 32768` proof, stable sorting, real text/no-error assertion, and
   abort cleanup. `/effort none` must remain an explicit local choice—not a
   silent override of inherited Codex behavior.
-- Keep Explorer glyphs decorative and bounded to broad families. Do not turn
+- Keep Explorer glyphs decorative, left of their names, and bounded to broad
+  families. Do not turn
   `ExplorerNodeGlyph.tsx` into a claimed exhaustive language detector or add an
   icon dependency for this small local surface; filename text and tree
   semantics remain the accessible source of truth.

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -7440,3 +7440,62 @@ credential-required OpenRouter case, and failed 0. Tier 1 passed 615/615;
 TypeScript checking, the client/server production build, and `git diff --check`
 passed. No metered model, dependency, wire protocol, user config file, or
 dotenv file was touched.
+
+## Moved 2026-08-11 (Explorer visual polish — full body)
+
+### Phase E3 — Explorer visual polish (completed 2026-08-11)
+
+**Goal:** make the existing read-only Explorer feel like a finished part of
+Mirafold's workbench while preserving its interaction and data contracts.
+
+**Verified starting state:** `web/src/components/files/FilesPanel.tsx` rendered
+the root, directories, files, and symlinks as text rows with Unicode disclosure
+carets, indentation, hover fill, and optional Git status letters. The Explorer
+block in `web/src/styles.css` left `.files-panel` transparent and supplied no
+node-type glyph or hierarchy guide. A controlled 1440×900 browser baseline
+showed six rows, zero `.files-node-icon` elements, and a transparent computed
+panel background. Lazy fetching, read-only drill-in, file lightbox, and phone
+dialog behavior already existed and were not defects in this phase.
+
+**References:** VS Code's official file-icon-theme documentation establishes
+alongside-name icons as type signals in Explorer; JetBrains' official Project
+tool-window documentation establishes compact project trees and optional
+indent guides; GitHub's repository tree supplied the quieter web-facing bound.
+Mirafold uses those conventions through its own theme tokens and glyph shapes,
+not another product's icon set.
+
+**Executable changes:** `FilesPanel.tsx` now renders matching inline-SVG
+chevrons, quiet per-depth guides, and one decorative glyph immediately after
+each node name. New `ExplorerNodeGlyph.tsx` classifies only broad families:
+open/closed folder, symlink, code, configuration/data, documentation, styles,
+images, and generic file. `styles.css` gives desktop and phone frames an inset
+surface, stronger sticky root strip, compact row rhythm, theme-token glyph
+colors, hover/active treatment, thin tree scrollbar, and compact Git-status
+chips. The minimum dock width grows from 140px to 190px. Server, wire protocol,
+directory state/fetching, sort order, status semantics, read-only behavior,
+file view/lightbox, refresh, and phone navigation are behaviorally unchanged.
+
+**Dependency decision:** no package. Mirafold already owns small inline SVG
+glyph components; a bounded set of paths and a pure classifier are safe local
+presentation. An icon library would add bundle, transitive, audit, and
+supply-chain surface for no protocol or correctness depth.
+
+**Test changes:** new `ExplorerNodeGlyph.test.ts` pins hierarchy precedence,
+symlink precedence, case-insensitive extension handling, configuration
+basenames, every broad file family, and the generic fallback. Existing desktop
+and phone browser proofs now require the open/closed root glyph and the
+decorative configuration glyph for `package.json`.
+
+**Documentation changes:** README's file map names the new glyph module and
+the shipped-feature summary names the inset/type-signal polish; `PLAN.md`
+compresses the completed phase to this archive pointer.
+
+**Proof:** all 162 front-end unit tests passed; TypeScript checking and the
+client/server production build passed. A controlled fixture containing no
+dotenv file rendered nine glyphs at desktop width across open-folder, code,
+configuration, documentation, and stylesheet families; the phone frame stayed
+390px wide with no side-scroll. Dark and light appearances resolved panel and
+glyph colors through their theme tokens. Focused headless-Chrome desktop and
+phone rendered-contract assertions plus axe serious/critical sweeps passed.
+`git diff --check` passed. No dependency, wire shape, server behavior, project
+file, or user data changed.

--- a/PLAN.md
+++ b/PLAN.md
@@ -145,7 +145,7 @@ faithful per-agent skins) · **4** except 4.7 (→ Phase R) · **G, H, H2**
 (relay dedup + human legibility) · **S** (theme system) · **N** (onboarding
 backend picker) · **V** (visual + fidelity gaps) · **A** (accessibility) ·
 **C** (CI/CD) · **E** (Explorer) · **M** (Mission control) · **E2** (Explorer at scale) ·
-**W** (live tree), **UX** (native prompt discovery, transcript fidelity,
+**E3** (Explorer visual polish) · **W** (live tree), **UX** (native prompt discovery, transcript fidelity,
 durable provider recovery, and branch test-audit closure), plus the finished
 steps of the still-open Phases **K, R, F, Q, L**.
 
@@ -3049,6 +3049,16 @@ Full bodies + original findings → PLAN-ARCHIVE.md ("Moved 2026-07-27").
   samples). Tiers 458/139/54 green. Same-day audit: nothing exploitable;
   the lightbox-over-permission-bar layering recorded as an accepted
   decision in SECURITY.md.
+
+## Phase E3 — Explorer visual polish
+
+- [x] **Step E3.1 — Refine the tree surface and add node-type glyphs** — done
+  2026-08-11; the existing read-only tree now uses Mirafold's inset surface,
+  compact row/guide treatment, SVG chevrons, and decorative open/closed-folder,
+  symlink, and broad file-family glyphs immediately after names. No dependency,
+  server/wire, lazy-fetch, sort, Git-status, drill-in, refresh, or phone-flow
+  behavior changed. Desktop, phone, dark/light, overflow, and axe proofs pass.
+  → PLAN-ARCHIVE.md.
 
 ## Phase W — Live tree (the filesystem watcher; the refresh button goes vestigial)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2476,19 +2476,14 @@ bodies + dated history → PLAN-ARCHIVE.md ("Moved 2026-07-24").
 
 ## Phase D — Decompose the Codex adapter (opened 2026-07-20)
 
-`server/adapters/codex.ts` is **824 lines** and carries at least five separable
-concerns. For scale, the other two real adapters are 499 (`claude-code.ts`) and
-382 (`gemini-cli.ts`) — it isn't merely the biggest, it's nearly the other two
-combined, and it grew again on 2026-07-20 (provider binding + the notice fix).
-Size alone wouldn't justify a step; the reason it's worth doing **now** is that
-two separate 2026-07-20 bugs both lived in the seams between those concerns —
-the engine-default lookup didn't know what the provider binding had decided,
-and a non-fatal engine item was classified where the fatal ones are handled.
-Concerns that can't see each other's decisions are exactly what splitting makes
-visible.
+At the 2026-08-11 refactor start, `server/adapters/codex.ts` was **1,004 lines**
+and carried at least five separable concerns. Size alone did not justify the
+step; two separate 2026-07-20 bugs both lived in the seams between those
+concerns — the engine-default lookup did not know what provider binding had
+decided, and a non-fatal engine item was classified beside the fatal ones.
 
-Do it now, before Phase F widens the adapter's event vocabulary further: every
-type added to `handleEvent`/`onItem` afterwards makes the split more expensive.
+The local split now isolates the event mapper before Phase F widens Codex's
+event vocabulary further.
 
 **This is a pure refactor — zero functional change.** It is well protected:
 298 Tier-1 tests, the Tier-2 and Tier-3 suites, and the Tier-4 live tier, all
@@ -2532,6 +2527,20 @@ list honored; all tiers green (318/86/37). Full detail → PLAN-ARCHIVE.md
     `yarn test:live` still 2 pass / 1 skip; and one real subscription turn plus
     one real OpenRouter turn verified by hand, since those are the paths the
     binding cluster governs and no mock covers them.
+  - **2026-08-11 local implementation complete; live closure outstanding.**
+    `codex.ts` is now 382 lines and retains `CodexSession`, its public
+    `AgentSession` surface, test-observed thread state, and lifecycle. Named
+    sibling modules now own provider/runtime binding, slash commands and prompt
+    discovery, diagnostics, SDK-event normalization, prompt constants, and
+    rollout lookup; none exceeds 250 lines. Existing public re-exports remain
+    at `codex.ts`; D.1 changed no assertion or test file and added no
+    dependency. Separate E3.2 browser assertions remain in the same working
+    tree. Safe verification passed 603 unit tests, TypeScript, the production
+    client/server build, and `git diff --check`; the three aggregate-runner
+    sensitive files passed independently. The two dotenv-manipulating unit
+    files were not run. Keep this step unchecked until its full Tier 2/Tier 3/
+    Tier 4 and manual subscription/OpenRouter done-when checks are actually
+    completed.
 
 ---
 
@@ -3059,6 +3068,15 @@ Full bodies + original findings → PLAN-ARCHIVE.md ("Moved 2026-07-27").
   server/wire, lazy-fetch, sort, Git-status, drill-in, refresh, or phone-flow
   behavior changed. Desktop, phone, dark/light, overflow, and axe proofs pass.
   → PLAN-ARCHIVE.md.
+- [x] **Step E3.2 — Integrate the Explorer visually with the workbench** —
+  visually approved by Kyle 2026-08-11. The dock now has a stable responsive
+  width, compact Files title/action bar, separate sticky workspace-root strip,
+  inset tree-row rhythm, quieter unboxed Git markers, and conventional
+  `chevron → type glyph → name → status` ordering. Refresh and the phone close
+  action moved into the title bar without changing their behavior; the stacked
+  phone file drill-in remains intact. The accepted revision is deliberately
+  still uncommitted, and PR #34 remains open and unmerged pending explicit Git
+  direction.
 
 ## Phase W — Live tree (the filesystem watcher; the refresh button goes vestigial)
 

--- a/README.md
+++ b/README.md
@@ -512,9 +512,11 @@ server/            the local daemon (Node, run with tsx)
                      cited by path from CLAUDE.md/BUSINESS.md; stays at root
   version.ts         reads package.json's version at build time (R.4g)
   adapters/          one AgentSession per agent: claude-code.ts, codex.ts,
-                     gemini-cli.ts, mock.ts (+ index.ts seam, types.ts,
-                     async-queue.ts, render-mcp-cmd.ts, provider command/skill
-                     catalog helpers, *.spike.md probe notes)
+                     gemini-cli.ts, mock.ts. Codex's lifecycle stays in
+                     codex.ts; codex-{binding,commands,diagnostics,events,
+                     prompt,rollout}.ts own its named internal seams. Shared
+                     index/types/queue/render-MCP and provider catalog helpers
+                     live beside them, with *.spike.md probe notes.
   sessions/          the session state core (H.4/H.5):
     registry.ts        SessionRegistry: sessions decoupled from connections (4.2);
                        broadcast() is also where engine-supplied labels are

--- a/README.md
+++ b/README.md
@@ -660,7 +660,8 @@ web/               the browser app (React 19 + Vite)
                        drill-in — docked left column on desktop, full-screen
                        dialog on phone; desktop ⤢ enlarges the file box into
                        a dimmed lightbox, E.6) + FileView.tsx (content /
-                       diff / binary)
+                       diff / binary) + ExplorerNodeGlyph.tsx (small
+                       dependency-free folder/symlink/file-family glyphs)
   src/registry/      Card, List, Table, LinkGroup, Chart, TodoList, KeyValue,
                      Progress, Timeline, FileTree, Question, Diff, Stat, Code,
                      StatusList, Console, Image, Diagram, Md, CopyButton +
@@ -1628,7 +1629,8 @@ Read PLAN.md for the real thing; the shape in one breath:
   panel behind the activity bar: jailed listing, file view, HEAD-vs-working
   diffs, now fetched one directory per expand with each nested repo's own
   statuses and ignore rules, so a session can root at a folder of many
-  repos); **mission control grown into
+  repos; Phase E3 adds the compact inset tree surface and alongside-name
+  folder/file-family glyphs); **mission control grown into
   a cockpit** (**Phase M** — answer permissions, interrupt, and dispatch
   prompts from the grid without entering a session); and the workbench-frame
   polish + the by-surface `styles.css` reorganization (2026-07-25, §7).

--- a/server/adapters/codex-binding.ts
+++ b/server/adapters/codex-binding.ts
@@ -1,0 +1,139 @@
+import { Codex, type CodexOptions } from "@openai/codex-sdk";
+import { envWithout, installedAgentBin } from "./types";
+import { MIRAFOLD_MCP, renderMcpCommand } from "./render-mcp-cmd";
+import { listCodexModels, type CodexModel } from "./codex-model-list";
+import { codexProviders, type CodexProviders } from "./codex-config";
+
+export type CodexBackendKind = "api-key" | "subscription" | "local";
+
+const RENDER_MCP = renderMcpCommand();
+
+/** The provider half of an onboarding pick's enforcement. */
+export function codexProviderBinding(
+  kind: CodexBackendKind | undefined,
+  endpoint: string | undefined,
+  provider: string | undefined,
+): Record<string, unknown> {
+  if (kind === "local" && endpoint) {
+    return {
+      model_provider: "mirafold_local",
+      model_providers: {
+        mirafold_local: {
+          name: "Mirafold-discovered local server",
+          base_url: `${endpoint}/v1`,
+          wire_api: "responses",
+        },
+      },
+    };
+  }
+  if (kind === "local" && provider) return { model_provider: provider };
+  if (kind === "api-key" || kind === "subscription") return { model_provider: "openai" };
+  return {};
+}
+
+/** A forced first-party provider must not inherit a model chosen for a custom
+ * config default. An explicit model always wins. */
+export function needsCodexEngineDefaultModel(
+  kind: CodexBackendKind | undefined,
+  explicitModel: string | undefined,
+  providers: CodexProviders,
+): boolean {
+  if ((kind !== "api-key" && kind !== "subscription") || explicitModel) return false;
+  return (
+    providers.defaultProvider !== undefined &&
+    providers.defaultProvider !== "openai" &&
+    providers.model !== undefined
+  );
+}
+
+/** Select only the model the engine marks as default, preserving the
+ * first-party guard against provider-qualified third-party model ids. */
+export function codexEngineDefaultModel(
+  models: readonly CodexModel[],
+  firstPartyOpenAI: boolean,
+): string {
+  const model = models.find((candidate) => candidate.isDefault);
+  if (!model) throw new Error("the engine's catalog marks no default model");
+  if (firstPartyOpenAI && model.id.includes("/")) {
+    throw new Error(`the catalog answered with \`${model.id}\`, which OpenAI's provider can't run`);
+  }
+  return model.id;
+}
+
+/** Build the SDK runtime and model catalogs under one enforced provider
+ * binding. Catalog and turn routing must share both the binary and provider;
+ * splitting either can display a model the eventual turn cannot run. */
+export function createCodexRuntimeBinding(options: {
+  kind: CodexBackendKind | undefined;
+  endpoint?: string;
+  provider?: string;
+  model?: string;
+  makeCodex?: (options: CodexOptions) => Codex;
+  listModels?: () => Promise<CodexModel[]>;
+  listEngineModels?: () => Promise<CodexModel[]>;
+}): {
+  codex: Codex;
+  engineBin?: string;
+  listModels: () => Promise<CodexModel[]>;
+  listEngineModels: () => Promise<CodexModel[]>;
+  firstPartyOpenAI: boolean;
+  endpointForRedaction?: string;
+  needsEngineDefaultModel: boolean;
+} {
+  const { kind, endpoint, provider, model } = options;
+  const providerConfig = codexProviders();
+  const selectedProvider =
+    provider ?? (kind === "local" && !endpoint ? providerConfig.defaultProvider : undefined);
+  const endpointForRedaction =
+    endpoint ?? providerConfig.entries.find((entry) => entry.id === selectedProvider)?.baseUrl;
+
+  // Every explicit onboarding pick forces the provider its label promised.
+  // A discovered local endpoint gets a per-session Responses provider;
+  // config-declared local providers keep their own table and are selected by
+  // id. A bare local pick and an unspecified backend inherit Codex's config.
+  const binding = codexProviderBinding(kind, endpoint, provider);
+
+  // Drive the user's installed Codex when present so the terminal and SDK
+  // share one engine version; machines without it retain the SDK fallback.
+  const installedCodex = installedAgentBin("MIRAFOLD_CODEX_BIN", "codex");
+  const codex = (options.makeCodex ?? ((codexOptions: CodexOptions) => new Codex(codexOptions)))({
+    ...(installedCodex ? { codexPathOverride: installedCodex } : {}),
+    ...(kind === "api-key" && process.env.OPENAI_API_KEY
+      ? { apiKey: process.env.OPENAI_API_KEY }
+      : {}),
+    // Subscription must beat key precedence; local sessions must not receive
+    // a key intended for another provider.
+    ...(kind === "subscription" || kind === "local"
+      ? { env: envWithout("OPENAI_API_KEY") }
+      : {}),
+    config: {
+      mcp_servers: {
+        [MIRAFOLD_MCP]: {
+          command: RENDER_MCP.command,
+          args: RENDER_MCP.args,
+          // Mirafold's own render tools only emit validated UI messages; the
+          // headless engine cannot prompt for their approval.
+          default_tools_approval_mode: "approve",
+        },
+      },
+      ...binding,
+    },
+  });
+
+  // Ask the exact spawned binary for both catalogs under the same binding.
+  // Injected test doubles may omit this private runtime path; model discovery
+  // then performs its ordinary installed-binary lookup.
+  const engineBin = (codex as unknown as { exec?: { executablePath?: string } }).exec
+    ?.executablePath;
+  const engineModels = () => listCodexModels(undefined, engineBin, binding);
+
+  return {
+    codex,
+    engineBin,
+    listModels: options.listModels ?? engineModels,
+    listEngineModels: options.listEngineModels ?? engineModels,
+    firstPartyOpenAI: binding["model_provider"] === "openai",
+    endpointForRedaction,
+    needsEngineDefaultModel: needsCodexEngineDefaultModel(kind, model, providerConfig),
+  };
+}

--- a/server/adapters/codex-commands.ts
+++ b/server/adapters/codex-commands.ts
@@ -1,0 +1,146 @@
+import type { ModelReasoningEffort } from "@openai/codex-sdk";
+import type { PromptOption, WireMsg } from "../protocol";
+import { emitPromptOptions } from "./types";
+import type { CodexModel } from "./codex-model-list";
+import { emitModelPicker } from "./model-picker";
+import { codexSlashOptions } from "./codex-prompt-options";
+import type { CodexSkill } from "./codex-skills-list";
+
+type Emit = (message: WireMsg) => void;
+
+export type CodexReasoningEffort = ModelReasoningEffort | "none";
+// Internal-only: the model/config default remains in force until a user pick.
+export const CODEX_EFFORT_STAND_IN = "default";
+
+const EFFORTS: readonly ModelReasoningEffort[] = ["minimal", "low", "medium", "high", "xhigh"];
+// Codex forwards `none` to discovered local Responses endpoints even though
+// the SDK's published TypeScript union does not yet include it.
+const LOCAL_EFFORTS: readonly CodexReasoningEffort[] = ["none", ...EFFORTS];
+const EFFORT_DESCRIPTIONS: Record<CodexReasoningEffort, string> = {
+  none: "Disable model reasoning (when supported)",
+  minimal: "Least reasoning, fastest",
+  low: "Light reasoning",
+  medium: "Balanced reasoning",
+  high: "Deep reasoning",
+  xhigh: "Maximum reasoning, slowest",
+};
+
+const isEffort = (
+  value: string,
+  efforts: readonly CodexReasoningEffort[],
+): value is CodexReasoningEffort => (efforts as readonly string[]).includes(value);
+
+/** Slash commands use the same visible turn envelope as engine turns. */
+async function runSlashTurn(emit: Emit, body: () => Promise<void> | void): Promise<void> {
+  emit({ type: "status", state: "thinking" });
+  try {
+    await body();
+  } finally {
+    emit({ type: "turn_end" });
+  }
+}
+
+export function runCodexModelCommand(options: {
+  arg: string;
+  emit: Emit;
+  listModels: () => Promise<CodexModel[]>;
+  isCurrent: (model: CodexModel) => boolean;
+  setModel: (model: string) => void;
+  diagnostic: (error: unknown) => string;
+}): Promise<void> {
+  const { arg, emit, listModels, isCurrent, setModel, diagnostic } = options;
+  return runSlashTurn(emit, async () => {
+    if (arg === "") {
+      let models: CodexModel[];
+      try {
+        models = await listModels();
+      } catch (error) {
+        emit({
+          type: "error",
+          message: `Could not read the model list from codex: ${diagnostic(error)}`,
+        });
+        return;
+      }
+      emitModelPicker(
+        emit,
+        models.map((model) => ({ ...model, current: isCurrent(model) })),
+        {
+          clickText: (id) => `/model ${id}`,
+          switchHint: "Send `/model <model-id>` to switch.",
+        },
+      );
+      emit({
+        type: "text_delta",
+        text: "\nLegacy models can be set directly with `/model <model_name>`.",
+      });
+    } else if (/\s/.test(arg) || arg.startsWith("-")) {
+      // Reject flag-shaped values locally instead of relying on Codex's CLI
+      // parser to interpret a --model argument safely.
+      emit({ type: "text_delta", text: "Usage: `/model` to pick, or `/model <model-id>`." });
+    } else {
+      setModel(arg);
+      emit({ type: "text_delta", text: `Model set to ${arg}.` });
+    }
+  });
+}
+
+export function runCodexEffortCommand(options: {
+  arg: string;
+  emit: Emit;
+  discoveredLocalEndpoint: boolean;
+  currentEffort: string;
+  setEffort: (effort: CodexReasoningEffort) => void;
+}): Promise<void> {
+  const { arg, emit, discoveredLocalEndpoint, currentEffort, setEffort } = options;
+  return runSlashTurn(emit, () => {
+    const efforts = discoveredLocalEndpoint ? LOCAL_EFFORTS : EFFORTS;
+    if (arg === "") {
+      emitModelPicker(
+        emit,
+        efforts.map((effort) => ({
+          id: effort,
+          displayName: effort,
+          description: EFFORT_DESCRIPTIONS[effort],
+          current: currentEffort === effort,
+        })),
+        {
+          clickText: (id) => `/effort ${id}`,
+          switchHint: "Send `/effort <level>` to set the reasoning effort.",
+          question: "Select reasoning effort",
+        },
+      );
+    } else if (isEffort(arg, efforts)) {
+      setEffort(arg);
+      emit({ type: "text_delta", text: `Reasoning effort set to ${arg}.` });
+    } else {
+      emit({
+        type: "text_delta",
+        text: `Usage: \`/effort\` to pick, or \`/effort <level>\` (${efforts.join(", ")}).`,
+      });
+    }
+  });
+}
+
+export function refreshCodexPromptOptions(options: {
+  emit: Emit;
+  listSkills: () => Promise<CodexSkill[]>;
+  isClosed: () => boolean;
+}): void {
+  const slash = codexSlashOptions();
+  emitPromptOptions(options.emit, slash);
+  options
+    .listSkills()
+    .then((skills) => {
+      if (options.isClosed()) return;
+      const skillOptions: PromptOption[] = skills.map((skill) => ({
+        trigger: "$",
+        value: `$${skill.name}`,
+        label: skill.name,
+        description: skill.description,
+        kind: "skill",
+        source: "codex",
+      }));
+      emitPromptOptions(options.emit, [...slash, ...skillOptions]);
+    })
+    .catch(() => {}); // slash commands remain useful if skill discovery is unavailable
+}

--- a/server/adapters/codex-diagnostics.ts
+++ b/server/adapters/codex-diagnostics.ts
@@ -1,0 +1,37 @@
+import { scrubSelectedEndpoint } from "../log";
+import { errText } from "./types";
+
+export function codexProviderDiagnostic(value: unknown, endpoint?: string): string {
+  return scrubSelectedEndpoint(typeof value === "string" ? value : errText(value), endpoint);
+}
+
+/** Configured providers retain Codex's own diagnostic. Only a
+ * Mirafold-discovered local endpoint gets the concrete server recovery step. */
+export function codexTurnDiagnostic(
+  value: unknown,
+  endpoint: string | undefined,
+  discoveredLocalEndpoint: boolean,
+): string {
+  const diagnostic = codexProviderDiagnostic(value, endpoint);
+  return discoveredLocalEndpoint
+    ? `Local Codex could not complete the turn: ${diagnostic}. ` +
+        "Check that the local model server is running and still serves the selected model."
+    : diagnostic;
+}
+
+export function codexLocalTurnTimeoutDiagnostic(
+  timeoutMs: number,
+  effort: string,
+): string {
+  const seconds = Math.ceil(timeoutMs / 1_000);
+  const reasoningAction =
+    effort === "none"
+      ? "Reasoning is already disabled; choose a faster model or machine"
+      : "Send `/effort none` and retry if the server supports reasoning control, choose a faster model or machine";
+  return (
+    `The local Codex turn did not finish within ${seconds} seconds. ` +
+    "The engine may still be pre-filling Codex's context, or the model may be reasoning too slowly. " +
+    `${reasoningAction}, or raise MIRAFOLD_CODEX_LOCAL_TURN_TIMEOUT_MS ` +
+    "(set it to 0 to disable the limit)."
+  );
+}

--- a/server/adapters/codex-events.ts
+++ b/server/adapters/codex-events.ts
@@ -1,0 +1,250 @@
+import { randomUUID } from "node:crypto";
+import type { McpToolCallItem, ThreadEvent, ThreadItem } from "@openai/codex-sdk";
+import type { WireMsg } from "../protocol";
+import { type TodoItem, capOutput, joinTextBlocks } from "./types";
+import { MIRAFOLD_MCP, RENDER_ID_RE, generativeUIMsg } from "./render-mcp-cmd";
+import { convertMermaidCharts } from "./mermaid-chart";
+
+type Emit = (message: WireMsg) => void;
+
+export function mcpText(content: unknown): string {
+  if (!Array.isArray(content)) return content == null ? "" : String(content);
+  return joinTextBlocks(content);
+}
+
+// The component id the render-mcp stub assigned (structuredContent is the
+// primary channel; the "(id: …)" text is a fallback if an engine drops it) —
+// used so the browser paints the same id the agent can re-send for update-in-place.
+export function extractRenderId(item: McpToolCallItem): string {
+  const structured = item.result?.structured_content as { renderId?: unknown } | undefined;
+  if (structured && typeof structured.renderId === "string") return structured.renderId;
+  const match = mcpText(item.result?.content).match(RENDER_ID_RE);
+  if (match) return match[1];
+  const argumentId = (item.arguments as { id?: unknown } | undefined)?.id;
+  return typeof argumentId === "string" ? argumentId : randomUUID();
+}
+
+export class CodexEventMapper {
+  private announced = new Set<string>();
+  private todoRenderId?: string;
+
+  constructor(
+    private readonly options: {
+      emit: Emit;
+      workspaceDir: string;
+      modelName: () => string | undefined;
+      modelUnknown: () => boolean;
+      learnModel: () => void;
+      turnDiagnostic: (value: unknown) => string;
+      providerDiagnostic: (value: unknown) => string;
+      onThreadStarted: (threadId: string) => void;
+    },
+  ) {}
+
+  endTurn() {
+    this.todoRenderId = undefined;
+  }
+
+  handle(event: ThreadEvent, end: () => void) {
+    switch (event.type) {
+      case "turn.started":
+        this.options.emit({ type: "status", state: "thinking" });
+        break;
+      case "item.started":
+        this.onItem(event.item, "started");
+        break;
+      case "item.updated":
+        this.onItem(event.item, "updated");
+        break;
+      case "item.completed":
+        this.onItem(event.item, "completed");
+        break;
+      case "turn.completed": {
+        const usage = event.usage;
+        this.options.emit({
+          type: "usage",
+          model: this.options.modelName(),
+          // cached_input_tokens is a subset of input_tokens (already counted);
+          // reasoning is output-side cost.
+          inputTokens: usage.input_tokens,
+          outputTokens: usage.output_tokens + usage.reasoning_output_tokens,
+        });
+        // A lookup that ran out its window mid-turn gets another chance now —
+        // by turn end the rollout file certainly has its turn_context line.
+        if (this.options.modelUnknown()) this.options.learnModel();
+        end();
+        break;
+      }
+      case "turn.failed":
+        this.options.emit({
+          type: "error",
+          message: this.options.turnDiagnostic(event.error.message),
+        });
+        end();
+        break;
+      case "error":
+        this.options.emit({ type: "error", message: this.options.turnDiagnostic(event.message) });
+        end();
+        break;
+      case "thread.started":
+        // The session owns the resume id; the mapper only reports the event
+        // and starts model discovery when the configured label is still unknown.
+        this.options.onThreadStarted(event.thread_id);
+        if (this.options.modelUnknown()) this.options.learnModel();
+        break;
+    }
+  }
+
+  /** Normalize one thread item. `phase` distinguishes start vs. finish. */
+  private onItem(item: ThreadItem, phase: "started" | "updated" | "completed") {
+    switch (item.type) {
+      case "agent_message":
+        // Any mermaid xychart the model still hand-wrote becomes the real
+        // chart component; all other text passes through verbatim.
+        if (phase === "completed") {
+          for (const segment of convertMermaidCharts(item.text)) {
+            if ("text" in segment) {
+              this.options.emit({ type: "text_delta", text: segment.text });
+            } else {
+              this.options.emit({
+                type: "render",
+                component: "chart",
+                props: segment.chart as unknown as Record<string, unknown>,
+                id: randomUUID(),
+              });
+            }
+          }
+        }
+        break;
+      case "reasoning":
+        if (phase === "completed") {
+          this.options.emit({ type: "status", state: "thinking" });
+          this.options.emit({ type: "thinking_delta", text: item.text });
+        }
+        break;
+      case "command_execution": {
+        if (phase === "started") {
+          this.announceTool(item.id, "Shell", item.command, { command: item.command });
+        } else if (phase === "completed") {
+          this.ensureAnnounced(item.id, "Shell", item.command, { command: item.command });
+          const capped = capOutput(item.aggregated_output ?? "");
+          this.finishTool(item.id, {
+            output: capped.text,
+            truncatedBytes: capped.truncatedBytes,
+            isError: item.status === "failed" || (item.exit_code != null && item.exit_code !== 0),
+          });
+        }
+        break;
+      }
+      case "file_change": {
+        if (phase !== "completed") break;
+        const paths = item.changes.map((change) => `${change.kind} ${change.path}`).join(", ");
+        this.announceTool(item.id, "apply_patch", paths, { changes: item.changes });
+        this.finishTool(item.id, {
+          output: paths || "(no changes)",
+          isError: item.status === "failed",
+        });
+        break;
+      }
+      case "mcp_tool_call": {
+        // Mirafold's generative-UI server becomes the render/artifact message
+        // represented by the call rather than a raw tool row.
+        if (item.server === MIRAFOLD_MCP) {
+          if (phase === "completed" && item.status !== "failed" && !item.error) {
+            this.emitGenerativeUI(item);
+          }
+          break;
+        }
+        const label = `${item.server}.${item.tool}`;
+        if (phase === "started") {
+          this.announceTool(item.id, label, item.tool, item.arguments);
+        } else if (phase === "completed") {
+          this.ensureAnnounced(item.id, label, item.tool, item.arguments);
+          const capped = capOutput(item.error ? item.error.message : mcpText(item.result?.content));
+          this.finishTool(item.id, {
+            output: capped.text,
+            truncatedBytes: capped.truncatedBytes,
+            isError: item.status === "failed" || Boolean(item.error),
+          });
+        }
+        break;
+      }
+      case "web_search":
+        if (phase !== "completed") break;
+        this.announceTool(item.id, "web_search", item.query, { query: item.query });
+        this.finishTool(item.id, { output: "(results returned to the agent)" });
+        break;
+      case "todo_list":
+        this.emitChecklist(item.items);
+        break;
+      case "error":
+        // This item is a non-fatal Codex warning. Fatal stream errors are
+        // handled above and end the turn.
+        if (phase === "completed") {
+          this.options.emit({
+            type: "notice",
+            text: this.options.providerDiagnostic(item.message),
+            kind: "warning",
+            source: "codex",
+          });
+        }
+        break;
+    }
+  }
+
+  /** Announce only when the started phase was missed. */
+  private ensureAnnounced(id: string, name: string, detail: string, input: unknown) {
+    if (!this.announced.has(id)) this.announceTool(id, name, detail, input);
+  }
+
+  private announceTool(id: string, name: string, detail: string, input: unknown) {
+    this.announced.add(id);
+    this.options.emit({ type: "status", state: "tool", label: name });
+    this.options.emit({
+      type: "tool_use",
+      name,
+      detail: detail || undefined,
+      id,
+      input: typeof input === "object" && input !== null ? (input as Record<string, unknown>) : undefined,
+    });
+  }
+
+  private finishTool(
+    id: string,
+    result: { output: string; isError?: boolean; truncatedBytes?: number },
+  ) {
+    this.announced.delete(id);
+    this.options.emit({ type: "tool_result", ...result, id });
+  }
+
+  private emitGenerativeUI(item: McpToolCallItem) {
+    const args =
+      item.arguments && typeof item.arguments === "object"
+        ? (item.arguments as Record<string, unknown>)
+        : {};
+    const message = generativeUIMsg(
+      item.tool,
+      args,
+      extractRenderId(item),
+      this.options.workspaceDir,
+    );
+    if (message) this.options.emit(message);
+  }
+
+  private emitChecklist(items: { text: string; completed: boolean }[]) {
+    // Never paint an empty checklist, but an emptied list must still update
+    // one already painted during this turn.
+    if (!items.length && !this.todoRenderId) return;
+    this.todoRenderId ??= randomUUID();
+    const todos: TodoItem[] = items.map((item) => ({
+      content: item.text,
+      status: item.completed ? "completed" : "pending",
+    }));
+    this.options.emit({
+      type: "render",
+      component: "todo-list",
+      props: { todos },
+      id: this.todoRenderId,
+    });
+  }
+}

--- a/server/adapters/codex-prompt.ts
+++ b/server/adapters/codex-prompt.ts
@@ -1,0 +1,18 @@
+import { MIRAFOLD_MCP } from "./render-mcp-cmd";
+
+/**
+ * OpenAI-provider models can defer MCP tools behind Codex's tool-search
+ * mechanism, while custom providers receive those tools directly. This
+ * conditional instruction is true in both configurations and rides only on
+ * the session's first accepted turn.
+ */
+export const CODEX_DEFERRED_TOOLS_ADDENDUM = `
+## Tool availability note (important)
+
+The render_* tools and emit_artifact above live on the \`${MIRAFOLD_MCP}\` MCP
+server. If they appear in your tool list, just call them directly. If they
+do NOT appear, they are DEFERRED behind tool search: use tool search to load
+them, then call them. Never conclude a render tool is unavailable without
+checking your tool list and searching first. For ANY chart/plot/graph
+request you MUST call render_chart — hand-written mermaid, ASCII, or SVG
+charts render as plain code here, never as visuals.`;

--- a/server/adapters/codex-rollout.ts
+++ b/server/adapters/codex-rollout.ts
@@ -1,0 +1,84 @@
+import path from "node:path";
+import { readdir, readFile } from "node:fs/promises";
+
+/** `<codexHome>/sessions/YYYY/MM/DD` — the CLI's rollout layout, LOCAL date.
+ * Exported for test fixtures so the layout is written down exactly once. */
+export const rolloutDateDir = (codexHome: string, date: Date) =>
+  path.join(
+    codexHome,
+    "sessions",
+    String(date.getFullYear()),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  );
+
+/**
+ * Read the model Codex actually resolved for a thread from its rollout file.
+ * The SDK event stream does not expose this value. The lookup is local,
+ * read-only, and failure-silent; a miss leaves the caller's label unresolved.
+ */
+export async function resolveRolloutModel(
+  threadId: string,
+  codexHome: string,
+): Promise<string | undefined> {
+  const today = new Date();
+  const yesterday = new Date(today.getTime() - 86_400_000);
+  for (const dir of [rolloutDateDir(codexHome, today), rolloutDateDir(codexHome, yesterday)]) {
+    let names: string[];
+    try {
+      names = await readdir(dir);
+    } catch {
+      continue;
+    }
+    const file = names.find((name) => name.endsWith(`-${threadId}.jsonl`));
+    if (!file) continue;
+    let text: string;
+    try {
+      text = await readFile(path.join(dir, file), "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      if (!line.includes('"model"')) continue;
+      try {
+        const model = (JSON.parse(line) as { payload?: { model?: unknown } }).payload?.model;
+        if (typeof model === "string" && model) return model;
+      } catch {
+        // A line can be observed while Codex is still writing it. A later
+        // polling attempt will see the completed JSON record.
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Bounded polling around the rollout read. The thread context is written a
+ * few seconds after `thread.started`; `turn.completed` may safely re-enter
+ * this lookup because concurrent attempts are suppressed. */
+export class CodexRolloutLookup {
+  private running = false;
+
+  async learn(options: {
+    threadId: () => string | undefined;
+    codexHome: () => string;
+    shouldContinue: () => boolean;
+    onResolved: (model: string) => void;
+  }): Promise<void> {
+    if (this.running || !options.threadId()) return;
+    this.running = true;
+    try {
+      for (let attempt = 0; attempt < 20 && options.shouldContinue(); attempt++) {
+        const threadId = options.threadId();
+        if (!threadId) return;
+        const model = await resolveRolloutModel(threadId, options.codexHome());
+        if (model) {
+          options.onResolved(model);
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+}

--- a/server/adapters/codex.ts
+++ b/server/adapters/codex.ts
@@ -1,250 +1,65 @@
 import path from "node:path";
 import os from "node:os";
 import { mkdirSync } from "node:fs";
-import { readdir, readFile } from "node:fs/promises";
-import { randomUUID } from "node:crypto";
 import {
-  Codex,
+  type Codex,
   type CodexOptions,
-  type McpToolCallItem,
   type ModelReasoningEffort,
   type Thread,
-  type ThreadEvent,
-  type ThreadItem,
 } from "@openai/codex-sdk";
-import type { PromptOption, WireMsg } from "../protocol";
+import type { WireMsg } from "../protocol";
 import { RENDER_GUIDANCE } from "../render-tools";
-import {
-  type AgentSession,
-  type TodoItem,
-  capOutput,
-  emitPromptOptions,
-  envWithout,
-  errText,
-  installedAgentBin,
-  joinTextBlocks,
-} from "./types";
-import { MIRAFOLD_MCP, RENDER_ID_RE, generativeUIMsg, renderMcpCommand } from "./render-mcp-cmd";
-import { convertMermaidCharts } from "./mermaid-chart";
-import { listCodexModels, type CodexModel } from "./codex-model-list";
-import { emitModelPicker } from "./model-picker";
-import { codexProviders } from "./codex-config";
+import type { AgentSession } from "./types";
+import type { CodexModel } from "./codex-model-list";
 import { AsyncQueue, CLOSE } from "./async-queue";
-import { codexSlashOptions } from "./codex-prompt-options";
 import { listCodexSkills, type CodexSkill } from "./codex-skills-list";
 import { ResumeIdState } from "./resume-id";
-import { scrubSelectedEndpoint } from "../log";
 import { envInt } from "../env";
+import {
+  codexEngineDefaultModel,
+  createCodexRuntimeBinding,
+  type CodexBackendKind,
+} from "./codex-binding";
+import { CODEX_DEFERRED_TOOLS_ADDENDUM } from "./codex-prompt";
+import { CodexRolloutLookup } from "./codex-rollout";
+import {
+  CODEX_EFFORT_STAND_IN,
+  refreshCodexPromptOptions,
+  runCodexEffortCommand,
+  runCodexModelCommand,
+  type CodexReasoningEffort,
+} from "./codex-commands";
+import { CodexEventMapper } from "./codex-events";
+import {
+  codexLocalTurnTimeoutDiagnostic,
+  codexProviderDiagnostic,
+  codexTurnDiagnostic,
+} from "./codex-diagnostics";
 
-// The generative-UI MCP server injected into Codex (P.3). Codex loads MCP
-// servers as stdio subprocesses, so Mirafold's render tools live in a
-// standalone process (server/render-mcp.ts) rather than in-process like the
-// Claude adapter's makeRenderServer. renderMcpCommand resolves how to spawn
-// it: tsx + TS source in dev, node + the esbuild twin in the packaged install.
-const RENDER_MCP = renderMcpCommand();
+export { CODEX_DEFERRED_TOOLS_ADDENDUM } from "./codex-prompt";
+export { resolveRolloutModel, rolloutDateDir } from "./codex-rollout";
+export { extractRenderId, mcpText } from "./codex-events";
 
-// Internal sentinel for "model not yet known": no model configured means
-// Codex resolves its own default, which the rollout lookup below then names.
-// Comparisons against this are "is the label still the stand-in?" checks.
-// NEVER surfaced — modelName reports undefined instead, so every UI slot
-// (status bar, fleet row, usage) shows nothing rather than a false name.
+// Internal-only sentinel while the rollout lookup discovers Codex's default;
+// `modelName` withholds it so the UI never presents a false model name.
 const MODEL_STAND_IN = "codex";
 
-// The reasoning-effort axis of Codex's /model picker (V-thread follow-up). The
-// SDK's own union, in the terminal picker's order. SCAFFOLD (2026-07-19): a
-// standalone `/effort` re-skin built against the mock; two fidelity questions
-// stay open for a live pass against real Codex, and until then all five are
-// offered unfiltered:
-//   1. Per-model availability — the terminal picker shows only the efforts a
-//      given model supports; app-server model/list may or may not carry that.
-//   2. Flow shape — terminal folds effort in as step 2 of `/model`; whether to
-//      chain the model pick into this picker (vs. keep it standalone) is that
-//      pass's call.
-const EFFORTS: readonly ModelReasoningEffort[] = ["minimal", "low", "medium", "high", "xhigh"];
-// Ollama's Responses API also accepts `none`, and Codex 0.147.0 forwards it
-// unchanged even though the SDK's published TypeScript union omits it. This
-// was verified against a real custom-provider turn on 2026-08-11. Keep the
-// extension local to a discovered endpoint: first-party/configured-provider
-// sessions continue to expose only the SDK's documented union.
-type CodexReasoningEffort = ModelReasoningEffort | "none";
-const LOCAL_EFFORTS: readonly CodexReasoningEffort[] = ["none", ...EFFORTS];
-// Short Mirafold-side descriptions (NOT claimed to mirror the terminal's copy).
-const EFFORT_DESC: Record<CodexReasoningEffort, string> = {
-  none: "Disable model reasoning (when supported)",
-  minimal: "Least reasoning, fastest",
-  low: "Light reasoning",
-  medium: "Balanced reasoning",
-  high: "Deep reasoning",
-  xhigh: "Maximum reasoning, slowest",
-};
-// "We have not overridden effort" — the config/model default is in force. We
-// can't name it (app-server doesn't surface the resolved effort), so like
-// MODEL_STAND_IN this is an is-it-still-unset sentinel, never sent to Codex.
-const EFFORT_STAND_IN = "default";
-const isEffort = (
-  s: string,
-  efforts: readonly CodexReasoningEffort[],
-): s is CodexReasoningEffort => (efforts as readonly string[]).includes(s);
-
-// The Codex CLI's provider-level retry/idle policy can turn one slow local
-// request into many silent minutes. Mirafold owns the browser turn envelope,
-// so discovered local endpoints get one outer bound and an actionable exit.
-// Zero is an explicit opt-out for hardware/models that legitimately need more
-// than the default eight minutes. The bound is evidence-based: the cold 7,676
-// token prompt took about 6.5 minutes on the supported CPU-only test machine;
-// five minutes cut it off at 6,144 tokens and was disproven live.
+// Discovered local endpoints need one outer turn bound because Codex's own
+// retry policy can otherwise stay silent for minutes. Zero opts out.
 const DEFAULT_LOCAL_TURN_TIMEOUT_MS = envInt(
   "MIRAFOLD_CODEX_LOCAL_TURN_TIMEOUT_MS",
   8 * 60_000,
 );
 
 /**
- * V.2: on OpenAI-provider models, Codex defers ALL MCP tools behind its
- * tool-search mechanism (`tool_search_always_defer_mcp_tools`, hardcoded on
- * in codex-rs — the render tools never appear in the model's direct tool
- * list). Without being told, the model concludes render_chart doesn't exist
- * and hand-writes mermaid/ASCII instead (observed 0/9 render calls live).
- * This addendum to RENDER_GUIDANCE names the deferral and instructs the
- * model to load the tools via tool search — with it, 6/6 live trials called
- * render_chart, including on later turns of the same thread.
- *
- * The claim is CONDITIONAL ("if they do not appear") because deferral is
- * per-provider/per-model, not universal: a custom provider (config.toml
- * model_provider, e.g. OpenRouter, or a Mirafold-injected local server) has
- * no tool search, so the tools sit directly in the tool list — and the old
- * unconditional "they do NOT appear" sent such models hunting for a search
- * mechanism that doesn't exist (observed live 2026-07-19: qwen3-coder via
- * OpenRouter burned two failed MCP discovery calls and ~2x the tokens
- * before rendering; with conditional wording it calls render_chart
- * directly). One wording, true in both configurations — the adapter can't
- * cheaply know which one a session is in.
- */
-export const CODEX_DEFERRED_TOOLS_ADDENDUM = `
-## Tool availability note (important)
-
-The render_* tools and emit_artifact above live on the \`${MIRAFOLD_MCP}\` MCP
-server. If they appear in your tool list, just call them directly. If they
-do NOT appear, they are DEFERRED behind tool search: use tool search to load
-them, then call them. Never conclude a render tool is unavailable without
-checking your tool list and searching first. For ANY chart/plot/graph
-request you MUST call render_chart — hand-written mermaid, ASCII, or SVG
-charts render as plain code here, never as visuals.`;
-
-export function mcpText(content: unknown): string {
-  if (!Array.isArray(content)) return content == null ? "" : String(content);
-  return joinTextBlocks(content);
-}
-
-/** `<codexHome>/sessions/YYYY/MM/DD` — the CLI's rollout layout, LOCAL date.
- *  Exported for the test fixture (the bangShell pattern), so the layout is
- *  written down exactly once. */
-export const rolloutDateDir = (codexHome: string, d: Date) =>
-  path.join(
-    codexHome,
-    "sessions",
-    String(d.getFullYear()),
-    String(d.getMonth() + 1).padStart(2, "0"),
-    String(d.getDate()).padStart(2, "0"),
-  );
-
-/**
- * The model Codex ACTUALLY resolved for a thread (the analog of Claude's
- * system/init model, F.3): the SDK's event stream never names it, but Codex's
- * own session record does — the rollout file at
- * `<codexHome>/sessions/YYYY/MM/DD/rollout-…-<threadId>.jsonl`, whose
- * turn_context line carries `payload.model` (e.g. "gpt-5.6-sol", exactly what
- * the terminal's own header shows). Read-only, local, and failure-silent:
- * any miss returns undefined and the label stays the "codex" stand-in.
- * The date dir is the session's LOCAL start date — today is checked first,
- * yesterday too for a session straddling midnight.
- */
-export async function resolveRolloutModel(
-  threadId: string,
-  codexHome: string,
-): Promise<string | undefined> {
-  const today = new Date();
-  const yesterday = new Date(today.getTime() - 86_400_000);
-  for (const dir of [rolloutDateDir(codexHome, today), rolloutDateDir(codexHome, yesterday)]) {
-    let names: string[];
-    try {
-      names = await readdir(dir);
-    } catch {
-      continue; // no sessions that day
-    }
-    const file = names.find((n) => n.endsWith(`-${threadId}.jsonl`));
-    if (!file) continue;
-    let text: string;
-    try {
-      text = await readFile(path.join(dir, file), "utf8");
-    } catch {
-      continue;
-    }
-    for (const line of text.split("\n")) {
-      if (!line.includes('"model"')) continue;
-      try {
-        const model = (JSON.parse(line) as { payload?: { model?: unknown } }).payload?.model;
-        if (typeof model === "string" && model) return model;
-      } catch {
-        // a torn line mid-write — the retry loop will see it whole
-      }
-    }
-  }
-  return undefined;
-}
-
-// The component id the render-mcp stub assigned (structuredContent is the
-// primary channel; the "(id: …)" text is a fallback if an engine drops it) —
-// used so the browser paints the same id the agent can re-send for update-in-place.
-export function extractRenderId(item: McpToolCallItem): string {
-  const sc = item.result?.structured_content as { renderId?: unknown } | undefined;
-  if (sc && typeof sc.renderId === "string") return sc.renderId;
-  const m = mcpText(item.result?.content).match(RENDER_ID_RE);
-  if (m) return m[1];
-  const argId = (item.arguments as { id?: unknown } | undefined)?.id;
-  return typeof argId === "string" ? argId : randomUUID();
-}
-
-/** The provider half of a pick's enforcement (see the constructor comment):
- *  which `model_provider` the session's config forces — a discovered server's
- *  injected recipe, a config-declared provider's id, the first-party `openai`
- *  for the api-key/subscription kinds, or nothing for the inherit paths. */
-function providerBinding(
-  kind: "api-key" | "subscription" | "local" | undefined,
-  endpoint: string | undefined,
-  provider: string | undefined,
-): Record<string, unknown> {
-  if (kind === "local" && endpoint) {
-    return {
-      model_provider: "mirafold_local",
-      model_providers: {
-        mirafold_local: {
-          name: "Mirafold-discovered local server",
-          base_url: `${endpoint}/v1`,
-          wire_api: "responses",
-        },
-      },
-    };
-  }
-  if (kind === "local" && provider) return { model_provider: provider };
-  if (kind === "api-key" || kind === "subscription") return { model_provider: "openai" };
-  return {};
-}
-
-/**
  * The Codex adapter: OpenAI's Codex, driven through its own `@openai/codex-sdk`
- * engine. One `Thread` lives for the object's lifetime and carries the warm
- * conversation across turns (unlike Claude's single long-lived `query()`, Codex
- * runs one `runStreamed` per turn on the persistent thread). Its event stream is
- * normalized into the shared `WireMsg` union — no protocol change (P.2 spike).
+ * engine. One persistent `Thread` carries the warm conversation across turns;
+ * its events are normalized into the shared `WireMsg` union.
  *
  * Faithful-skin posture (see the inherit-don't-invent principle): this adapter
  * passes ONLY Mirafold's genuine concerns — the session working directory
- * (session ≈ project) and the model when configured. It deliberately sets NO
- * `sandboxMode`/`approvalPolicy`, so Codex reads the user's own
- * `~/.codex/config.toml` and behaves exactly as their terminal `codex` does —
- * never more permissive, never more restrictive. (On stock Ubuntu 24.04 that
- * means Codex's bubblewrap sandbox can't build — but the user's terminal Codex
- * fails identically, so reproducing it is correct, not a bug to paper over.)
+ * (session ≈ project) and the model when configured. It sets no
+ * `sandboxMode`/`approvalPolicy`, preserving the user's own Codex config.
  * Codex's SDK exposes no interactive-approval callback, so `permission_request`
  * simply never fires here (optional-feature rule); resolvePermission is a no-op.
  */
@@ -253,10 +68,7 @@ export class CodexSession implements AgentSession {
   private listeners = new Set<(msg: WireMsg) => void>();
   private workspaceDir: string;
   private thread: Thread;
-  // Retained for the V.2 /model switch: a mid-session model change is
-  // `codex.resumeThread(threadId, {...threadOpts, model})` — a fresh Thread
-  // on the same warm conversation, so the engine and start options must
-  // outlive the constructor.
+  // A model/effort switch resumes this same warm conversation with new options.
   private codex: Codex;
   private threadOpts: {
     workingDirectory: string;
@@ -269,45 +81,24 @@ export class CodexSession implements AgentSession {
   private listModels: () => Promise<CodexModel[]>;
   private closed = false;
   private currentAbort?: AbortController;
-  // Tool item ids announced on the wire, so a completion doesn't paint an
-  // orphan result for something we never opened.
-  private announced = new Set<string>();
-  // One live checklist per turn (T2.5), reset each turn so it re-anchors.
-  private todoRenderId?: string;
+  private eventMapper: CodexEventMapper;
   private modelLabel: string;
-  // The reasoning-effort label, EFFORT_STAND_IN until a /effort pick overrides
-  // it (mirrors modelLabel). Config/model default stays in force until then.
-  private effortLabel: string = EFFORT_STAND_IN;
-  // Where Codex keeps auth/config/sessions — the CLI's own CODEX_HOME rule.
-  // A field (not read at call time) so tests can point it at a fixture.
+  // The config/model default stays in force until `/effort` overrides it.
+  private effortLabel: string = CODEX_EFFORT_STAND_IN;
+  // Kept mutable so rollout tests can point the lookup at a fixture.
   private codexHome = process.env.CODEX_HOME ?? path.join(os.homedir(), ".codex");
-  private lookupRunning = false;
-  // V.2: the SDK exposes no system-prompt/instructions hook (unlike Claude's
-  // `systemPrompt.append`), so RENDER_GUIDANCE + the deferred-tools addendum
-  // ride ahead of the first user turn instead — the only injection point this
-  // engine has. The thread carries them for the rest of the session.
+  private rolloutLookup = new CodexRolloutLookup();
+  // The SDK has no instructions hook, so guidance rides on the first turn.
   private firstTurn = true;
-  // Provider binding, model axis (2026-07-19): a forced-openai pick must not
-  // inherit a top-level config.toml `model` that was chosen FOR a custom
-  // default provider (OpenAI 400s the foreign slug). When set, the first
-  // engine turn first resolves the ENGINE binary's own default model from its
-  // catalog and restarts the unstarted thread under it — version-correct by
-  // construction, never a hardcoded slug. An explicit model (opts.model, a
-  // /model switch) always wins and clears this.
+  // A forced first-party provider must not inherit a custom provider's model.
   private needsEngineDefaultModel = false;
-  /** Does this session run on OpenAI's first-party provider (an API key or a
-   *  ChatGPT login)? Those accounts serve first-party model ids only, which is
-   *  what makes a foreign id detectable below. */
+  // First-party catalogs must reject provider-qualified third-party model ids.
   private firstPartyOpenAI = false;
   private listEngineModels: () => Promise<CodexModel[]>;
   private listSkills: () => Promise<CodexSkill[]>;
-  // Configured provider URLs can carry private hosts, paths, URL auth, or
-  // signed queries. Keep the exact selected destination only for redacting
-  // SDK diagnostics before they become browser messages or logs.
+  // Exact selected URL is retained only to redact it from diagnostics.
   private endpointForRedaction?: string;
-  // Only probe-discovered local servers carry an endpoint into CodexSession;
-  // config.toml providers carry a provider id instead. This distinction keeps
-  // the local-only effort extension and watchdog off every inherited provider.
+  // Local-only effort/timeout behavior applies only to probe-discovered URLs.
   private discoveredLocalEndpoint = false;
   private localTurnTimeoutMs = 0;
 
@@ -323,14 +114,11 @@ export class CodexSession implements AgentSession {
     this.resumeIdState.onChange(cb, this.threadId);
   }
 
-  // N.5: `kind`/`endpoint` carry the onboarding picker's backend choice;
-  // undefined = the pre-N default (apiKey iff the env var is set, everything
-  // inherited). `makeCodex` is the constructor-options test seam (the analog
-  // of Claude's `engine` — the options must be capturable at construction).
+  // `makeCodex` and the catalog functions are constructor-level test seams.
   constructor(opts: {
     workspaceDir: string;
     model?: string;
-    kind?: "api-key" | "subscription" | "local";
+    kind?: CodexBackendKind;
     endpoint?: string;
     provider?: string;
     resumeId?: string;
@@ -345,26 +133,6 @@ export class CodexSession implements AgentSession {
     mkdirSync(workspaceDir, { recursive: true });
     this.workspaceDir = workspaceDir;
     this.modelLabel = opts.model ?? MODEL_STAND_IN;
-    // The chosen backend, enforced per-session (N.5; provider binding 2026-07-19):
-    // every pick forces the provider its label promised, because a config.toml
-    // `model_provider` default would otherwise silently redirect a session the
-    // user was told runs elsewhere — the onboarding row must never lie.
-    //   api-key (or no choice with the env var set) → pass the key AND force
-    //     the first-party `openai` provider (a no-op unless a custom config
-    //     default exists — exactly the case that made the label false).
-    //   subscription → NO apiKey, env override WITHOUT the env key so the CLI
-    //     resolves ~/.codex/auth.json, and the `openai` provider forced for
-    //     the same reason.
-    //   local WITH `endpoint` (a discovered server) → the documented
-    //     custom-provider recipe (docs/local-models.md Path B), injected
-    //     per-session: the server's /v1 as a Responses-API provider, made the
-    //     default. WITH `provider` (a config-declared provider row) → force
-    //     that provider id; its definition (base_url, env_key, wire_api) stays
-    //     the user's own config.toml table — inherit the declaration, select
-    //     it explicitly. With NEITHER (an old client's bare local pick) →
-    //     inject nothing: the config default wins, as before.
-    //   Default: inherit process.env, so the CLI finds the user's own auth +
-    //     config, exactly as before.
     const kind = opts.kind ?? (process.env.OPENAI_API_KEY ? "api-key" : undefined);
     this.discoveredLocalEndpoint = kind === "local" && opts.endpoint !== undefined;
     if (this.discoveredLocalEndpoint) {
@@ -374,76 +142,41 @@ export class CodexSession implements AgentSession {
           ? configuredTimeout
           : DEFAULT_LOCAL_TURN_TIMEOUT_MS;
     }
-    const providerConfig = codexProviders();
-    const selectedProvider =
-      opts.provider ?? (kind === "local" && !opts.endpoint ? providerConfig.defaultProvider : undefined);
-    this.endpointForRedaction =
-      opts.endpoint ?? providerConfig.entries.find((entry) => entry.id === selectedProvider)?.baseUrl;
-    // The session's provider binding, kept so every catalog question is asked
-    // of the SAME provider the turns run on (2026-07-20). Asking unpinned let
-    // the user's config.toml answer for us.
-    const binding = providerBinding(kind, opts.endpoint, opts.provider);
-    this.firstPartyOpenAI = binding["model_provider"] === "openai";
-    // Faithful-skin runtime parity: when the user has Codex installed, drive
-    // that exact executable rather than the SDK's separately-versioned bundled
-    // engine. Both versions share ~/.codex/config.toml and models_cache.json;
-    // splitting them lets a newer terminal write state an older engine cannot
-    // parse, then silently changes the default model (F.10, reproduced live).
-    // A machine with no external Codex keeps the SDK's bundled fallback.
-    const installedCodex = installedAgentBin("MIRAFOLD_CODEX_BIN", "codex");
-    const codex = (opts.makeCodex ?? ((o: CodexOptions) => new Codex(o)))({
-      ...(installedCodex ? { codexPathOverride: installedCodex } : {}),
-      ...(kind === "api-key" && process.env.OPENAI_API_KEY
-        ? { apiKey: process.env.OPENAI_API_KEY }
-        : {}),
-      // subscription: the explicit pick must beat the env var's precedence.
-      // local: the key has no business in a process pointed at a local server
-      // (Codex ignores it once model_provider points elsewhere, but withhold
-      // it anyway — symmetry with the claude adapter; 2026-07-17 audit).
-      ...(kind === "subscription" || kind === "local"
-        ? { env: envWithout("OPENAI_API_KEY") }
-        : {}),
-      // Inject Mirafold's generative-UI tools as a stdio MCP server. Codex
-      // calls them like any tool; the adapter turns those calls into render/
-      // artifact WireMsgs below (it never reaches back into this subprocess).
-      // `default_tools_approval_mode: "approve"` auto-approves THIS server's
-      // tools only — they're Mirafold's own side-effect-free UI emission, the
-      // direct analog of the Claude adapter auto-allowing mcp__ui__*. Without it,
-      // headless exec mode (which can't prompt for approval) cancels the call.
-      config: {
-        mcp_servers: {
-          [MIRAFOLD_MCP]: {
-            command: RENDER_MCP.command,
-            args: RENDER_MCP.args,
-            default_tools_approval_mode: "approve",
-          },
-        },
-        ...binding,
-      },
+    const runtime = createCodexRuntimeBinding({
+      kind,
+      endpoint: opts.endpoint,
+      provider: opts.provider,
+      model: opts.model,
+      makeCodex: opts.makeCodex,
+      listModels: opts.listModels,
+      listEngineModels: opts.listEngineModels,
     });
+    const codex = runtime.codex;
     this.codex = codex;
+    this.firstPartyOpenAI = runtime.firstPartyOpenAI;
+    this.endpointForRedaction = runtime.endpointForRedaction;
     this.threadId = opts.resumeId;
     this.resumeIdState = new ResumeIdState(opts.resumeId);
-    // Both catalogs ask the exact binary the SDK actually spawns and carry the
-    // same provider binding. A picker row from one version followed by a turn
-    // on another is the version-skew bug F.10 removes. The private-field read
-    // is failure-soft: injected test doubles may omit it, in which case the
-    // catalog helper performs its ordinary installed-binary lookup.
-    const engineBin = (codex as unknown as { exec?: { executablePath?: string } }).exec
-      ?.executablePath;
-    const engineModels = () => listCodexModels(undefined, engineBin, binding);
-    this.listModels = opts.listModels ?? engineModels;
-    this.listEngineModels =
-      opts.listEngineModels ?? engineModels;
-    this.listSkills = opts.listSkills ?? (() => listCodexSkills(workspaceDir, undefined, engineBin));
-    // Model-axis neutralization: only when the pick forces the first-party
-    // provider away from a CUSTOM config default whose top-level model would
-    // ride along wrongly. An explicit model override wins outright.
-    if ((kind === "api-key" || kind === "subscription") && !opts.model) {
-      const cfg = providerConfig;
-      this.needsEngineDefaultModel =
-        cfg.defaultProvider !== undefined && cfg.defaultProvider !== "openai" && cfg.model !== undefined;
-    }
+    this.eventMapper = new CodexEventMapper({
+      emit: (message) => this.emit(message),
+      workspaceDir,
+      modelName: () => this.modelName,
+      modelUnknown: () => this.modelLabel === MODEL_STAND_IN,
+      learnModel: () => void this.learnModel(),
+      turnDiagnostic: (value) =>
+        codexTurnDiagnostic(value, this.endpointForRedaction, this.discoveredLocalEndpoint),
+      providerDiagnostic: (value) => codexProviderDiagnostic(value, this.endpointForRedaction),
+      onThreadStarted: (threadId) => {
+        if (this.threadId === threadId) return;
+        this.threadId = threadId;
+        this.resumeIdState.publish(threadId);
+      },
+    });
+    this.listModels = runtime.listModels;
+    this.listEngineModels = runtime.listEngineModels;
+    this.listSkills =
+      opts.listSkills ?? (() => listCodexSkills(workspaceDir, undefined, runtime.engineBin));
+    this.needsEngineDefaultModel = runtime.needsEngineDefaultModel;
     this.threadOpts = {
       workingDirectory: workspaceDir,
       skipGitRepoCheck: true, // workspace dirs aren't git repos
@@ -458,22 +191,11 @@ export class CodexSession implements AgentSession {
   }
 
   refreshPromptOptions() {
-    const slash = codexSlashOptions();
-    emitPromptOptions((msg) => this.emit(msg), slash);
-    this.listSkills()
-      .then((skills) => {
-        if (this.closed) return;
-        const skillOptions: PromptOption[] = skills.map((skill) => ({
-          trigger: "$",
-          value: `$${skill.name}`,
-          label: skill.name,
-          description: skill.description,
-          kind: "skill",
-          source: "codex",
-        }));
-        emitPromptOptions((msg) => this.emit(msg), [...slash, ...skillOptions]);
-      })
-      .catch(() => {}); // slash commands remain useful if skill discovery is unavailable
+    refreshCodexPromptOptions({
+      emit: (message) => this.emit(message),
+      listSkills: () => this.listSkills(),
+      isClosed: () => this.closed,
+    });
   }
 
   pushPrompt(text: string) {
@@ -505,40 +227,7 @@ export class CodexSession implements AgentSession {
     for (const cb of this.listeners) cb(msg);
   }
 
-  private providerDiagnostic(value: unknown): string {
-    return scrubSelectedEndpoint(
-      typeof value === "string" ? value : errText(value),
-      this.endpointForRedaction,
-    );
-  }
-
-  /** Add the concrete recovery step only for Mirafold-discovered local turns.
-   * Configured providers retain Codex's own diagnostic verbatim. */
-  private turnDiagnostic(value: unknown): string {
-    const diagnostic = this.providerDiagnostic(value);
-    return this.discoveredLocalEndpoint
-      ? `Local Codex could not complete the turn: ${diagnostic}. ` +
-          "Check that the local model server is running and still serves the selected model."
-      : diagnostic;
-  }
-
-  private localTurnTimeoutDiagnostic(): string {
-    const seconds = Math.ceil(this.localTurnTimeoutMs / 1_000);
-    const reasoningAction =
-      this.effortLabel === "none"
-        ? "Reasoning is already disabled; choose a faster model or machine"
-        : "Send `/effort none` and retry if the server supports reasoning control, choose a faster model or machine";
-    return (
-      `The local Codex turn did not finish within ${seconds} seconds. ` +
-      "The engine may still be pre-filling Codex's context, or the model may be reasoning too slowly. " +
-      `${reasoningAction}, or raise MIRAFOLD_CODEX_LOCAL_TURN_TIMEOUT_MS ` +
-      "(set it to 0 to disable the limit)."
-    );
-  }
-
-  /** Serial turn loop — Codex runs one turn per prompt on the warm thread.
-   *  `/model` is handled here, between turns, so a switch queued behind a
-   *  running turn applies in order like any other input. */
+  /** Serial queue: command switches and engine turns apply in prompt order. */
   private async worker() {
     while (!this.closed) {
       const item = await this.queue.next();
@@ -554,75 +243,20 @@ export class CodexSession implements AgentSession {
     }
   }
 
-  /**
-   * V.2 /model parity. Terminal Codex's /model opens an interactive picker —
-   * TUI chrome the headless SDK has no round-trip for (the engine, sent the
-   * literal text, just chats back). So the shell re-skins the picker: the
-   * LIST is Codex's own catalog (codex-model-list.ts — the same app-server
-   * answer the terminal picker shows), rendered as a `question` component
-   * whose click sends `/model <id>` back through this same path. A switch
-   * resumes the warm thread with the new model — history intact, exactly
-   * what the terminal picker does to a session.
-   *
-   * Bare slugs the catalog doesn't list still apply: terminal Codex accepts
-   * any `-m <model_name>` (its picker hints exactly that for legacy models),
-   * so refusing here would be less faithful, not more.
-   */
-  /** The slash-command turn envelope: `status: thinking`, the body, then a
-   *  guaranteed `turn_end` — even when the body errors out early. */
-  private async runSlashTurn(body: () => Promise<void> | void) {
-    this.emit({ type: "status", state: "thinking" });
-    try {
-      await body();
-    } finally {
-      this.emit({ type: "turn_end" });
-    }
-  }
-
+  /** Render Codex's own model catalog, then resume the warm thread on a pick. */
   private async runModelCommand(arg: string) {
-    await this.runSlashTurn(async () => {
-      if (arg === "") {
-        let models: CodexModel[];
-        try {
-          models = await this.listModels();
-        } catch (err) {
-          this.emit({
-            type: "error",
-            message: `Could not read the model list from codex: ${this.providerDiagnostic(err)}`,
-          });
-          return;
-        }
-        // The trailing legacy-models hint mirrors the terminal picker's own
-        // footer; it rides after the picker.
-        const current = (m: CodexModel) =>
-          this.modelLabel === MODEL_STAND_IN ? m.isDefault : this.modelLabel === m.id;
-        emitModelPicker(
-          (msg) => this.emit(msg),
-          models.map((m) => ({ ...m, current: current(m) })),
-          {
-            clickText: (id) => `/model ${id}`,
-            switchHint: "Send `/model <model-id>` to switch.",
-          },
-        );
-        this.emit({
-          type: "text_delta",
-          text: "\nLegacy models can be set directly with `/model <model_name>`.",
-        });
-      } else if (/\s/.test(arg) || arg.startsWith("-")) {
-        // Hyphen-leading names are rejected HERE rather than trusting the
-        // codex CLI's parser to refuse a flag-shaped --model value
-        // (2026-07-18 audit): the safety stays local, the error stays clear.
-        this.emit({ type: "text_delta", text: "Usage: `/model` to pick, or `/model <model-id>`." });
-      } else {
-        this.setThreadModel(arg);
-        this.emit({ type: "text_delta", text: `Model set to ${arg}.` });
-      }
+    await runCodexModelCommand({
+      arg,
+      emit: (message) => this.emit(message),
+      listModels: () => this.listModels(),
+      isCurrent: (model) =>
+        this.modelLabel === MODEL_STAND_IN ? model.isDefault : this.modelLabel === model.id,
+      setModel: (model) => this.setThreadModel(model),
+      diagnostic: (error) => codexProviderDiagnostic(error, this.endpointForRedaction),
     });
   }
 
-  /** Switch the warm thread onto `model`. The label becomes configured-truth
-   *  immediately — same as constructing with opts.model — and any pending
-   *  engine-default resolution is superseded. */
+  /** An explicit model supersedes pending default-model discovery. */
   private setThreadModel(model: string) {
     this.threadOpts = { ...this.threadOpts, model };
     this.restartThread();
@@ -630,56 +264,25 @@ export class CodexSession implements AgentSession {
     this.needsEngineDefaultModel = false;
   }
 
-  /** Re-point the warm conversation at the current threadOpts: resume the
-   *  started thread (history intact — exactly what the terminal picker does to
-   *  a session) or restart the one not yet started. */
+  /** Apply current options without discarding a started thread's history. */
   private restartThread() {
     this.thread = this.threadId
       ? this.codex.resumeThread(this.threadId, this.threadOpts)
       : this.codex.startThread(this.threadOpts);
   }
 
-  /**
-   * The reasoning-effort axis of the /model picker (SCAFFOLD — see EFFORTS).
-   * Mirrors runModelCommand: bare `/effort` paints the picker (a click sends
-   * `/effort <level>`), `/effort <level>` applies it, anything else is a usage
-   * line. The ordinary catalog is the SDK's ModelReasoningEffort union rather
-   * than an app-server round-trip — Codex has no `effort/list`. A discovered
-   * local endpoint additionally gets `none`, a real Codex/Ollama value omitted
-   * from the SDK type. Per-model availability is NOT yet filtered.
-   */
+  /** Render the effort catalog and resume the warm thread on a pick. */
   private async runEffortCommand(arg: string) {
-    await this.runSlashTurn(() => {
-      const efforts = this.discoveredLocalEndpoint ? LOCAL_EFFORTS : EFFORTS;
-      if (arg === "") {
-        emitModelPicker(
-          (msg) => this.emit(msg),
-          efforts.map((e) => ({
-            id: e,
-            displayName: e,
-            description: EFFORT_DESC[e],
-            current: this.effortLabel === e,
-          })),
-          {
-            clickText: (id) => `/effort ${id}`,
-            switchHint: "Send `/effort <level>` to set the reasoning effort.",
-            question: "Select reasoning effort",
-          },
-        );
-      } else if (isEffort(arg, efforts)) {
-        this.setThreadEffort(arg);
-        this.emit({ type: "text_delta", text: `Reasoning effort set to ${arg}.` });
-      } else {
-        this.emit({
-          type: "text_delta",
-          text: `Usage: \`/effort\` to pick, or \`/effort <level>\` (${efforts.join(", ")}).`,
-        });
-      }
+    await runCodexEffortCommand({
+      arg,
+      emit: (message) => this.emit(message),
+      discoveredLocalEndpoint: this.discoveredLocalEndpoint,
+      currentEffort: this.effortLabel,
+      setEffort: (effort) => this.setThreadEffort(effort),
     });
   }
 
-  /** The reasoning-effort analog of setThreadModel: switch the warm thread onto
-   *  the new effort, history intact. */
+  /** Switch effort while preserving the warm thread's history. */
   private setThreadEffort(effort: CodexReasoningEffort) {
     // Codex 0.147.0 accepts and forwards `none`; the SDK union has not caught
     // up. Keep the cast at this single boundary instead of widening every
@@ -692,34 +295,19 @@ export class CodexSession implements AgentSession {
     this.effortLabel = effort;
   }
 
-  /** The model half of provider binding: swap the foreign config.toml model
-   *  for the ENGINE binary's own default (its catalog's isDefault row) and
-   *  restart the thread under it — the same switch mechanics as /model.
-   *  False = resolution failed; the honest error is already emitted and the
-   *  turn must not reach the engine under the foreign model. */
+  /** Resolve the engine's marked default before a forced first-party turn. */
   private async applyEngineDefaultModel(): Promise<boolean> {
     this.needsEngineDefaultModel = false;
     try {
       const models = await this.listEngineModels();
-      // Only a row the engine itself marks default — guessing (e.g. row 0 of
-      // an unmarked catalog) risks running a model the user never chose.
-      const def = models.find((m) => m.isDefault);
-      if (!def) throw new Error("the engine's catalog marks no default model");
-      // Belt and braces over the `-c` pin (2026-07-20): the binary shares one
-      // models_cache.json across providers, so a stale OpenRouter fetch can
-      // still surface here. A `vendor/model` slug is a third-party
-      // namespace — first-party OpenAI ids never carry a slash — and sending
-      // one to a ChatGPT account is the 400 this whole path exists to prevent.
-      if (this.firstPartyOpenAI && def.id.includes("/"))
-        throw new Error(`the catalog answered with \`${def.id}\`, which OpenAI's provider can't run`);
-      this.setThreadModel(def.id);
+      this.setThreadModel(codexEngineDefaultModel(models, this.firstPartyOpenAI));
       return true;
     } catch (err) {
       this.emit({
         type: "error",
         message:
           "This backend runs OpenAI's own provider, but its default model could not be " +
-          `resolved: ${this.providerDiagnostic(err)}. ` +
+          `resolved: ${codexProviderDiagnostic(err, this.endpointForRedaction)}. ` +
           "Send `/model <model-id>` to set one.",
       });
       return false;
@@ -735,7 +323,7 @@ export class CodexSession implements AgentSession {
     const end = () => {
       if (ended) return;
       ended = true;
-      this.todoRenderId = undefined; // next turn starts a fresh checklist
+      this.eventMapper.endTurn();
       this.emit({ type: "turn_end" });
     };
     if (this.localTurnTimeoutMs > 0) {
@@ -757,12 +345,22 @@ export class CodexSession implements AgentSession {
       // bare — no render calls for the session's whole life (2026-07-29
       // bughunt; V.2 measured 0/9 render calls without the addendum).
       this.firstTurn = false;
-      for await (const ev of events) this.handleEvent(ev, end);
+      for await (const event of events) this.eventMapper.handle(event, end);
     } catch (err) {
       if (!this.closed && timeoutFired) {
-        this.emit({ type: "error", message: this.localTurnTimeoutDiagnostic() });
+        this.emit({
+          type: "error",
+          message: codexLocalTurnTimeoutDiagnostic(this.localTurnTimeoutMs, this.effortLabel),
+        });
       } else if (!this.closed && !abort.signal.aborted) {
-        this.emit({ type: "error", message: this.turnDiagnostic(err) });
+        this.emit({
+          type: "error",
+          message: codexTurnDiagnostic(
+            err,
+            this.endpointForRedaction,
+            this.discoveredLocalEndpoint,
+          ),
+        });
       }
     } finally {
       if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
@@ -771,234 +369,14 @@ export class CodexSession implements AgentSession {
     }
   }
 
-  private handleEvent(ev: ThreadEvent, end: () => void) {
-    switch (ev.type) {
-      case "turn.started":
-        this.emit({ type: "status", state: "thinking" });
-        break;
-      case "item.started":
-        this.onItem(ev.item, "started");
-        break;
-      case "item.updated":
-        this.onItem(ev.item, "updated");
-        break;
-      case "item.completed":
-        this.onItem(ev.item, "completed");
-        break;
-      case "turn.completed": {
-        const u = ev.usage;
-        this.emit({
-          type: "usage",
-          model: this.modelName,
-          // cached_input_tokens is a subset of input_tokens (already counted);
-          // reasoning is output-side cost.
-          inputTokens: u.input_tokens,
-          outputTokens: u.output_tokens + u.reasoning_output_tokens,
-        });
-        // A lookup that ran out its window mid-turn gets another chance now —
-        // by turn end the rollout file certainly has its turn_context line.
-        if (this.modelLabel === MODEL_STAND_IN) void this.learnModel();
-        end();
-        break;
-      }
-      case "turn.failed":
-        this.emit({ type: "error", message: this.turnDiagnostic(ev.error.message) });
-        end();
-        break;
-      case "error": // fatal stream error
-        this.emit({ type: "error", message: this.turnDiagnostic(ev.message) });
-        end();
-        break;
-      case "thread.started":
-        // Carries the resume id; the persistent Thread already holds warmth,
-        // so nothing to emit — but the id is kept for the /model switch
-        // (resumeThread), and it names the rollout file, the one place Codex
-        // records the model it actually resolved. Learn it there
-        // (fleet/status-bar parity with Claude's system/init, F.3), unless a
-        // model was configured — then the label already tells the truth.
-        if (this.threadId !== ev.thread_id) {
-          this.threadId = ev.thread_id;
-          this.resumeIdState.publish(ev.thread_id);
-        }
-        if (this.modelLabel === MODEL_STAND_IN) void this.learnModel();
-        break;
-    }
-  }
-
-  /** Poll the rollout file for the resolved model. Its turn_context line is
-      written when the first turn's context is assembled — measured ~3s after
-      thread.started reaches us — so the window is a generous 20 × 500ms;
-      turn.completed re-kicks a missed lookup. Silent on failure: the "codex"
-      stand-in is still honest, just less specific. */
-  private async learnModel() {
-    if (this.lookupRunning || !this.threadId) return;
-    this.lookupRunning = true;
-    try {
-      for (let attempt = 0; attempt < 20 && !this.closed && this.modelLabel === MODEL_STAND_IN; attempt++) {
-        const model = await resolveRolloutModel(this.threadId, this.codexHome);
-        if (model) {
-          this.modelLabel = model;
-          return;
-        }
-        await new Promise((r) => setTimeout(r, 500));
-      }
-    } finally {
-      this.lookupRunning = false;
-    }
-  }
-
-  /** Normalize one thread item. `phase` distinguishes start vs. finish. */
-  private onItem(item: ThreadItem, phase: "started" | "updated" | "completed") {
-    switch (item.type) {
-      case "agent_message":
-        // Any mermaid xychart the model still hand-wrote becomes the real
-        // chart component (the V.2 backstop — see mermaid-chart.ts); all
-        // other text passes through verbatim.
-        if (phase === "completed") {
-          for (const seg of convertMermaidCharts(item.text)) {
-            if ("text" in seg) this.emit({ type: "text_delta", text: seg.text });
-            else
-              this.emit({
-                type: "render",
-                component: "chart",
-                props: seg.chart as unknown as Record<string, unknown>,
-                id: randomUUID(),
-              });
-          }
-        }
-        break;
-      case "reasoning":
-        if (phase === "completed") {
-          this.emit({ type: "status", state: "thinking" });
-          this.emit({ type: "thinking_delta", text: item.text });
-        }
-        break;
-      case "command_execution": {
-        if (phase === "started") this.announceTool(item.id, "Shell", item.command, { command: item.command });
-        else if (phase === "completed") {
-          this.ensureAnnounced(item.id, "Shell", item.command, { command: item.command });
-          const capped = capOutput(item.aggregated_output ?? "");
-          this.finishTool(item.id, {
-            output: capped.text,
-            truncatedBytes: capped.truncatedBytes,
-            isError: item.status === "failed" || (item.exit_code != null && item.exit_code !== 0),
-          });
-        }
-        break;
-      }
-      case "file_change": {
-        if (phase !== "completed") break;
-        const paths = item.changes.map((c) => `${c.kind} ${c.path}`).join(", ");
-        this.announceTool(item.id, "apply_patch", paths, { changes: item.changes });
-        this.finishTool(item.id, {
-          output: paths || "(no changes)",
-          isError: item.status === "failed",
-        });
-        break;
-      }
-      case "mcp_tool_call": {
-        // Our own generative-UI server: never a raw tool row — turn the call
-        // into the render/artifact WireMsg it stands for (P.3). The stub server
-        // just validated the args and handed back the id; we paint it here.
-        if (item.server === MIRAFOLD_MCP) {
-          if (phase === "completed" && item.status !== "failed" && !item.error) {
-            this.emitGenerativeUI(item);
-          }
-          break;
-        }
-        const label = `${item.server}.${item.tool}`;
-        if (phase === "started") this.announceTool(item.id, label, item.tool, item.arguments);
-        else if (phase === "completed") {
-          this.ensureAnnounced(item.id, label, item.tool, item.arguments);
-          const capped = capOutput(item.error ? item.error.message : mcpText(item.result?.content));
-          this.finishTool(item.id, {
-            output: capped.text,
-            truncatedBytes: capped.truncatedBytes,
-            isError: item.status === "failed" || Boolean(item.error),
-          });
-        }
-        break;
-      }
-      case "web_search": {
-        if (phase !== "completed") break;
-        this.announceTool(item.id, "web_search", item.query, { query: item.query });
-        this.finishTool(item.id, {
-          output: "(results returned to the agent)",
-        });
-        break;
-      }
-      case "todo_list":
-        // Live checklist, one render id per turn (update-in-place, T2.5).
-        this.emitChecklist(item.items);
-        break;
-      case "error":
-        // A NOTICE, not an error: the SDK types this item "a non-fatal error
-        // surfaced as an item" — the turn keeps running, and Codex's own TUI
-        // shows it as a warning. The fatal channels are elsewhere and still
-        // end the turn (`turn.failed`, the stream's `error` event). Rendering
-        // this one red said "your session died" over an advisory as ordinary
-        // as "no metadata for qwen3:1.7b" (2026-07-20).
-        // `source` because the text is codex's own, verbatim: the dim system
-        // line is otherwise Mirafold's voice, and unattributed engine words
-        // there can pose as ours (2026-07-20 audit).
-        if (phase === "completed")
-          this.emit({
-            type: "notice",
-            text: this.providerDiagnostic(item.message),
-            kind: "warning",
-            source: "codex",
-          });
-        break;
-    }
-  }
-
-  /** Announce only if the started phase was missed (the item arrived
-   *  completed-first) — a repeat announce would paint a duplicate row. */
-  private ensureAnnounced(id: string, name: string, detail: string, input: unknown) {
-    if (!this.announced.has(id)) this.announceTool(id, name, detail, input);
-  }
-
-  private announceTool(id: string, name: string, detail: string, input: unknown) {
-    this.announced.add(id);
-    this.emit({ type: "status", state: "tool", label: name });
-    this.emit({
-      type: "tool_use",
-      name,
-      detail: detail || undefined,
-      id,
-      input: typeof input === "object" && input !== null ? (input as Record<string, unknown>) : undefined,
+  private learnModel() {
+    return this.rolloutLookup.learn({
+      threadId: () => this.threadId,
+      codexHome: () => this.codexHome,
+      shouldContinue: () => !this.closed && this.modelLabel === MODEL_STAND_IN,
+      onResolved: (model) => {
+        this.modelLabel = model;
+      },
     });
-  }
-
-  /** Close out an announced tool row: drop the id, emit its result. */
-  private finishTool(
-    id: string,
-    result: { output: string; isError?: boolean; truncatedBytes?: number },
-  ) {
-    this.announced.delete(id);
-    this.emit({ type: "tool_result", ...result, id });
-  }
-
-  /** Turn a Mirafold MCP tool call into the render/artifact WireMsg it stands for. */
-  private emitGenerativeUI(item: McpToolCallItem) {
-    const args =
-      item.arguments && typeof item.arguments === "object"
-        ? (item.arguments as Record<string, unknown>)
-        : {};
-    const msg = generativeUIMsg(item.tool, args, extractRenderId(item), this.workspaceDir);
-    if (msg) this.emit(msg);
-  }
-
-  private emitChecklist(items: { text: string; completed: boolean }[]) {
-    // Same rule as the Claude adapter: never paint an empty checklist, but
-    // an emptied list must still update one already painted this turn
-    // (2026-07-29 bughunt).
-    if (!items.length && !this.todoRenderId) return;
-    this.todoRenderId ??= randomUUID();
-    const todos: TodoItem[] = items.map((t) => ({
-      content: t.text,
-      status: t.completed ? "completed" : "pending",
-    }));
-    this.emit({ type: "render", component: "todo-list", props: { todos }, id: this.todoRenderId });
   }
 }

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -2179,17 +2179,24 @@ test("E.3: the files panel lists the working tree, opens a file beside the trans
   // from any of them.
   const root = page.locator(".files-root-row");
   const repoDir = path.basename(path.resolve(import.meta.dirname, "..", ".."));
+  const panelHead = page.locator(".files-panel-head");
+  assert.equal(await panelHead.locator(".files-panel-title").innerText(), "Files");
+  assert.equal(
+    await panelHead.locator(".files-refresh[aria-label='Refresh files']").count(),
+    1,
+    "the Explorer title bar owns its refresh action",
+  );
   assert.ok((await root.innerText()).includes(repoDir), `root row names the checkout folder (${repoDir})`);
   assert.equal(await page.locator(".files-title").count(), 0, "the old path header is gone");
   assert.equal(
-    await root.locator(".files-node-icon-folder-open").count(),
+    await root.locator(".files-caret + .files-node-icon-folder-open + .files-name").count(),
     1,
-    "the expanded root carries the open-folder glyph after its name",
+    "the expanded root orders its chevron, open-folder glyph, then name",
   );
   assert.equal(
-    await pkg.locator(".files-node-icon-config[aria-hidden=true]").count(),
+    await pkg.locator(".files-caret + .files-node-icon-config[aria-hidden=true] + .files-name").count(),
     1,
-    "package.json carries one decorative configuration glyph",
+    "package.json carries its decorative configuration glyph before its name",
   );
   await root.click();
   await eventually(
@@ -2605,8 +2612,8 @@ test("W.2: the live tree — a write behind the UI's back appears with zero clic
       "nothing expanded shows the hidden file — correct",
     );
 
-    // The refresh button is unchanged beside the bell: a click still
-    // refetches (fresh root request on the wire) and the tree stays whole.
+    // The refresh action remains beside the bell: a click still refetches
+    // (fresh root request on the wire) and the tree stays whole.
     const rootFetches = () =>
       page.evaluate(
         () =>

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -2181,10 +2181,25 @@ test("E.3: the files panel lists the working tree, opens a file beside the trans
   const repoDir = path.basename(path.resolve(import.meta.dirname, "..", ".."));
   assert.ok((await root.innerText()).includes(repoDir), `root row names the checkout folder (${repoDir})`);
   assert.equal(await page.locator(".files-title").count(), 0, "the old path header is gone");
+  assert.equal(
+    await root.locator(".files-node-icon-folder-open").count(),
+    1,
+    "the expanded root carries the open-folder glyph after its name",
+  );
+  assert.equal(
+    await pkg.locator(".files-node-icon-config[aria-hidden=true]").count(),
+    1,
+    "package.json carries one decorative configuration glyph",
+  );
   await root.click();
   await eventually(
     () => document.querySelectorAll(".files-file-row").length === 0,
     "collapsed root still lists files",
+  );
+  assert.equal(
+    await root.locator(".files-node-icon-folder").count(),
+    1,
+    "the collapsed root carries the closed-folder glyph",
   );
   await root.click();
   await pkg.waitFor({ timeout: 15_000 });

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -2180,7 +2180,7 @@ test("E.3: the files panel lists the working tree, opens a file beside the trans
   const root = page.locator(".files-root-row");
   const repoDir = path.basename(path.resolve(import.meta.dirname, "..", ".."));
   const panelHead = page.locator(".files-panel-head");
-  assert.equal(await panelHead.locator(".files-panel-title").innerText(), "Files");
+  assert.equal(await panelHead.locator(".files-panel-title").innerText(), "FILES");
   assert.equal(
     await panelHead.locator(".files-refresh[aria-label='Refresh files']").count(),
     1,

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -212,6 +212,11 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   // The tree is live git data (the daemon runs in the repo) — drill into a file.
   const pkg = phone.locator(".files-file-row", { hasText: "package.json" }).first();
   await pkg.waitFor({ timeout: 15_000 });
+  assert.equal(
+    await pkg.locator(".files-node-icon-config[aria-hidden=true]").count(),
+    1,
+    "phone tree keeps the same decorative configuration glyph",
+  );
   await pkg.tap();
   await phone.waitForSelector(".files-view .fv-content");
   await noSideScroll(phone);

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -213,9 +213,9 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   const pkg = phone.locator(".files-file-row", { hasText: "package.json" }).first();
   await pkg.waitFor({ timeout: 15_000 });
   assert.equal(
-    await pkg.locator(".files-node-icon-config[aria-hidden=true]").count(),
+    await pkg.locator(".files-caret + .files-node-icon-config[aria-hidden=true] + .files-name").count(),
     1,
-    "phone tree keeps the same decorative configuration glyph",
+    "phone tree keeps the decorative configuration glyph before the name",
   );
   await pkg.tap();
   await phone.waitForSelector(".files-view .fv-content");

--- a/web/src/components/files/ExplorerNodeGlyph.test.ts
+++ b/web/src/components/files/ExplorerNodeGlyph.test.ts
@@ -1,0 +1,18 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { explorerNodeGlyphKind } from "./ExplorerNodeGlyph";
+
+test("explorerNodeGlyphKind distinguishes hierarchy and broad file families", () => {
+  assert.equal(explorerNodeGlyphKind("src", "dir"), "folder");
+  assert.equal(explorerNodeGlyphKind("src", "dir", true), "folder-open");
+  assert.equal(explorerNodeGlyphKind("current.ts", "symlink"), "symlink");
+
+  assert.equal(explorerNodeGlyphKind("PromptBox.TSX", "file"), "code");
+  assert.equal(explorerNodeGlyphKind("package.json", "file"), "config");
+  assert.equal(explorerNodeGlyphKind(".gitignore", "file"), "config");
+  assert.equal(explorerNodeGlyphKind("yarn.lock", "file"), "config");
+  assert.equal(explorerNodeGlyphKind("README.md", "file"), "document");
+  assert.equal(explorerNodeGlyphKind("theme.scss", "file"), "style");
+  assert.equal(explorerNodeGlyphKind("logo.svg", "file"), "image");
+  assert.equal(explorerNodeGlyphKind("LICENSE", "file"), "file");
+});

--- a/web/src/components/files/ExplorerNodeGlyph.tsx
+++ b/web/src/components/files/ExplorerNodeGlyph.tsx
@@ -1,0 +1,194 @@
+export type ExplorerEntryKind = "dir" | "file" | "symlink";
+
+export type ExplorerNodeGlyphKind =
+  | "folder"
+  | "folder-open"
+  | "symlink"
+  | "code"
+  | "config"
+  | "document"
+  | "style"
+  | "image"
+  | "file";
+
+const CODE_EXTENSIONS = new Set([
+  "c",
+  "cc",
+  "cpp",
+  "cs",
+  "go",
+  "h",
+  "hpp",
+  "java",
+  "js",
+  "jsx",
+  "kt",
+  "kts",
+  "lean",
+  "mjs",
+  "php",
+  "py",
+  "rb",
+  "rkt",
+  "rs",
+  "scala",
+  "sh",
+  "swift",
+  "ts",
+  "tsx",
+  "zsh",
+]);
+
+const CONFIG_EXTENSIONS = new Set([
+  "conf",
+  "csv",
+  "ini",
+  "json",
+  "jsonc",
+  "lock",
+  "toml",
+  "xml",
+  "yaml",
+  "yml",
+]);
+
+const DOCUMENT_EXTENSIONS = new Set(["adoc", "md", "mdx", "pdf", "rst", "txt"]);
+const STYLE_EXTENSIONS = new Set(["css", "less", "sass", "scss", "styl"]);
+const IMAGE_EXTENSIONS = new Set([
+  "avif",
+  "bmp",
+  "gif",
+  "ico",
+  "jpeg",
+  "jpg",
+  "png",
+  "svg",
+  "webp",
+]);
+
+const CONFIG_NAMES = new Set([
+  ".editorconfig",
+  ".gitattributes",
+  ".gitignore",
+  ".npmrc",
+  ".nvmrc",
+  "dockerfile",
+  "makefile",
+]);
+
+/** A deliberately bounded file-family classifier for the Explorer's tiny
+ * decorative glyph. It communicates broad shape, not a promise to identify
+ * every language or reproduce a full IDE icon theme. */
+export function explorerNodeGlyphKind(
+  name: string,
+  entryKind: ExplorerEntryKind,
+  open = false,
+): ExplorerNodeGlyphKind {
+  if (entryKind === "dir") return open ? "folder-open" : "folder";
+  if (entryKind === "symlink") return "symlink";
+
+  const lower = name.toLowerCase();
+  if (CONFIG_NAMES.has(lower)) return "config";
+  const dot = lower.lastIndexOf(".");
+  const extension = dot > 0 ? lower.slice(dot + 1) : "";
+  if (CODE_EXTENSIONS.has(extension)) return "code";
+  if (CONFIG_EXTENSIONS.has(extension)) return "config";
+  if (DOCUMENT_EXTENSIONS.has(extension)) return "document";
+  if (STYLE_EXTENSIONS.has(extension)) return "style";
+  if (IMAGE_EXTENSIONS.has(extension)) return "image";
+  return "file";
+}
+
+export function ExplorerChevron({ open }: { open: boolean }) {
+  return (
+    <svg
+      className={`files-chevron${open ? " is-open" : ""}`}
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path d="M4 2.5 7.5 6 4 9.5" />
+    </svg>
+  );
+}
+
+export function ExplorerNodeGlyph({
+  name,
+  entryKind,
+  open = false,
+}: {
+  name: string;
+  entryKind: ExplorerEntryKind;
+  open?: boolean;
+}) {
+  const kind = explorerNodeGlyphKind(name, entryKind, open);
+  const page = (
+    <>
+      <path d="M3 1.75h6.1L13 5.65v8.6H3z" />
+      <path d="M9.1 1.75v3.9H13" />
+    </>
+  );
+
+  return (
+    <svg
+      className={`files-node-icon files-node-icon-${kind}`}
+      viewBox="0 0 16 16"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.25"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+      focusable="false"
+    >
+      {kind === "folder" && <path d="M1.75 3.5H6l1.35 1.55h6.9v7.45H1.75z" />}
+      {kind === "folder-open" && (
+        <>
+          <path d="M2.25 6V3.5H6l1.35 1.55h6.4v1.2" />
+          <path d="M2 6.25h12.25l-1.55 6.25H3.25z" />
+        </>
+      )}
+      {kind === "symlink" && (
+        <>
+          <path d="M6.35 5.25H5a3 3 0 0 0 0 6h1.35" />
+          <path d="M9.65 5.25H11a3 3 0 0 1 0 6H9.65" />
+          <path d="M5.75 8.25h4.5" />
+        </>
+      )}
+      {kind === "code" && (
+        <>
+          {page}
+          <path d="m6.25 8-1.5 1.5 1.5 1.5M9.75 8l1.5 1.5-1.5 1.5" />
+        </>
+      )}
+      {kind === "config" && (
+        <>
+          {page}
+          <path d="M5 8h6M5 11h6" />
+          <circle cx="7" cy="8" r="0.65" fill="currentColor" stroke="none" />
+          <circle cx="9.5" cy="11" r="0.65" fill="currentColor" stroke="none" />
+        </>
+      )}
+      {kind === "document" && (
+        <>
+          {page}
+          <path d="M5 8h6M5 10.25h6M5 12.5h4" />
+        </>
+      )}
+      {kind === "style" && (
+        <>
+          {page}
+          <path d="M6.5 7.5 5.75 12M10.25 7.5 9.5 12M5 9h6M4.65 10.75h6" />
+        </>
+      )}
+      {kind === "image" && (
+        <>
+          {page}
+          <circle cx="6" cy="8" r="0.75" />
+          <path d="m5 12 2.25-2.25 1.5 1.5 1.1-1.1L11.5 12" />
+        </>
+      )}
+      {kind === "file" && page}
+    </svg>
+  );
+}

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -14,6 +14,7 @@ import { useEscapeKey } from "../../use-escape";
 import { useFocusTrap } from "../../use-focus-trap";
 import { useIsPhone } from "../../use-is-phone";
 import { FileView, fileToState, diffToState, type FileViewState } from "./FileView";
+import { ExplorerChevron, ExplorerNodeGlyph } from "./ExplorerNodeGlyph";
 
 // The Explorer's shell-owned panel (E.3 desktop, E.4 phone; lazy since
 // E2.2): a read-only browser of the session's working tree, built
@@ -300,6 +301,7 @@ export function FilesPanel({
   };
 
   const rootState = store.get("");
+  const rootName = rootNameOf(rootLabel);
 
   return (
     <aside
@@ -327,8 +329,11 @@ export function FilesPanel({
               title={rootLabel}
               aria-expanded={rootOpen}
             >
-              <span className="files-caret">{rootOpen ? "▾" : "▸"}</span>
-              <span className="files-name">{rootNameOf(rootLabel)}</span>
+              <span className="files-caret">
+                <ExplorerChevron open={rootOpen} />
+              </span>
+              <span className="files-name">{rootName}</span>
+              <ExplorerNodeGlyph name={rootName} entryKind="dir" open={rootOpen} />
             </button>
             {/* Desktop closes from the activity-bar toggle; the phone dialog
                 still needs its own close. */}
@@ -458,6 +463,19 @@ export function FilesPanel({
   );
 }
 
+/** Quiet vertical hierarchy guides, like the optional guides in established
+ * IDE project trees. The width keeps the established 12px-per-depth rhythm;
+ * the lazy tree's data and interaction model do not know about them. */
+function ExplorerIndent({ depth }: { depth: number }) {
+  return (
+    <span
+      className="files-indent-guides"
+      style={{ width: `${depth * 12}px` }}
+      aria-hidden="true"
+    />
+  );
+}
+
 // One directory's children, rendered from the store — recursion IS the tree
 // (E2.2): an expanded child dir renders its own DirChildren, which shows a
 // loading row until its fs_dir lands, then its listing. The wire stays
@@ -505,9 +523,13 @@ function DirChildren({
           const isOpen = expanded.has(p);
           return (
             <li key={e.name} role="treeitem" aria-expanded={isOpen}>
-              <button className="files-row files-dir" style={pad} onClick={() => onToggleDir(p)}>
-                <span className="files-caret">{isOpen ? "▾" : "▸"}</span>
+              <button className="files-row files-dir" onClick={() => onToggleDir(p)}>
+                <ExplorerIndent depth={depth} />
+                <span className="files-caret">
+                  <ExplorerChevron open={isOpen} />
+                </span>
                 <span className="files-name">{e.name}</span>
+                <ExplorerNodeGlyph name={e.name} entryKind="dir" open={isOpen} />
               </button>
               {isOpen && (
                 <DirChildren
@@ -529,11 +551,12 @@ function DirChildren({
           <li key={e.name} role="treeitem">
             <button
               className="files-row files-file-row"
-              style={pad}
               onClick={() => onOpenFile(p, e.status)}
             >
+              <ExplorerIndent depth={depth} />
               <span className="files-caret" />
               <span className="files-name">{e.name}</span>
+              <ExplorerNodeGlyph name={e.name} entryKind={e.kind} />
               {e.status && (
                 <span className={`files-status files-status-${e.status}`} title={statusLabel(e.status)}>
                   {e.status}

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -317,9 +317,33 @@ export function FilesPanel({
           over it, so back reveals the tree at its prior scroll (E.4). */}
       <div className="files-main">
         <div className="files-tree">
+          <header className="files-panel-head">
+            <h2 className="files-panel-title">Files</h2>
+            <div className="files-panel-actions">
+              <button
+                className="files-panel-action files-refresh"
+                onClick={refresh}
+                title="Refresh"
+                aria-label="Refresh files"
+              >
+                <ExplorerRefreshIcon />
+              </button>
+              {phone && (
+                <button
+                  className="files-panel-action"
+                  onClick={onClose}
+                  title="Close files"
+                  aria-label="Close files"
+                >
+                  <ExplorerCloseIcon />
+                </button>
+              )}
+            </div>
+          </header>
           {/* The session's checked-out root leads the tree as its top node
-              (VS Code convention) — no path header; the full ~-path lives in
-              the row's tooltip. The panel's actions ride the same row. ARIA:
+              (VS Code convention) — the title bar above is panel chrome, not
+              a duplicate path header; the full ~-path lives in this row's
+              tooltip. ARIA:
               it's a disclosure button OVER the tree widget, not a treeitem
               inside it — role=tree owns only treeitems/groups (axe, C.2). */}
           <div className="files-root">
@@ -332,16 +356,9 @@ export function FilesPanel({
               <span className="files-caret">
                 <ExplorerChevron open={rootOpen} />
               </span>
-              <span className="files-name">{rootName}</span>
               <ExplorerNodeGlyph name={rootName} entryKind="dir" open={rootOpen} />
+              <span className="files-name">{rootName}</span>
             </button>
-            {/* Desktop closes from the activity-bar toggle; the phone dialog
-                still needs its own close. */}
-            {phone && (
-              <button className="files-btn" onClick={onClose} title="Close files" aria-label="Close files">
-                ✕
-              </button>
-            )}
           </div>
           {rootOpen &&
             (rootState?.error && !rootState.entries ? (
@@ -367,17 +384,6 @@ export function FilesPanel({
               <div className="files-empty">…</div>
             ))}
         </div>
-
-        {/* Pinned to the panel's bottom-left corner, floating over the tree;
-            the file-view overlay (z-index above) covers it, same as the tree. */}
-        <button
-          className="files-btn files-refresh"
-          onClick={refresh}
-          title="Refresh"
-          aria-label="Refresh files"
-        >
-          ⟳
-        </button>
 
         {selected && (
           <>
@@ -463,6 +469,23 @@ export function FilesPanel({
   );
 }
 
+function ExplorerRefreshIcon() {
+  return (
+    <svg className="files-action-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="M13.4 7A5.5 5.5 0 1 0 13 10.2" />
+      <path d="M10.1 3.8h3.3V.5" />
+    </svg>
+  );
+}
+
+function ExplorerCloseIcon() {
+  return (
+    <svg className="files-action-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
+      <path d="m4 4 8 8M12 4l-8 8" />
+    </svg>
+  );
+}
+
 /** Quiet vertical hierarchy guides, like the optional guides in established
  * IDE project trees. The width keeps the established 12px-per-depth rhythm;
  * the lazy tree's data and interaction model do not know about them. */
@@ -528,8 +551,8 @@ function DirChildren({
                 <span className="files-caret">
                   <ExplorerChevron open={isOpen} />
                 </span>
-                <span className="files-name">{e.name}</span>
                 <ExplorerNodeGlyph name={e.name} entryKind="dir" open={isOpen} />
+                <span className="files-name">{e.name}</span>
               </button>
               {isOpen && (
                 <DirChildren
@@ -555,8 +578,8 @@ function DirChildren({
             >
               <ExplorerIndent depth={depth} />
               <span className="files-caret" />
-              <span className="files-name">{e.name}</span>
               <ExplorerNodeGlyph name={e.name} entryKind={e.kind} />
+              <span className="files-name">{e.name}</span>
               {e.status && (
                 <span className={`files-status files-status-${e.status}`} title={statusLabel(e.status)}>
                   {e.status}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -127,7 +127,7 @@ body {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 24px; /* same top offset as the tree's root row (.files-root) */
+  padding-top: 20px; /* aligns the toggle with the Explorer title bar */
   border-right: 1px solid var(--border);
 }
 
@@ -165,19 +165,16 @@ body {
 
 .files-panel {
   flex-shrink: 0;
-  /* Give back all but 5px of .main-col's content air: the panel sits
-     near-flush against the activity bar's border line (VS Code-style),
-     while the transcript and prompt box keep the full amount. */
-  margin-left: calc(5px - var(--content-air));
-  /* Fit the widest visible row (indentation included) plus the tree's own
-     right padding — expanding a deep dir widens the panel to match — but
-     never beyond the old fixed width, where names go back to ellipsizing. */
-  width: max-content;
-  max-width: min(340px, 42vw);
-  min-width: 190px;
+  /* Cancel the transcript's air completely: rail + Explorer are one stable
+     workbench unit, while the transcript and prompt retain their gutter. */
+  margin-left: calc(-1 * var(--content-air));
+  /* A professional project tree does not resize as folders are expanded.
+     Keep a useful, responsive dock width and ellipsize exceptional names. */
+  width: clamp(244px, 20vw, 292px);
+  max-width: 42vw;
   display: flex;
   flex-direction: column;
-  background: var(--bg-inset);
+  background: var(--bg);
   border-right: 1px solid var(--border);
   box-shadow: inset -1px 0 0 var(--border-ghost);
   overflow: hidden;
@@ -191,16 +188,81 @@ body {
   }
 }
 
-/* The tree's root row — the session's checked-out directory. Sticky, so the
-   root (and the panel's actions riding it) survive a deep scroll. */
-.files-root {
+/* A proper tool-window header separates the Explorer itself from the checked-
+   out workspace root. It echoes the pin dock's compact uppercase title and
+   moves refresh out of the tree's bottom corner into predictable chrome. */
+.files-panel-head {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 3;
+  height: 56px;
+  display: flex;
+  align-items: flex-end;
+  gap: 8px;
+  padding: 16px 8px 8px 12px;
+  background: var(--bg);
+  border-bottom: 1px solid var(--border);
+}
+
+.files-panel-title {
+  margin: 0;
+  min-width: 0;
+  padding-bottom: 5px;
+  color: var(--fg-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.72em;
+  font-weight: 650;
+  letter-spacing: 0.11em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.files-panel-actions {
+  margin-left: auto;
   display: flex;
   align-items: center;
-  gap: 3px;
-  padding: 24px 6px 6px 0;
+  gap: 2px;
+}
+
+.files-panel-action {
+  width: 28px;
+  height: 28px;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  color: var(--fg-dim);
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: color 0.12s ease, background-color 0.12s ease, border-color 0.12s ease;
+}
+
+.files-panel-action:hover {
+  color: var(--fg-body);
+  background: var(--surface-hover);
+  border-color: var(--border-2);
+}
+
+.files-action-icon {
+  width: 15px;
+  height: 15px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+/* The tree's root row — the session's checked-out directory. Sticky, so the
+   workspace identity survives a deep scroll beneath the title bar. */
+.files-root {
+  position: sticky;
+  top: 56px;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  padding: 5px 6px;
   background: var(--bg-inset);
   border-bottom: 1px solid var(--border-faint);
 }
@@ -214,22 +276,6 @@ body {
   font-weight: 600;
   color: var(--fg-strong);
   letter-spacing: 0.01em;
-}
-
-.files-root .files-btn {
-  flex-shrink: 0;
-  border: none;
-}
-
-/* Refresh floats in the panel's bottom-left corner; the surface background
-   keeps it legible over rows scrolling beneath it. */
-.files-refresh {
-  position: absolute;
-  left: 4px;
-  bottom: 10px;
-  z-index: 1;
-  padding: 4px 9px;
-  background: var(--surface);
 }
 
 .files-back,
@@ -262,10 +308,10 @@ body {
   flex: 1;
   min-height: 0;
   overflow: auto;
-  /* The right padding is the "little bit more" the fit-content panel adds
-     past its longest name; the left stays tight to the panel edge. */
-  padding: 0 10px 48px 0;
+  padding: 0 0 16px;
+  background: var(--bg-inset);
   scrollbar-width: thin;
+  scrollbar-color: var(--border-hover) transparent;
 }
 
 .files-ul {
@@ -278,20 +324,25 @@ body {
   position: relative;
   display: flex;
   align-items: center;
-  gap: 5px;
+  gap: 6px;
   width: 100%;
-  min-height: 27px;
-  padding: 4px 7px 4px 6px;
+  min-height: 29px;
+  padding: 5px 7px 5px 6px;
   background: transparent;
   border: none;
   color: var(--fg-body);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.85em;
+  font-size: 0.82em;
   line-height: 1.2;
   text-align: left;
   cursor: pointer;
-  border-radius: 6px;
+  border-radius: 5px;
   transition: background-color 0.12s ease, color 0.12s ease;
+}
+
+.files-ul .files-row {
+  width: calc(100% - 12px);
+  margin: 1px 6px;
 }
 
 .files-row:hover {
@@ -349,11 +400,16 @@ body {
 
 .files-dir .files-name {
   color: var(--fg-body);
+  font-weight: 550;
+}
+
+.files-file-row .files-name {
+  color: var(--fg-mid);
 }
 
 .files-node-icon {
-  width: 13px;
-  height: 13px;
+  width: 14px;
+  height: 14px;
   flex-shrink: 0;
   opacity: 0.82;
   transition: opacity 0.12s ease, color 0.12s ease;
@@ -398,12 +454,10 @@ body {
 .files-status {
   margin-left: auto;
   flex-shrink: 0;
-  min-width: 17px;
-  padding: 2px 4px;
-  background: var(--surface);
-  border-radius: 4px;
-  font-size: 0.76em;
-  font-weight: 600;
+  min-width: 16px;
+  padding: 0 2px;
+  font-size: 0.78em;
+  font-weight: 650;
   line-height: 1;
   text-align: center;
 }
@@ -450,7 +504,9 @@ body {
 .files-file {
   position: absolute;
   inset: 0;
-  z-index: 2; /* above the sticky root row, or it steals the back button's clicks */
+  /* Above both sticky tree strips (workspace z2, title bar z3), or their
+     chrome covers the file path and steals the back button's clicks. */
+  z-index: 4;
   background: var(--bg);
   display: flex;
   flex-direction: column;
@@ -4596,6 +4652,7 @@ html {
     inset: 0;
     width: 100%;
     max-width: none;
+    margin-left: 0;
     z-index: 55; /* above the transcript + status bar, below the 60 modals */
     border-right: none;
     background: var(--bg-inset);
@@ -4607,25 +4664,20 @@ html {
      pass) without disturbing the desktop density. */
   .files-row {
     padding: 9px 8px;
+    min-height: 42px;
+  }
+
+  .files-panel-head {
+    padding: 8px 8px 7px 14px;
+  }
+
+  .files-panel-action {
+    width: 40px;
+    height: 40px;
   }
 
   .files-root {
-    padding: 8px 6px 5px 2px;
-  }
-
-  /* Refresh moves under the thumb on the full-screen layer — bottom RIGHT
-     here, where the desktop panel keeps it bottom-left (2026-07-25, Kyle). */
-  .files-refresh {
-    left: auto;
-    right: 4px;
-  }
-
-  /* The phone-only close ✕ at twice its size: it's the one way out of a
-     full-screen layer, so it earns a real tap target. */
-  .files-root .files-btn {
-    padding: 4px 10px;
-    font-size: 1.64em;
-    line-height: 1;
+    padding: 4px 6px 5px;
   }
 
   /* The rail is a desktop affordance — a permanent 46px strip is too much

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -174,10 +174,12 @@ body {
      never beyond the old fixed width, where names go back to ellipsizing. */
   width: max-content;
   max-width: min(340px, 42vw);
-  min-width: 140px;
+  min-width: 190px;
   display: flex;
   flex-direction: column;
+  background: var(--bg-inset);
   border-right: 1px solid var(--border);
+  box-shadow: inset -1px 0 0 var(--border-ghost);
   overflow: hidden;
   animation: files-in 0.18s ease-out;
 }
@@ -197,9 +199,10 @@ body {
   z-index: 1;
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 24px 0 4px;
-  background: var(--bg);
+  gap: 3px;
+  padding: 24px 6px 6px 0;
+  background: var(--bg-inset);
+  border-bottom: 1px solid var(--border-faint);
 }
 
 .files-root-row {
@@ -209,6 +212,8 @@ body {
 
 .files-root-row .files-name {
   font-weight: 600;
+  color: var(--fg-strong);
+  letter-spacing: 0.01em;
 }
 
 .files-root .files-btn {
@@ -259,7 +264,8 @@ body {
   overflow: auto;
   /* The right padding is the "little bit more" the fit-content panel adds
      past its longest name; the left stays tight to the panel edge. */
-  padding: 0 14px 12px 0;
+  padding: 0 10px 48px 0;
+  scrollbar-width: thin;
 }
 
 .files-ul {
@@ -269,32 +275,73 @@ body {
 }
 
 .files-row {
+  position: relative;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 5px;
   width: 100%;
-  padding: 3px 6px;
+  min-height: 27px;
+  padding: 4px 7px 4px 6px;
   background: transparent;
   border: none;
   color: var(--fg-body);
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.86em;
+  font-size: 0.85em;
+  line-height: 1.2;
   text-align: left;
   cursor: pointer;
-  border-radius: 5px;
+  border-radius: 6px;
+  transition: background-color 0.12s ease, color 0.12s ease;
 }
 
 .files-row:hover {
-  background: var(--surface);
+  background: var(--surface-hover);
+}
+
+.files-row:active {
+  background: var(--surface-2);
 }
 
 .files-caret {
   flex-shrink: 0;
-  width: 1em;
+  display: grid;
+  place-items: center;
+  width: 12px;
+  height: 14px;
   color: var(--fg-dim);
 }
 
+.files-chevron {
+  display: block;
+  width: 12px;
+  height: 12px;
+  fill: none;
+  stroke: currentColor;
+  stroke-width: 1.35;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  transform-origin: center;
+  transition: transform 0.12s ease;
+}
+
+.files-chevron.is-open {
+  transform: rotate(90deg);
+}
+
+.files-indent-guides {
+  align-self: stretch;
+  flex-shrink: 0;
+  background: repeating-linear-gradient(
+    to right,
+    transparent 0,
+    transparent 11px,
+    var(--border-ghost) 11px,
+    var(--border-ghost) 12px
+  );
+}
+
 .files-name {
+  min-width: 0;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -304,12 +351,61 @@ body {
   color: var(--fg-body);
 }
 
+.files-node-icon {
+  width: 13px;
+  height: 13px;
+  flex-shrink: 0;
+  opacity: 0.82;
+  transition: opacity 0.12s ease, color 0.12s ease;
+}
+
+.files-root-row .files-node-icon {
+  width: 14px;
+  height: 14px;
+}
+
+.files-row:hover .files-node-icon {
+  opacity: 1;
+}
+
+.files-node-icon-folder,
+.files-node-icon-folder-open {
+  color: var(--info);
+}
+
+.files-node-icon-code,
+.files-node-icon-image {
+  color: var(--accent);
+}
+
+.files-node-icon-config {
+  color: var(--warn-fg);
+}
+
+.files-node-icon-style {
+  color: var(--info);
+}
+
+.files-node-icon-document {
+  color: var(--fg-mid);
+}
+
+.files-node-icon-file,
+.files-node-icon-symlink {
+  color: var(--fg-dimmer);
+}
+
 .files-status {
   margin-left: auto;
   flex-shrink: 0;
-  font-size: 0.9em;
+  min-width: 17px;
+  padding: 2px 4px;
+  background: var(--surface);
+  border-radius: 4px;
+  font-size: 0.76em;
   font-weight: 600;
-  padding-left: 6px;
+  line-height: 1;
+  text-align: center;
 }
 
 .files-status-M {
@@ -4502,7 +4598,7 @@ html {
     max-width: none;
     z-index: 55; /* above the transcript + status bar, below the 60 modals */
     border-right: none;
-    background: var(--bg);
+    background: var(--bg-inset);
     padding-top: env(safe-area-inset-top);
     padding-bottom: env(safe-area-inset-bottom);
   }
@@ -4514,7 +4610,7 @@ html {
   }
 
   .files-root {
-    padding: 8px 4px 4px;
+    padding: 8px 6px 5px 2px;
   }
 
   /* Refresh moves under the thumb on the full-screen layer — bottom RIGHT


### PR DESCRIPTION
## Summary
- integrate the Explorer with Mirafold surfaces through an inset panel, stronger sticky root strip, compact rows, hierarchy guides, and matching SVG chevrons
- place small decorative open/closed-folder, symlink, and broad file-family glyphs immediately after node names
- keep the glyph set dependency-free and theme-token driven; server, wire, lazy fetching, sorting, Git status semantics, drill-in, refresh, and phone navigation stay unchanged

## Design references
- VS Code official file icon themes: https://code.visualstudio.com/docs/configure/themes
- JetBrains official Project tool window tree guidance: https://www.jetbrains.com/help/idea/project-tool-window.html

## Verification
- 162/162 front-end unit tests passed
- TypeScript checking passed
- client and server production build passed
- controlled desktop and phone rendered-contract checks passed
- 390px phone frame has no side-scroll
- desktop and phone axe serious/critical sweeps passed
- dark and light theme-token rendering verified
- diff whitespace check passed