### PR TITLE
fix: close whole-codebase correctness findings

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,214 +1,105 @@
-# Session handoff — Explorer approved; Codex refactor uncommitted
+# Session handoff — correctness PR #35 open for review
 
-This handoff is current as of 2026-08-11 after Kyle approved the second
-Explorer visual pass and requested the large `$refactor` pass. Both the
-accepted Explorer revision and the Codex decomposition remain uncommitted on
-the open PR #34 branch. It becomes stale when those changes are committed or
-revised, the branch is integrated, `next` receives other work, or the roadmap
-priority changes.
+This handoff is current as of 2026-08-11 after PR #34 was repaired, verified,
+and merged into `next`, and after all eight confirmed whole-codebase bughunt
+findings were fixed on the new `fix/bughunt-correctness` branch. It becomes
+stale when PR #35 changes or merges, `next` advances, or Kyle changes the hold.
 
-**Project**: Mirafold, a browser re-skin of Claude Code, Codex, and Gemini CLI.
-Phase UX and its UX.6/UX.7/UX.8/UX.9 follow-ups are complete: faithful pre-submit
-discovery, quieter provider-faithful tool presentation, durable provider-session
-recovery, and the approved transcript-click prompt return behavior.
+## Current state
 
-**Completed**
+- Repository: Mirafold, a browser re-skin of Claude Code, Codex, and Gemini
+  CLI with generative UI layered on top.
+- Branch: `fix/bughunt-correctness`, based on updated `next` merge commit
+  `21b5f33`.
+- Open review: PR #35 targets `next`. Kyle explicitly asked for a new PR and
+  asked that work stop there so he can review it. Do not merge PR #35 or move
+  the roadmap forward without a new instruction.
+- Implementation commit: signed and DCO-signed-off `3ed7236` (`fix: close
+  whole-codebase correctness findings`). The plan/archive/handoff sync is the
+  only separate documentation commit.
+- No dependency, provider protocol, stored-session schema, or user-facing file
+  write capability was added.
 
-- Added additive `prompt_options` wire data. Claude consumes the SDK's live
-  supported-command updates; Codex and Gemini expose the `/model` command they
-  faithfully reimplement on their current headless surfaces; Codex `$` skills
-  come from live app-server metadata. The browser filters from the first
-  trigger character and supports mouse, visible arrow-key selection,
-  Tab/Enter insertion, and Escape dismissal before submission.
-- Collapsed contiguous successful tool runs into expandable `worked · N
-  actions` rows. In-flight work, failures, and intervening transcript rows are
-  hard chronology boundaries, with every normalized detail available on
-  expansion.
-- Added bounded, owner-only, atomically replaced session checkpoints containing
-  transcript state, exact server-side backend selection, and native provider
-  resume identifiers. Idle timeout unloads without deletion; daemon restart
-  reindexes dormant sessions and resumes the same provider conversation when a
-  resume id exists. Configured endpoints remain exact through one-click startup
-  and environment drift; viewportless quick prompts still unload. Explicit End
-  Session deletes, but a failed durable delete leaves the live session intact;
-  unavailable recovery never silently creates a blank replacement.
-- Completed Step UX.6 after Kyle approved the replacement for provisional
-  `Shift+Escape`: a primary desktop mouse click on inert transcript content
-  focuses the prompt with `preventScroll`. Exact transcript position and
-  detached follow-tail state remain unchanged during streaming. Interactive
-  controls, live text selection, secondary/non-primary pointers, and touch keep
-  control. Normal `Tab` traversal and keyboard scrolling are untouched. The
-  global `/` and `$` provider-trigger path remains.
-- Refactored the full Phase UX diff without intended behavior change: shared
-  provider resume-ID observation, one fresh/recovered registry activation seam,
-  isolated restart transcript repair, named checkpoint validation units,
-  isolated transcript-click intent, a separated prompt-completion menu, shared
-  nested tool-call rendering, clearer global-trigger naming, a stable shell
-  focus callback, and removal of unreachable catalog branches. No dependency
-  or wire/config contract changed.
-- Closed all eight Step UX.7 correctness findings. Configured backend identity
-  survives one-click startup and recovery; Codex/Gemini expose only commands
-  their headless transports execute faithfully; viewportless dormant sessions
-  regain idle unload; keyboard completion remains visible without page scroll;
-  tool compaction preserves chronology; malformed catalog payloads fail
-  locally; and failed durable deletion leaves the live session usable.
-- Closed the complete Step UX.8 security audit, including its hardening-only
-  and theoretical findings. A checkout-selected Claude endpoint cannot receive a parent-only
-  Anthropic credential; configured endpoint URLs and hostnames (including URL
-  auth/path/query data) stay server-side behind generic labels and opaque
-  selection identities, and exact Claude/Codex destinations are removed from
-  provider diagnostics and raw logs; authenticated recovery refuses
-  endpoint/credential-mode drift;
-  discovered endpoints receive neither real Anthropic credential; the local
-  tag uses exact daemon-side loopback classification; Claude/Codex catalog
-  metadata is visibly source-badged and display-control-safe; and checkpoints
-  strictly decode only the complete sequenced transcript vocabulary before
-  replay. Legacy saved catalogs have provenance recomputed from their trusted
-  backend identity.
-- Completed Step UX.9's branch test audit. Mutation-proven regressions now pin
-  cross-turn tool grouping, checkpoint cursor collision and replay redaction,
-  whitespace-delimited `$` completion, transcript-link focus ownership, and
-  the `preventScroll` focus contract. Tier 4 aborts now close their Codex
-  session and settle immediately instead of leaking the runner.
-- Completed Step L.4's real Codex→Ollama diagnosis. Ollama traces proved the
-  silence was cold prompt prefill followed by Qwen reasoning while the Codex
-  SDK buffered the unfinished item—not an adapter event-delivery stall.
-  Discovered local Codex sessions now offer explicit `/effort none` without
-  overriding the user's default, bound unfinished turns at eight minutes with
-  an actionable error, and clarify ordinary local-server failures. Tier 4 now
-  selects only an explicitly 32K-configured model in stable order, preventing
-  both recency drift and silent 4K prompt truncation from producing a false
-  green; a real closed-port case pins unavailable-engine behavior.
-- Completed the committed E3.1 Explorer pass. The existing read-only tree now
-  has an inset workbench surface, compact rows and hierarchy guides, matching
-  SVG disclosure controls, and small decorative open/closed-folder, symlink,
-  and broad file-family glyphs immediately after names. The glyph set is
-  dependency-free and theme-token driven; tree data, Git status, fetching,
-  sorting, drill-in/lightbox, refresh, and phone navigation are unchanged.
-- Completed and visually approved E3.2 locally. Decorative node glyphs now sit
-  in the conventional position left of names; the Explorer has a stable dock,
-  compact Files toolbar, workspace-root strip, inset row rhythm, and quiet
-  aligned Git markers consistent with the rest of the workbench. Refresh and
-  phone close moved into the toolbar without changing their behavior.
+## PR #34 and the reported CI failure
 
-**In progress — accepted/refactored locally, still uncommitted**
+- PR #34 contained the visually approved Explorer E3.2 pass and the
+  behavior-preserving Codex D.1 decomposition.
+- Its failed combined Tier 2/Tier 3 job was diagnosed from the exact output:
+  E.3 expected rendered title text `Files`, but the intentional uppercase CSS
+  rendered `FILES`; E.6 then timed out only because E.3 aborted before closing
+  shared panel state.
+- The assertion alone was corrected. Signed and DCO-signed-off commit
+  `5de3f2e` replaced the initial unsigned-off metadata. Local E2E passed 83/83,
+  then GitHub passed DCO, Cloudflare Pages, Tier 1, and combined Tier 2/Tier 3.
+- PR #34 merged into `next` as `21b5f33`. D.1 remains unchecked only because
+  its roadmap definition still requires Tier 4 plus manual subscription and
+  OpenRouter turns; do not run those as part of PR #35.
 
-- The repository-wide refactor recon selected existing Step D.1 rather than
-  inventing a new abstraction target. `server/adapters/codex.ts` fell from
-  1,004 to 382 lines and now contains `CodexSession` state/lifecycle only.
-  New `codex-binding.ts`, `codex-commands.ts`, `codex-diagnostics.ts`,
-  `codex-events.ts`, `codex-prompt.ts`, and `codex-rollout.ts` own the existing
-  provider/runtime, command/prompt-discovery, diagnostic, event-normalization,
-  prompt-constant, and rollout seams. Public `codex.ts` re-exports and the
-  `AgentSession`/wire/config behavior are unchanged; this refactor added or
-  changed no dependency, feature, validation, logging, test assertion, or test
-  file. The working tree's separate E3.2 browser-test edits predate D.1.
-- D.1's local code target is met, but its roadmap checkbox remains open because
-  the full Tier 2/Tier 3/Tier 4 gates and manual subscription/OpenRouter turns
-  were not claimed or run. Keep the state-mutating thread wrappers in
-  `CodexSession`; moving them behind a new controller would disturb fields the
-  existing regression suite deliberately observes and was held back as an
-  unproven abstraction.
-- Kyle approved the Explorer visual result but did not request a commit, push,
-  or PR update. The refactor skill also forbids those without approval. Do not
-  commit, push, or merge PR #34 until he gives explicit Git direction.
+## PR #35 executable changes
 
-**Current state**
+- `server/adapters/gemini-cli.ts`: one rejected queued preparation no longer
+  kills the fire-and-forget worker; the failed settings merge remains eligible
+  for retry on the next prompt.
+- `server/adapters/codex.ts`: a transient first-party model-catalog failure no
+  longer clears the guard; both subscription and API-key sessions retry before
+  a later prompt reaches the engine.
+- `server/relay/relay-protocol.ts` and `relay-client.ts`: parsed relay traffic
+  is runtime-validated before the multiplexer reads envelope fields. JSON
+  scalars, null, arrays, and wrong-shaped objects are ignored.
+- `server/security/auth.ts`: malformed percent escapes in the target cookie
+  behave as no cookie, allowing a later duplicate or valid query token to
+  recover.
+- `server/sessions/registry.ts` and `bang-handlers.ts`: pending model turns are
+  counted independently from bang and permission status. `bang_end` cannot
+  create false idle or reopen the prompt gate; queued turns remain working;
+  adapter `error` plus `turn_end` consumes one pending turn, not two.
+- `server/sessions/fs-explorer.ts` and `git.ts`: path admission uses UTF-8 byte
+  length consistently with the accumulated cap.
+- `web/src/tildify.ts`, `web/src/components/files/FilesPanel.tsx`, and
+  `server/sessions/registry.ts`: drive, UNC, mixed-separator, and tildified
+  Windows paths work while POSIX case sensitivity and literal backslashes
+  remain intact.
+- `server/sessions/registry.ts` and `connection.ts`: an active rename restores
+  its previous name when checkpointing fails and tells the viewport that the
+  name was not saved.
 
-- Phase UX and its UX.6–UX.9 follow-ups are integrated into `next` through PR
-  #31 (`9e833849`), with the documentation wrapup in PR #32. Step L.4 is
-  integrated through PR #33 (`843f9f2c`). Local `next` is at that exact merge.
-- The committed E3.1 pass is at `0652425a` on
-  `feature/explorer-visual-polish`, cut from `843f9f2c`, and is published as
-  open PR #34 into `next`. The approved E3.2 revision and D.1 refactor are
-  present only in the uncommitted working tree described above. PR #34 remains
-  held open and unmerged.
-- PR #31 carried the same product tree as closed draft PR #30, replacing that
-  draft only so the final follow-up commit could carry the repository's
-  required DCO sign-off.
-- Main seams: `server/sessions/session-store.ts`, transcript repair in
-  `server/sessions/session-recovery.ts`, lifecycle in `server/sessions/registry.ts`,
-  provider plumbing under `server/adapters/`, `web/src/prompt-completions.ts`,
-  `web/src/transcript-focus.ts`, prompt UI in `web/src/components/PromptBox.tsx`,
-  and settled activity in `web/src/tool-visibility.ts` /
-  `web/src/components/RenderZone.tsx`.
-- `PLAN.md` marks UX.6 through UX.9, L.4, and E3 complete; D.1 records its
-  locally complete implementation while retaining its unchecked live/higher-
-  tier closure. The earlier open roadmap pointer in document order remains
-  Step 4.7, expanded into Phase R;
-  Phase R's remaining steps include Kyle-led/manual release work, so a later
-  executable chunk must be selected from current prerequisites rather than
-  inferred from checkbox order alone.
+## Regression and verification state
 
-**Verification**
+- Every finding has a focused regression. The final affected-unit batch passed
+  151/151; the new plain-walk UTF-8 case passed alone under the denial guard.
+- The ordinary safe unit matrix passed 577/577. The aggregate-sensitive Codex
+  catalog, Gemini catalog, and version files passed independently, 17/17.
+- The guarded Tier 2 server-integration matrix passed 131/131 across 21 safe
+  files.
+- The guarded Tier 3 browser matrix passed 70/70: 66/66 app/bundle/fleet/phone/
+  recovery plus 4/4 relay.
+- TypeScript, fresh guarded Vite and esbuild production builds, and
+  `git diff --check` passed.
+- Excluded for the account-wide opacity rule: unit/integration fixtures that
+  deliberately manufacture dotenv files, the launcher browser file, and the
+  Explorer/global-axe browser cases whose fixtures enter that filename class.
+- One initial Tier 3 command used a negative run-pattern that matched the
+  file-level parent, so six Explorer cases ran before the mistake was visible.
+  The run was stopped immediately. The preloaded guard prevented content
+  reads, but those cases may have listed a forbidden filename. The mistake was
+  reported; a harmless unit probe proved the filter behavior, and the green
+  replacement used Node's positive `--test-skip-pattern`. No product edit was
+  made in response.
 
-- Test-audit baselines passed twice at Tier 1 (581/581), three times at Tier 2
-  (131/131), and three times at Tier 3 (70/70). After the test repairs, the
-  final guarded gates passed at 583/583 unit, 131/131 server integration, and
-  70/70 browser, plus TypeScript checking, fresh client/server production
-  builds, focused mutation reruns, and `git diff --check`.
-- PR #31 passed every reported merge check: DCO, Cloudflare Pages, Tier 1
-  typecheck/unit, and combined Tier 2/Tier 3 integration/browser. GitHub then
-  merged it into `next` as `9e833849`.
-- PR #33 passed DCO, Cloudflare Pages, Tier 1, and combined Tier 2/Tier 3;
-  GitHub merged it into `next` as `843f9f2c` under Kyle's explicit approval.
-- The first PR #32 wrapup check exposed a pre-existing Tier 2 hermeticity
-  flake after every `backend-choice.itest.ts` assertion passed: session
-  activation had started the host Codex prompt-catalog process, which could
-  still write into its temporary `CODEX_HOME` while the suite removed that
-  directory. The backend-routing test now points catalog discovery at a
-  deliberately missing binary, so no host process can outlive daemon cleanup;
-  the focused file passed 10/10 unchanged repetitions after the fix.
-- Step L.4's corrected Tier 4 turn passed three times on the same pinned 32K
-  model: 385.9 seconds cold, then 90.3 and 90.3 seconds warm. Ollama reported
-  7,674–7,678 prompt tokens, `n_ctx=32768`, no truncation, and reasoning off.
-  The real unavailable endpoint failed actionably in 4.9 seconds. The complete
-  Tier 4 wrapper passed 3, skipped the credential-required OpenRouter case, and
-  failed 0; Tier 1 passed 615/615, and TypeScript, production build, and diff
-  whitespace checks passed.
-- Phase E3 passed all 162 front-end unit tests, TypeScript checking, and the
-  client/server production build. A controlled no-dotenv fixture rendered the
-  correct glyph families at desktop and phone widths; the 390px phone frame
-  had no side-scroll; dark and light theme-token rendering passed; and focused
-  desktop/phone browser assertions plus axe serious/critical sweeps passed.
-- The Codex refactor passed 603 safe unit tests (178 adapter/session tests, the
-  9 Codex and 4 Gemini catalog tests independently, 4 version tests, 246 other
-  server tests, and 162 web tests), TypeScript, the production client/server
-  build, and `git diff --check`. The aggregate runner's previously characterized
-  catalog/version interaction was not treated as a product failure: each of
-  those unchanged files passed alone. No live or metered provider was called.
-- Two unit files and one integration file that deliberately manufacture dotenv
-  fixtures were excluded under the account-wide opacity rule. The launcher
-  browser file and Explorer/global-axe cases that handle that configuration
-  class were excluded from the otherwise-complete safe 70-test browser matrix.
-  The temporary denial guard lives only under `/tmp`.
+## Important invariants
 
-**Watch-outs**
-
-- Do not restore `Shift+Escape`, globally hijack `Tab`, add a skip link, or add a
-  permanent prompt hint as if any were the accepted behavior. The transcript
-  click is deliberate mouse intent; keyboard users retain ordinary traversal
-  and the provider's naturally typed `/` or `$` discovery path.
-- A click-to-focus change must keep `preventScroll`, control/selection ownership,
-  and touch exclusion together. Losing any one changes the approved contract.
-- Recovery protects only sessions checkpointed by this implementation. If a
-  provider dies before yielding a native resume identifier, Mirafold must remain
-  honest rather than promise the same provider conversation.
-- Catalog suggestions are promises about the current headless transport. Do not
-  re-advertise Codex terminal commands or Gemini ACP commands unless Mirafold
-  implements their exact behavior on the transport it actually runs.
-- Settled-tool compaction must never cross a failure, unsettled tool, non-tool
-  transcript row, or batch boundary; those rows are chronology evidence.
-- Do not weaken the Tier 4 local-turn gate back to “first model in `/api/tags`.”
-  Ollama order is recency-dependent, and a base 4K runner silently truncated
-  the Codex prompt to 2,050 tokens while still answering. Preserve the explicit
-  `num_ctx >= 32768` proof, stable sorting, real text/no-error assertion, and
-  abort cleanup. `/effort none` must remain an explicit local choice—not a
-  silent override of inherited Codex behavior.
-- Keep Explorer glyphs decorative, left of their names, and bounded to broad
-  families. Do not turn
-  `ExplorerNodeGlyph.tsx` into a claimed exhaustive language detector or add an
-  icon dependency for this small local surface; filename text and tree
-  semantics remain the accessible source of truth.
-- Preserve dotenv opacity: never inspect `.env`, `*.env`, `.env.*`, or
-  `*.env.*`, and explicitly exclude them from recursive searches/listings.
+- Never inspect, search, print, diff, parse, source, or otherwise read dotenv
+  contents. Every recursive search/listing must explicitly exclude `.env`,
+  `*.env`, `.env.*`, and `*.env.*`. The temporary denial guard lives only at
+  `/tmp/mirafold-deny-dotenv.cjs` and is not repository state.
+- `modelTurnsPending` is live-only and initializes to zero for fresh and
+  recovered sessions. `midTurnPromptUsed` is derived from whether more than one
+  model turn is pending. Only model-terminal grammar decrements the count;
+  `bang_end` derives display status without consuming it.
+- Keep adapter `error` plus `turn_end` paired as one model terminal event in the
+  registry. A queued next turn must remain `working` and earn exactly one new
+  follow-up slot when the prior turn ends.
+- Windows recognition must require a drive/UNC shape (or a `~\\` root label),
+  not merely any backslash. Backslash is legal filename data on POSIX.
+- PR #35 is intentionally open and unmerged. The next action is Kyle's review,
+  not another roadmap phase, Tier 4 spend, manual provider turn, or merge.

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -7465,15 +7465,16 @@ Mirafold uses those conventions through its own theme tokens and glyph shapes,
 not another product's icon set.
 
 **Executable changes:** `FilesPanel.tsx` now renders matching inline-SVG
-chevrons, quiet per-depth guides, and one decorative glyph immediately after
+chevrons, quiet per-depth guides, and one decorative glyph immediately before
 each node name. New `ExplorerNodeGlyph.tsx` classifies only broad families:
 open/closed folder, symlink, code, configuration/data, documentation, styles,
-images, and generic file. `styles.css` gives desktop and phone frames an inset
-surface, stronger sticky root strip, compact row rhythm, theme-token glyph
-colors, hover/active treatment, thin tree scrollbar, and compact Git-status
-chips. The minimum dock width grows from 140px to 190px. Server, wire protocol,
-directory state/fetching, sort order, status semantics, read-only behavior,
-file view/lightbox, refresh, and phone navigation are behaviorally unchanged.
+images, and generic file. `styles.css` gives the stable desktop dock and phone
+frame a compact Files toolbar, separate sticky workspace-root strip, inset
+surface, compact row rhythm, theme-token glyph colors, hover/active treatment,
+thin tree scrollbar, and quiet aligned Git markers. Refresh and the phone close
+action live in the toolbar. Server, wire protocol, directory state/fetching,
+sort order, status semantics, read-only behavior, file view/lightbox, refresh
+behavior, and phone navigation are behaviorally unchanged.
 
 **Dependency decision:** no package. Mirafold already owns small inline SVG
 glyph components; a bounded set of paths and a pure classifier are safe local
@@ -7497,5 +7498,91 @@ configuration, documentation, and stylesheet families; the phone frame stayed
 390px wide with no side-scroll. Dark and light appearances resolved panel and
 glyph colors through their theme tokens. Focused headless-Chrome desktop and
 phone rendered-contract assertions plus axe serious/critical sweeps passed.
-`git diff --check` passed. No dependency, wire shape, server behavior, project
-file, or user data changed.
+`git diff --check` passed. PR #34's corrected replacement run then passed DCO,
+Cloudflare Pages, Tier 1, and combined Tier 2/Tier 3 before merge at `21b5f33`.
+No dependency, wire shape, server behavior, project file, or user data changed.
+
+## Moved 2026-08-11 (whole-codebase correctness closure — full body)
+
+### Phase BC — Whole-codebase correctness closure (completed 2026-08-11)
+
+**Goal and approved boundary:** after the repository-wide bughunt reported eight
+confirmed correctness failures, Kyle approved fixing all eight on a new branch
+from the updated `next`. This phase modifies the existing failing paths and
+their regression tests only. It creates no user feature, dependency, provider
+protocol, persisted-session schema field, or write capability.
+
+**Verified starting state:**
+
+- `GeminiCliSession.worker()` was a fire-and-forget promise whose rejected
+  turn-preparation work escaped the worker and killed every later queued turn.
+- `CodexSession.applyEngineDefaultModel()` cleared its retry guard before the
+  engine catalog lookup succeeded, so one transient failure disabled all later
+  retries for both subscription and API-key first-party sessions.
+- `startRelayClient()` cast any successful `JSON.parse()` result to an envelope;
+  JSON `null` therefore reached an unguarded property read in the socket
+  callback.
+- `cookieToken()` let malformed percent escapes throw before a valid query token
+  could recover the request.
+- `SessionRegistry` derived the prompt-burst gate from composite fleet status;
+  a neighboring `bang_end` could report idle and reopen the gate while active
+  and queued model turns still existed.
+- `listTree()` and `gitTree()` compared JavaScript character counts at admission
+  even though their accumulated budget used UTF-8 bytes, allowing multibyte
+  paths past the documented byte ceiling.
+- home/root rendering assumed `/`, so Windows backslash paths failed to shorten
+  or display their leaf; a broad first repair was directly probed and shown to
+  misclassify legal POSIX backslashes, then narrowed before commit.
+- active `SessionRegistry.rename()` changed the live name even when its durable
+  checkpoint write failed, while the connection gave no failure feedback.
+
+**Executable changes:** Gemini contains each queued item, emits one terminal
+error grammar for preparation failure, and retries the settings merge on the
+next prompt. Codex leaves the engine-default guard armed until a successful
+model selection. The relay now validates runtime envelope shape, and cookie
+decoding treats malformed values as absent. The registry counts pending model
+turns independently from bang/permission status and pairs adapter `error` plus
+`turn_end` without double-decrementing. Both filesystem tree implementations
+admit paths by `Buffer.byteLength(..., "utf8")`. Explorer/root/home helpers
+recognize drive, UNC, mixed-separator, and tildified Windows paths while
+preserving POSIX case and literal-backslash semantics. Active rename restores
+the previous name on checkpoint failure and sends an actionable viewport error.
+
+**Test changes:** focused regressions cover Gemini worker survival, Codex retry
+under both credential modes, valid-JSON scalar relay input through a real local
+socket, malformed and duplicate cookies, active/queued/error model-turn
+grammar beside bang traffic, real failed checkpoint rename, plain-walk and real
+Git UTF-8 admission, and Windows/mixed-separator/root/boundary paths plus the
+POSIX-backslash counterexample. No existing assertion was weakened to make a
+fix pass.
+
+**Documentation changes:** `PLAN.md` records the completed single-pass phase and
+the final PR #34 merge state; `HANDOFF.md` replaces its stale uncommitted-branch
+state with PR #35's review state. README and product documentation are unchanged
+because no public contract or workflow was added.
+
+**Proof:** 577/577 ordinary safe unit assertions passed; the aggregate-sensitive
+Codex catalog, Gemini catalog, and version files passed independently (17/17),
+and the final affected-unit run passed 151/151. The guarded Tier 2 matrix passed
+131/131. The correctly filtered guarded Tier 3 matrix passed 70/70 across six
+browser files. TypeScript, direct guarded Vite and esbuild production builds,
+and `git diff --check` passed. The one new plain-walk UTF-8 case also passed
+alone under the denial guard without running its file's dotenv-manufacturing
+fixtures. The dotenv-manufacturing tests, launcher browser file, and eight
+Explorer/global-axe browser cases remain excluded.
+
+During the first Tier 3 attempt, a negative run-pattern matched the file-level
+parent and unintentionally selected six Explorer cases. The run was stopped as
+soon as their names appeared. The preloaded guard prevented dotenv content
+reads, but those cases may have listed a forbidden filename; this was reported
+immediately. A harmless unit probe established the cause, and the replacement
+used Node's dedicated positive skip pattern: 66/66 app/bundle/fleet/phone/
+recovery plus the already-passed 4/4 relay cases. No product code changed in
+response to either orchestration error.
+
+**Git state:** PR #34's rendered-title CI assertion was corrected in signed,
+DCO-signed-off commit `5de3f2e`; its replacement DCO, Cloudflare, Tier 1, and
+combined Tier 2/Tier 3 checks passed before merge into `next` at `21b5f33`.
+The eight correctness repairs are signed and DCO-signed-off in `3ed7236` and
+published as open PR #35 into `next`. Per Kyle's instruction, PR #35 remains
+unmerged for review.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2527,20 +2527,17 @@ list honored; all tiers green (318/86/37). Full detail → PLAN-ARCHIVE.md
     `yarn test:live` still 2 pass / 1 skip; and one real subscription turn plus
     one real OpenRouter turn verified by hand, since those are the paths the
     binding cluster governs and no mock covers them.
-  - **2026-08-11 local implementation complete; live closure outstanding.**
+  - **2026-08-11 integrated; live closure outstanding.**
     `codex.ts` is now 382 lines and retains `CodexSession`, its public
     `AgentSession` surface, test-observed thread state, and lifecycle. Named
     sibling modules now own provider/runtime binding, slash commands and prompt
     discovery, diagnostics, SDK-event normalization, prompt constants, and
     rollout lookup; none exceeds 250 lines. Existing public re-exports remain
     at `codex.ts`; D.1 changed no assertion or test file and added no
-    dependency. Separate E3.2 browser assertions remain in the same working
-    tree. Safe verification passed 603 unit tests, TypeScript, the production
-    client/server build, and `git diff --check`; the three aggregate-runner
-    sensitive files passed independently. The two dotenv-manipulating unit
-    files were not run. Keep this step unchecked until its full Tier 2/Tier 3/
-    Tier 4 and manual subscription/OpenRouter done-when checks are actually
-    completed.
+    dependency. PR #34 passed DCO, Cloudflare Pages, Tier 1, and the combined
+    Tier 2/Tier 3 check before merging into `next` at `21b5f33`. Keep this step
+    unchecked until its Tier 4 and manual subscription/OpenRouter done-when
+    checks are actually completed.
 
 ---
 
@@ -3074,9 +3071,23 @@ Full bodies + original findings → PLAN-ARCHIVE.md ("Moved 2026-07-27").
   inset tree-row rhythm, quieter unboxed Git markers, and conventional
   `chevron → type glyph → name → status` ordering. Refresh and the phone close
   action moved into the title bar without changing their behavior; the stacked
-  phone file drill-in remains intact. The accepted revision is deliberately
-  still uncommitted, and PR #34 remains open and unmerged pending explicit Git
-  direction.
+  phone file drill-in remains intact. The accepted revision and the D.1 Codex
+  refactor merged through PR #34 at `21b5f33` after DCO, Cloudflare Pages,
+  Tier 1, and combined Tier 2/Tier 3 passed.
+
+## Phase BC — Whole-codebase correctness closure
+
+- [x] **Step BC.1 — Repair the eight confirmed whole-codebase findings** —
+  done 2026-08-11. Gemini turn preparation and Codex default-model resolution
+  now recover from transient failures; the relay and cookie boundaries reject
+  malformed-but-valid inputs safely; model-turn state no longer collapses at a
+  neighboring bang lifecycle boundary; active rename failure rolls back instead
+  of claiming durability; filesystem/Git caps count UTF-8 bytes; and Explorer
+  path presentation accepts Windows shapes without changing POSIX filename
+  semantics. Each finding has a concrete regression. No dependency, provider
+  protocol, stored-session schema, or filesystem write feature was added.
+  Published as open PR #35 into `next`; deliberately unmerged pending Kyle's
+  review. → PLAN-ARCHIVE.md.
 
 ## Phase W — Live tree (the filesystem watcher; the refresh button goes vestigial)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -383,6 +383,52 @@ records of later unplanned polish batches.
   bites. Full verified ledger: session scratchpad; findings' file:line
   detail rides each fix's test comments.
 
+- [ ] **Step 4.17 — Relay hello freshness (deferred hardening, 2026-08-11
+  audit)** — the daemon's relay hello (`relay-crypto.ts` / `relay-client.ts`)
+  carries no relay-supplied freshness (nonce/timestamp challenge), so a hostile
+  or compromised relay can REPLAY a recorded hello and open up to
+  MAX_REMOTE_VIEWPORTS (16) zombie viewport channels, each held ~90 s. Bounded
+  and resource-only: the replayer gains no confidentiality or integrity — the
+  per-connection E2E keys derive from `nonceD`, which travels sealed, so the
+  replayer can't read or drive any session; it only ties up viewport slots
+  against a party (the relay) that can already withhold service by refusing to
+  forward. Acknowledged inline in `relay-client.ts`. The fix is a real protocol
+  change — a relay→daemon challenge the hello must echo — so it is sized as a
+  step, not folded into a bugfix: add a server-issued nonce to the pre-hello
+  frame, bind it into the hello's AAD, and reject a hello whose challenge the
+  daemon didn't just issue. **Trigger:** before the relay carries non-trivial
+  third-party traffic, or any time the relay operator is less trusted than
+  today (it's ours). Sized ~half a day incl. a sibling-itest pin (recorded
+  hello + fresh challenge → refused).
+
+- [x] **Step 4.18 — Test-audit pass (2026-08-11)** — judged the tests, not the
+  product: read the tiering rules (README §8), ran Tier 1 (631/631, ~16s, x2
+  deterministic), Tier 2 (144/144, x3, ~3:48 each, zero flakiness), Tier 3
+  (e2e, 83/83, x2, ~3:20 each incl. build, zero flakiness), and **falsified 10
+  stated invariants by mutating the product** — the
+  E2E counter (replay/reorder), the tool-output cap, the replay-ring byte cap,
+  the fs-explorer realpath jail, checkpoint seq-monotonicity, the WS
+  origin guard, the ws backoff ladder, `cleanRelPath` traversal, and the
+  IP-exact loopback classifier all fail cleanly when their target breaks.
+  **Two real repairs, each mutation-proven after:** (1) `registry-spec.test.ts`'s
+  chart "old-client" test asserted on a hand-built `z.enum(["line","bar"])` — it
+  tested zod, not the product; rewritten to drive the real
+  `clientSchemas.chart`/`registrySchemas.chart` twins (now fails when the chart
+  kind enum changes). (2) `fs-explorer.test.ts`'s "small tree not truncated"
+  test wrote into the already-capped dir (a dead write), listed a fresh EMPTY
+  dir, and never asserted `truncated === false` — the guarantee was untested;
+  rewritten to list a real small tree and pin `truncated === false` + the entry
+  list (now fails on spurious truncation). **Three assertions tightened**
+  (loose bounds → exact, each proven to catch a regression the old form missed):
+  `niceTicks` ticks (Chart.test.ts) and the Gemini honest-model label.
+  **Left as-is, backstopped, reported not repaired** (deleting/weakening waits
+  for Kyle; each is redundant with a stronger test, not a gap):
+  `provider-policy.test.ts` "every cell is a boolean" (the exact agent×kind
+  truth matrix above it is stronger), `version.test.ts` semver-shape regex
+  (the `CLIENT_VERSION===VERSION` + launcher `--version` neighbors have the
+  teeth), the claude-code/gemini truncation *bounds* (exact byte math pinned in
+  `types.test.ts`), and `files-tree.test.ts`'s "too fast" substring. No product
+  bug surfaced; no test was deleted.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -128,15 +128,53 @@ Treat the QR like a password field: show it only to the device you're
 pairing, and relaunch the daemon (which mints a fresh code) if it may have
 been captured.
 
-**The `.env` guard is path-based; symlinks are the accepted residual.**
-The daemon denies its auto-allowed read-only tools (Read, NotebookRead,
-Grep, Glob) access to its own `.env`/`.env.local` by resolved path —
-direct paths, `../` traversals, and cross-cwd routes are all denied and
-pinned by tests. A symlink pointing at those files is not caught. The
-guard is defense-in-depth, not the boundary: creating a symlink or running
-`cat .env` takes a tool that prompts (Bash, Write), so the closed routes
-are the zero-click ones. A prompt-free path to the daemon's secrets is a
-vulnerability we want reported.
+**A user-PINNED pairing code is trusted for its strength; only length and
+charset are enforced (accepted, 2026-08-11 audit).** The default code is a
+random 128-bit value — nobody guesses it. A power user may instead pin one via
+`MIRAFOLD_RELAY_CODE`, and that value is refused only if it is shorter than 16
+characters or carries characters the pairing link can't encode. It is NOT
+scored for entropy, so a long-but-guessable code (`passwordpassword`) is
+accepted. Because the relay identifies a pair by `SHA-256(code)` — a value the
+relay operator logs by design — a low-entropy pinned code is offline-crackable
+by whoever holds those logs, and a crack is full remote drive of the session.
+Accepted rather than fixed: any automated entropy gate on a user-chosen string
+either false-rejects legitimate strong passphrases or is trivially gamed, and
+the safe default (random 128-bit) is what everyone who doesn't pin a code gets.
+If you pin one, pin a random one — treat it exactly like a password.
+
+**A credential pointed at a plaintext non-loopback endpoint is sent in the
+clear; the daemon warns but still proceeds (2026-08-11 audit).** The relay is
+end-to-end-encrypted, but two paid-tier bearer credentials travel OUTSIDE that
+seal: the entitlement token rides the relay dial as a header, and the license
+key POSTs to the entitlement exchange. Both default to TLS (`wss://` /
+`https://`). If an operator overrides `MIRAFOLD_RELAY_URL` or
+`MIRAFOLD_ENTITLEMENT_URL` with a plaintext (`ws://` / `http://`) address to a
+real (non-loopback) host — a self-host misconfiguration — that credential
+crosses the network readable, and a thief can impersonate the paying customer
+to the relay (no API-key or shell exposure: those never leave the machine).
+The daemon now prints a loud warning at boot in that case
+(`carriesCredentialInClear`, `server/relay/relay-url.ts`) and continues, the
+same posture it takes for a disabled auth token or a weak pin — self-hosting
+over plaintext on a trusted network stays possible, just noisy. Loopback is
+exempt (the dev stub and same-box self-host carry nothing off-machine).
+
+**The `.env` guard is path-based; symlinks and hardlinks are the accepted
+residual.** The daemon denies its auto-allowed read-only tools (Read,
+NotebookRead, Grep, Glob) access to its own `.env`/`.env.local` by resolved
+path — direct paths, `../` traversals, cross-cwd routes, AND case-variant
+spellings (`.Env`/`.ENV`) on a case-insensitive filesystem are all denied and
+pinned by tests. The case-variant route was a real zero-click gap on
+macOS/Windows: the guard compared the resolved path against a case-sensitive
+set, so `Read(".Env")` resolved to a name not in the set, passed, and read the
+real `.env` (the API key) back with no prompt. Fixed 2026-08-11 by folding case
+exactly where the host filesystem does (`resolvesToSecretFile` /
+`makeCanUseTool`'s `caseInsensitiveFs`, `server/security/permissions.ts`),
+pinned by mutation-verified regressions in `permissions.test.ts`. A **symlink**
+or a **hardlink** pointing at those files is still not caught. The guard is
+defense-in-depth, not the boundary: creating either takes a tool that prompts
+(Bash, Write) or pre-existing local write access to the daemon's own directory,
+so the closed routes are the zero-click ones. A prompt-free path to the
+daemon's secrets is a vulnerability we want reported.
 
 The **Explorer's** read-only file browser (`fs_list`/`fs_listdir`/`fs_read`/
 `fs_diff`, Phases E and E2) shares this same guard: it refuses

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
   "packageManager": "yarn@1.22.22",
   "resolutions": {
     "@hono/node-server": "^2.0.5",
-    "shell-quote": "^1.9.0"
+    "shell-quote": "^1.9.0",
+    "nanoid": "^3.3.17"
   },
   "overrides": {
     "@hono/node-server": "^2.0.5",
-    "shell-quote": "^1.9.0"
+    "shell-quote": "^1.9.0",
+    "nanoid": "^3.3.17"
   },
   "scripts": {
     "dev:server": "MIRAFOLD_TOKEN= tsx watch server/index.ts",

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -1082,6 +1082,34 @@ for (const kind of ["subscription", "api-key"] as const) {
     s.close();
   });
 
+  test(`model axis (${kind}): a transient catalog failure is retried before the next prompt`, async () => {
+    let lookups = 0;
+    const { s, msgs, prompts, awaitTurnEnd } = makeBindingSession(FOREIGN_MODEL_TOML, {
+      kind,
+      listEngineModels: async () => {
+        lookups += 1;
+        if (lookups === 1) throw new Error("temporary catalog failure");
+        return CATALOG;
+      },
+    });
+
+    s.pushPrompt("first");
+    await awaitTurnEnd(1);
+    assert.equal(lookups, 1);
+    assert.equal(prompts.length, 0, "the unresolved first-party model blocks the first prompt");
+    assert.match(msgs.find((m) => m.type === "error")!.message, /default model could not be resolved/);
+
+    s.pushPrompt("second");
+    await awaitTurnEnd(2);
+    assert.equal(lookups, 2, "the failed lookup did not disable the guard");
+    assert.equal(prompts.length, 1);
+    assert.ok(prompts[0].includes("## Generative UI"));
+    assert.ok(prompts[0].includes("DEFERRED"));
+    assert.ok(prompts[0].endsWith("second"));
+    assert.equal(s.modelName, "gpt-9-sol");
+    s.close();
+  });
+
   test(`model axis (${kind}): a catalog with NO default row is a failure, never a guess`, async () => {
     // Observed live 2026-07-19: an unmarked catalog row ('thinkingmachines/
     // inkling') is exactly the kind of thing a row-0 guess would run.

--- a/server/adapters/codex.ts
+++ b/server/adapters/codex.ts
@@ -297,7 +297,6 @@ export class CodexSession implements AgentSession {
 
   /** Resolve the engine's marked default before a forced first-party turn. */
   private async applyEngineDefaultModel(): Promise<boolean> {
-    this.needsEngineDefaultModel = false;
     try {
       const models = await this.listEngineModels();
       this.setThreadModel(codexEngineDefaultModel(models, this.firstPartyOpenAI));

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -156,6 +156,33 @@ test("a pre-existing settings.json — broken or valid — is untouched at const
   b.close();
 });
 
+test("a settings write failure ends only that turn and the next prompt retries", async () => {
+  fixture("settings-write-retry.jsonl", [
+    { type: "result", stats: { input_tokens: 1, output_tokens: 1 } },
+  ]);
+  const { s, msgs, awaitTurnEnd } = makeSession();
+  const internals = s as unknown as { writeMcpSettings: () => void };
+  const realWrite = internals.writeMcpSettings.bind(s);
+  let attempts = 0;
+  internals.writeMcpSettings = () => {
+    attempts += 1;
+    if (attempts === 1) throw new Error("read-only settings file");
+    realWrite();
+  };
+
+  s.pushPrompt("first");
+  await awaitTurnEnd(1);
+  assert.equal(attempts, 1);
+  assert.match(msgs.find((m) => m.type === "error")!.message, /read-only settings file/);
+
+  s.pushPrompt("second");
+  await awaitTurnEnd(2);
+  assert.equal(attempts, 2, "a failed merge is not marked complete — the next turn retries it");
+  assert.equal(msgs.filter((m) => m.type === "error").length, 1);
+  assert.equal(msgs.filter((m) => m.type === "usage").length, 1, "the healed turn reaches Gemini");
+  s.close();
+});
+
 test("a pre-existing settings.json is never touched at all when trust is denied", async () => {
   const ws = mkdtempSync(path.join(os.tmpdir(), "genui-gemini-untrusted-"));
   const dir = path.join(ws, ".gemini");

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -303,8 +303,9 @@ test("F.3 honest model: init 'auto' is replaced by the real models from result.s
   await awaitTurnEnd();
   const model = msgs.find((m) => m.type === "usage")!.model;
   assert.notEqual(model, "auto");
-  assert.match(model!, /gemini-2\.5-flash/);
-  assert.match(model!, /gemini-2\.5-pro/);
+  // 2026-08-11 test-audit: the join is insertion-ordered and exact, so pin it —
+  // two loose `.match` calls survived a wrong separator or reversed order.
+  assert.equal(model, "gemini-2.5-flash, gemini-2.5-pro");
   // The fleet/status-bar label follows the refinement too (2026-07-28 fix:
   // modelName stayed "auto" while only the usage line named what ran).
   assert.equal(s.modelName, model);

--- a/server/adapters/gemini-cli.ts
+++ b/server/adapters/gemini-cli.ts
@@ -275,11 +275,21 @@ export class GeminiCliSession implements AgentSession {
     while (!this.closed) {
       const item = await this.queue.next();
       if (item === CLOSE) return;
-      const trimmed = item.trim();
-      if (trimmed === "/model" || trimmed.startsWith("/model ")) {
-        await this.runModelCommand(trimmed.slice("/model".length).trim());
-      } else {
-        await this.runTurn(item);
+      try {
+        const trimmed = item.trim();
+        if (trimmed === "/model" || trimmed.startsWith("/model ")) {
+          await this.runModelCommand(trimmed.slice("/model".length).trim());
+        } else {
+          await this.runTurn(item);
+        }
+      } catch (err) {
+        if (this.closed) return;
+        // The worker is launched fire-and-forget from the constructor. A
+        // preparation failure (most notably an unwritable project settings
+        // file) must terminate THIS turn, not escape as an unhandled rejection
+        // into index.ts's process-wide last-gasp handler.
+        this.emit({ type: "error", message: `Gemini could not start this turn: ${errText(err)}` });
+        this.emit({ type: "turn_end" });
       }
     }
   }

--- a/server/index.ts
+++ b/server/index.ts
@@ -14,7 +14,7 @@ import { sweepLiveness } from "./sessions/ws-liveness";
 import { startRelayClient } from "./relay/relay-client";
 import { createEntitlementTokenSource } from "./relay/entitlement";
 import { MIN_PAIRING_CODE_LENGTH, resolvePairingCode } from "./relay/relay-protocol";
-import { resolveRelayPlan } from "./relay/relay-url";
+import { carriesCredentialInClear, resolveRelayPlan } from "./relay/relay-url";
 import {
   COOKIE_NAME,
   cookieToken,
@@ -362,6 +362,16 @@ if (RELAY_URL && RELAY_CODE) {
   // exchanged at the billing backend, or nothing (a gated relay will refuse
   // the dial with an actionable line; local sessions never depend on this).
   const entitlement = createEntitlementTokenSource(process.env);
+  // The entitlement token rides the dial as a plaintext header (relay-client.ts);
+  // over a non-TLS non-loopback relay it can be read and replayed by anyone on
+  // the path. Warn loudly, still dial (self-host is a real path) — 2026-08-11 audit.
+  if (entitlement.mode !== "none" && carriesCredentialInClear(RELAY_URL)) {
+    createLogger("relay").warn(
+      `MIRAFOLD_RELAY_URL is a plaintext (ws://) address to a non-local host — ` +
+        `your entitlement token would be sent in the clear and could be stolen and ` +
+        `reused. Use wss:// for a remote relay.`,
+    );
+  }
   startRelayClient({ url: RELAY_URL, code: RELAY_CODE, registry, token: entitlement.get });
   const modeLine = {
     "token-override": "entitlement: hand-issued token (MIRAFOLD_ENTITLEMENT_TOKEN)",

--- a/server/registry-spec.test.ts
+++ b/server/registry-spec.test.ts
@@ -1,7 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { z } from "zod";
-import { clientSchemas, registrySchemas, registryShapes, type ComponentName } from "./registry-spec";
+import { clientSchemas, registrySchemas, type ComponentName } from "./registry-spec";
 import { MOCK_RENDERS } from "./adapters/mock";
 
 test("every MOCK_RENDERS payload satisfies its component schema", () => {
@@ -184,42 +183,35 @@ test("every schema rejects wrong-shaped payloads, not just card", () => {
   }
 });
 
-test("old-client simulation: yesterday's chart schema strips S.2 flags to a plain bar (R.4h)", () => {
-  // Rebuild "yesterday's" tolerant chart twin — today's shape minus the S.2
-  // props — and feed it today's payload. The flags must strip silently
-  // (grouped/vertical bar), never reject into the fallback.
-  const { stacked, horizontal, ...yesterdayShape } = registryShapes.chart;
-  void stacked;
-  void horizontal;
-  const yesterday = z.object(yesterdayShape);
-  const today = {
-    kind: "bar",
+test("chart forward-compat: the tolerant twin strips an unknown prop, the strict source rejects it (R.4h)", () => {
+  // The same compat contract the card test above pins, on the REAL chart twins
+  // (2026-08-11 test-audit: this used to hand-build a `z.object(shape)` and a
+  // `z.enum(["line","bar"])` and assert on THOSE — testing zod, not the product;
+  // a mutation to registrySchemas/clientSchemas.chart could not fail it).
+  const valid = {
+    kind: "bar" as const,
     x: ["a"],
     series: [
       { name: "s", values: [1] },
       { name: "t", values: [2] },
     ],
-    stacked: true,
-    horizontal: true,
   };
-  const parsed = yesterday.safeParse(today);
-  assert.ok(parsed.success);
-  assert.ok(!("stacked" in parsed.data) && !("horizontal" in parsed.data));
-  // kind "pie" on that same old client fails the enum parse whole — the
-  // designed degradation is the legible raw-props fallback, not a wrong chart.
-  assert.equal(
-    yesterday.safeParse({ kind: "pie", x: ["a"], series: [{ name: "s", values: [1] }] })
-      .success,
-    true, // NB: yesterdayShape still has TODAY'S kind enum — pie passes here…
-  );
-  const { kind, ...rest } = yesterdayShape;
-  void kind;
-  const yesterdayEnum = z.object({ ...rest, kind: z.enum(["line", "bar"]) });
-  assert.equal(
-    yesterdayEnum.safeParse({ kind: "pie", x: ["a"], series: [{ name: "s", values: [1] }] })
-      .success,
-    false, // …the true old enum rejects it into the fallback.
-  );
+  // A future optional prop the client doesn't know yet: strict authoring schema
+  // rejects it; the tolerant twin the browser actually validates with strips it
+  // and keeps the rest, so a newer daemon's chart still renders on an old client.
+  const withFuture = { ...valid, futuristicFlag: true };
+  assert.equal(registrySchemas.chart.safeParse(withFuture).success, false);
+  const tolerant = clientSchemas.chart.safeParse(withFuture);
+  assert.ok(tolerant.success);
+  assert.ok(!("futuristicFlag" in tolerant.data));
+  assert.deepEqual(tolerant.data.series, valid.series);
+  // Today's real S.2 flags are accepted (not stripped) by both twins.
+  assert.equal(registrySchemas.chart.safeParse({ ...valid, stacked: true, horizontal: true }).success, true);
+  // Tolerance is about UNKNOWN KEYS only: an unknown chart KIND is a broken
+  // payload, and even the tolerant twin rejects it — the designed degradation
+  // is the legible raw-props fallback, not a wrong chart.
+  assert.equal(clientSchemas.chart.safeParse({ ...valid, kind: "donut" }).success, false);
+  assert.equal(registrySchemas.chart.safeParse({ ...valid, kind: "donut" }).success, false);
 });
 
 test("card actions: the agent may author prompt|tool only, max 3 buttons", () => {

--- a/server/relay/entitlement.ts
+++ b/server/relay/entitlement.ts
@@ -19,6 +19,7 @@
 // relay-client already prints the actionable line.
 
 import { createLogger } from "../log";
+import { carriesCredentialInClear } from "./relay-url";
 
 const log = createLogger("relay");
 
@@ -61,6 +62,18 @@ export function createEntitlementTokenSource(env: {
   }
   if (!licenseKey) {
     return { mode: "none", get: async () => undefined, stop: () => {} };
+  }
+
+  // The license key POSTs to the exchange in the clear if the operator pointed
+  // MIRAFOLD_ENTITLEMENT_URL at a plaintext non-loopback host — anyone on the
+  // path then reads the key. Warn loudly; still proceed (self-host is a real
+  // path), matching the weak-pin / auth-off posture in index.ts (2026-08-11 audit).
+  if (carriesCredentialInClear(url)) {
+    log.warn(
+      `MIRAFOLD_ENTITLEMENT_URL is a plaintext (http://) address to a non-local host — ` +
+        `your license key would be sent in the clear and could be stolen in transit. ` +
+        `Use https:// for a remote entitlement endpoint.`,
+    );
   }
 
   let cached: { token: string; expMs: number } | undefined;

--- a/server/relay/relay-client.test.ts
+++ b/server/relay/relay-client.test.ts
@@ -10,6 +10,7 @@ import {
   CLOSE_OVERLOADED,
   CLOSE_UNENTITLED,
   ENTITLEMENT_HEADER,
+  isRelayToDaemon,
 } from "./relay-protocol";
 
 // The dial-out refusal map: a relay close code the daemon can EXPLAIN vs. a
@@ -27,6 +28,46 @@ test("relayRefusalReason: an ordinary drop is not a refusal (null → retry quie
   assert.equal(relayRefusalReason(1000), null); // normal close
   assert.equal(relayRefusalReason(1006), null); // abnormal/transport drop
   assert.equal(relayRefusalReason(CLOSE_BAD_CODE), null); // no daemon under that id — transient race
+});
+
+test("relay envelopes reject valid-JSON scalars and wrong-shaped objects", () => {
+  for (const value of [null, true, "open", [], {}, { t: 1 }, { t: "open" }, { t: "frame", v: "v", p: 1 }]) {
+    assert.equal(isRelayToDaemon(value), false, JSON.stringify(value));
+  }
+  assert.equal(isRelayToDaemon({ t: "ping" }), true);
+  assert.equal(isRelayToDaemon({ t: "open", v: "v1" }), true);
+  assert.equal(isRelayToDaemon({ t: "frame", v: "v1", p: "ciphertext" }), true);
+  assert.equal(isRelayToDaemon({ t: "close", v: "v1" }), true);
+});
+
+test("a relay sending JSON null is ignored without escaping the socket handler", async () => {
+  let observed!: () => void;
+  const survived = new Promise<void>((resolve) => (observed = resolve));
+  const server = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (req, socket, head) => {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      ws.send("null");
+      setTimeout(observed, 25);
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  const client = startRelayClient({
+    url: `ws://127.0.0.1:${port}`,
+    code: "a-strong-pairing-code-for-tests",
+    registry: {} as SessionRegistry,
+  });
+  try {
+    await survived;
+  } finally {
+    client.stop();
+    wss.close();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections?.();
+    });
+  }
 });
 
 // R.5: the dial-out presents the entitlement token as an upgrade header — and

--- a/server/relay/relay-client.ts
+++ b/server/relay/relay-client.ts
@@ -9,9 +9,9 @@ import {
   DAEMON_PATH,
   ENTITLEMENT_HEADER,
   HANDSHAKE_TIMEOUT_MS,
+  isRelayToDaemon,
   PAIR_PARAM,
   type DaemonToRelay,
-  type RelayToDaemon,
 } from "./relay-protocol";
 import {
   derivePair,
@@ -177,12 +177,14 @@ export function startRelayClient(opts: {
       }, PAIR_CONFIRM_MS);
     });
     ws.on("message", (data) => {
-      let env: RelayToDaemon;
+      let parsed: unknown;
       try {
-        env = JSON.parse(String(data)) as RelayToDaemon;
+        parsed = JSON.parse(String(data));
       } catch {
         return;
       }
+      if (!isRelayToDaemon(parsed)) return;
+      const env = parsed;
       switch (env.t) {
         case "open":
           if (typeof env.v === "string" && !remotes.has(env.v)) {

--- a/server/relay/relay-protocol.ts
+++ b/server/relay/relay-protocol.ts
@@ -14,6 +14,25 @@ export type RelayToDaemon =
   | { t: "close"; v: string } // that viewport is gone
   | { t: "ping" }; // relay-side liveness
 
+/** Runtime boundary for the untrusted relay socket. JSON.parse only proves
+ * syntax: scalars, null, arrays, and wrong-shaped objects are all valid JSON
+ * but none may reach the multiplexer's property reads or session actions. */
+export function isRelayToDaemon(value: unknown): value is RelayToDaemon {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) return false;
+  const env = value as Record<string, unknown>;
+  switch (env.t) {
+    case "ping":
+      return true;
+    case "open":
+    case "close":
+      return typeof env.v === "string";
+    case "frame":
+      return typeof env.v === "string" && typeof env.p === "string";
+    default:
+      return false;
+  }
+}
+
 /** Daemon → relay. */
 export type DaemonToRelay =
   | { t: "frame"; v: string; p: string } // one WireMsg for that viewport

--- a/server/relay/relay-url.test.ts
+++ b/server/relay/relay-url.test.ts
@@ -1,6 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { DEFAULT_APP_URL, DEFAULT_RELAY_URL, resolveRelayPlan } from "./relay-url";
+import {
+  carriesCredentialInClear,
+  DEFAULT_APP_URL,
+  DEFAULT_RELAY_URL,
+  resolveRelayPlan,
+} from "./relay-url";
 
 // The bake's load-bearing rule: the default engages ONLY when a dial could
 // succeed (an entitlement is configured). An unentitled daemon must never
@@ -71,6 +76,28 @@ test("empty / whitespace URL means unset, not opt-out", () => {
   });
   const entitled = resolveRelayPlan({ MIRAFOLD_RELAY_URL: "", MIRAFOLD_LICENSE_KEY: "mf_abc" });
   assert.equal(entitled.kind === "dial" && entitled.url, DEFAULT_RELAY_URL);
+});
+
+// 2026-08-11 audit: a bearer credential (entitlement token / license key)
+// riding a plaintext non-loopback URL is stealable on the path. TLS and
+// loopback are exempt; a plaintext remote host warns.
+test("audit 2026-08-11: cleartext-credential detection covers scheme and host", () => {
+  // Exempt: TLS anywhere.
+  assert.equal(carriesCredentialInClear("wss://relay.example"), false);
+  assert.equal(carriesCredentialInClear("https://mirafold.com/api/entitlement"), false);
+  // Exempt: plaintext but loopback (dev stub / same-box self-host).
+  assert.equal(carriesCredentialInClear("ws://127.0.0.1:9100"), false);
+  assert.equal(carriesCredentialInClear("ws://localhost:9100"), false);
+  assert.equal(carriesCredentialInClear("http://127.0.0.1:8000/api"), false);
+  assert.equal(carriesCredentialInClear("ws://[::1]:9100"), false);
+  // Exposed: plaintext to a real host.
+  assert.equal(carriesCredentialInClear("ws://relay.example"), true);
+  assert.equal(carriesCredentialInClear("http://entitlement.example/api"), true);
+  assert.equal(carriesCredentialInClear("ws://10.0.0.5:9100"), true);
+  // A host that only LOOKS loopback is still remote.
+  assert.equal(carriesCredentialInClear("ws://127.0.0.1.evil.test"), true);
+  // Malformed → false (other code refuses it).
+  assert.equal(carriesCredentialInClear("not a url"), false);
 });
 
 // A malformed explicit URL still reaches index.ts's REFUSED path (relayOrigin

--- a/server/relay/relay-url.ts
+++ b/server/relay/relay-url.ts
@@ -28,6 +28,36 @@ export type RelayPlan =
    *  = nothing configured, so the bake stood down (one actionable boot line). */
   | { kind: "off"; reason: "opt-out" | "unentitled-default" };
 
+/**
+ * True when a bearer credential riding this URL would cross the network in the
+ * clear: a non-TLS scheme (`http:`/`ws:`) to a host that is not loopback. The
+ * relay's E2E seal protects the *session*, but the entitlement token (relay
+ * dial header) and the license key (entitlement-exchange POST body) travel
+ * OUTSIDE that seal — over plaintext to a real host, anyone on the path reads
+ * them and can impersonate the paying customer to the relay. Defaults are
+ * `wss:`/`https:`, so this only fires when a user explicitly points a credential
+ * at a plaintext non-loopback endpoint. Loopback is exempt: the dev stub and a
+ * self-hosted relay on the same box carry nothing off-machine. A malformed URL
+ * returns false — other code already refuses it. (2026-08-11 audit.)
+ */
+export function carriesCredentialInClear(urlString: string): boolean {
+  let u: URL;
+  try {
+    u = new URL(urlString);
+  } catch {
+    return false;
+  }
+  if (u.protocol === "https:" || u.protocol === "wss:") return false;
+  if (u.protocol !== "http:" && u.protocol !== "ws:") return false;
+  const host = u.hostname;
+  const loopback =
+    host === "localhost" ||
+    host === "[::1]" ||
+    host === "::1" ||
+    /^127(?:\.\d{1,3}){3}$/.test(host);
+  return !loopback;
+}
+
 export function resolveRelayPlan(env: {
   MIRAFOLD_RELAY_URL?: string;
   MIRAFOLD_APP_URL?: string;

--- a/server/security/auth.test.ts
+++ b/server/security/auth.test.ts
@@ -23,6 +23,12 @@ test("cookieToken returns undefined when absent/malformed", () => {
   assert.equal(cookieToken("foo=1"), undefined);
   assert.equal(cookieToken("no-equals-sign"), undefined);
   assert.equal(cookieToken("mirafold_tokenX=abc"), undefined); // must be an exact name match
+  assert.equal(cookieToken("mirafold_token=%"), undefined, "a malformed URI escape is invalid, not fatal");
+  assert.equal(
+    cookieToken("mirafold_token=%; mirafold_token=healed"),
+    "healed",
+    "a later valid duplicate can recover from a malformed stale value",
+  );
 });
 
 const authOn = { port: 3000, authEnabled: true };
@@ -64,6 +70,11 @@ test("verifyToken accepts a matching cookie or ?token= query", () => {
   const T = "secret";
   assert.equal(verifyToken({ headers: { cookie: "mirafold_token=secret" } }, T, true), true);
   assert.equal(verifyToken({ headers: {}, url: "/ws?token=secret" }, T, true), true);
+  assert.equal(
+    verifyToken({ headers: { cookie: "mirafold_token=%" }, url: "/ws?token=secret" }, T, true),
+    true,
+    "a malformed cookie does not block valid query-token recovery",
+  );
 });
 
 test("verifyToken rejects a wrong or missing token when enabled", () => {

--- a/server/security/auth.ts
+++ b/server/security/auth.ts
@@ -41,7 +41,14 @@ export function cookieToken(cookieHeader?: string): string | undefined {
     const eq = part.indexOf("=");
     if (eq < 0) continue;
     if (part.slice(0, eq).trim() === COOKIE_NAME) {
-      return decodeURIComponent(part.slice(eq + 1).trim());
+      try {
+        return decodeURIComponent(part.slice(eq + 1).trim());
+      } catch {
+        // A malformed stale cookie must behave like no cookie. In particular,
+        // the startup URL's valid ?token= can then mint a clean replacement
+        // instead of every request dying in decodeURIComponent first.
+        continue;
+      }
     }
   }
   return undefined;

--- a/server/security/permissions.test.ts
+++ b/server/security/permissions.test.ts
@@ -3,7 +3,12 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { mkdtempSync } from "node:fs";
-import { isSecretFile, makeCanUseTool, type PermissionAsker } from "./permissions";
+import {
+  isSecretFile,
+  makeCanUseTool,
+  resolvesToSecretFile,
+  type PermissionAsker,
+} from "./permissions";
 
 // The SDK's canUseTool passes an options object; our policy ignores it, so a
 // minimal-but-complete stub is enough to exercise the callback.
@@ -19,13 +24,13 @@ const READERS: [string, string][] = [
   ["Glob", "path"],
 ];
 
-function harness(answer: boolean, root = ROOT) {
+function harness(answer: boolean, root = ROOT, caseInsensitiveFs = false) {
   const asked: string[] = [];
   const ask: PermissionAsker = async (tool) => {
     asked.push(tool);
     return answer;
   };
-  const canUse = makeCanUseTool(root, ask);
+  const canUse = makeCanUseTool(root, ask, caseInsensitiveFs);
   const call = async (tool: string, input: Record<string, unknown>) => {
     const r = await canUse(tool, input, opts);
     assert.ok(r, "canUseTool unexpectedly returned null");
@@ -90,6 +95,52 @@ test("Q.5 cross-cwd: absolute + traversal routes to the daemon .env still deny; 
   // A bare ".env" now resolves to otherDir/.env — a DIFFERENT file, outside the
   // guard's scope (it protects the daemon's own secrets), so it is not denied.
   assert.notEqual((await call("Read", { file_path: ".env" })).behavior, "deny");
+});
+
+// 2026-08-11 audit: on a case-insensitive filesystem (macOS default, Windows)
+// `.Env`/`.ENV` name the SAME file as `.env`, so a case-sensitive string match
+// let an auto-allowed `Read(".Env")` read the daemon's secret with no prompt —
+// the exact zero-click route the guard exists to close. The compare must fold
+// case exactly where the host filesystem does.
+test("audit 2026-08-11: case-variant .env spellings deny on a case-insensitive FS", async () => {
+  const { call } = harness(true, ROOT, true);
+  const variants = [".Env", ".ENV", ".eNv", ".env.LOCAL", ".ENV.LOCAL"];
+  for (const name of variants) {
+    for (const [tool, field] of READERS) {
+      assert.equal(
+        (await call(tool, { [field]: name })).behavior,
+        "deny",
+        `${tool} @ ${name} must deny on a case-insensitive FS`,
+      );
+    }
+  }
+  // The absolute-path route folds too.
+  const absUpper = path.resolve(process.cwd(), ".ENV");
+  assert.equal((await call("Read", { file_path: absUpper })).behavior, "deny");
+});
+
+test("audit 2026-08-11: a case-sensitive FS keeps .ENV as a different, allowed file", async () => {
+  // Linux resolves `.ENV` to a genuinely different file; folding it in would
+  // wrongly deny a legitimate workspace file, so case-sensitive stays exact.
+  const { call } = harness(false, ROOT, false);
+  assert.notEqual((await call("Read", { file_path: ".ENV" })).behavior, "deny");
+  // The real secret is still denied regardless.
+  assert.equal((await call("Read", { file_path: ".env" })).behavior, "deny");
+});
+
+test("audit 2026-08-11: resolvesToSecretFile folds case only when told to", () => {
+  const secret = path.resolve(process.cwd(), ".env");
+  const upper = path.resolve(process.cwd(), ".ENV");
+  assert.equal(resolvesToSecretFile(secret, false), true);
+  assert.equal(resolvesToSecretFile(upper, false), false);
+  assert.equal(resolvesToSecretFile(upper, true), true);
+});
+
+test("audit 2026-08-11: isSecretFile folds case only when told to", () => {
+  assert.equal(isSecretFile("/x/.ENV", false), false);
+  assert.equal(isSecretFile("/x/.ENV", true), true);
+  assert.equal(isSecretFile("/x/.Env.Local", true), true);
+  assert.equal(isSecretFile("/x/.env", false), true);
 });
 
 test("local read-only tools and mcp__ui__* are allowed without asking", async () => {

--- a/server/security/permissions.ts
+++ b/server/security/permissions.ts
@@ -42,10 +42,42 @@ const DETAIL_FIELD: Record<string, string> = {
 const SECRET_FILE_BASENAMES = new Set([".env", ".env.local"]);
 const SECRET_PATHS = new Set([...SECRET_FILE_BASENAMES].map((n) => path.resolve(n)));
 
+// macOS and Windows resolve `.Env` and `.ENV` to the SAME file as `.env`, but a
+// case-sensitive string compare treats them as different names — so a purely
+// lexical guard misses `Read(".Env")` on those platforms and reads the secret
+// back through an auto-allowed tool with no prompt, exactly the zero-click route
+// this guard exists to close. Compare the way the host filesystem does. Linux is
+// case-sensitive, so `.ENV` there is a genuinely different file and stays out of
+// scope. Derived once from the platform; injectable so a case-sensitive CI host
+// can still pin the case-insensitive behavior. (2026-08-11 audit.)
+const CASE_INSENSITIVE_FS = process.platform === "darwin" || process.platform === "win32";
+
 /** True when `p` names a secret env file (by basename) — the Explorer's
  *  content-read denial. Listing may still SHOW the file (honesty over
- *  hiding); only reading its contents is refused. */
-export const isSecretFile = (p: string) => SECRET_FILE_BASENAMES.has(path.basename(p));
+ *  hiding); only reading its contents is refused. On a case-insensitive
+ *  filesystem `.Env`/`.ENV` name the same file as `.env`, so they match too. */
+export const isSecretFile = (p: string, caseInsensitiveFs = CASE_INSENSITIVE_FS): boolean => {
+  const base = path.basename(p);
+  if (SECRET_FILE_BASENAMES.has(base)) return true;
+  return caseInsensitiveFs && SECRET_FILE_BASENAMES.has(base.toLowerCase());
+};
+
+/** Does an auto-allowed reader's resolved target land on one of the daemon's
+ *  own secret files? Case-folds on a case-insensitive filesystem so a
+ *  case-variant spelling can't slip past the exact-string set. Exported for
+ *  the guard's regression pin. */
+export const resolvesToSecretFile = (
+  resolvedTarget: string,
+  caseInsensitiveFs = CASE_INSENSITIVE_FS,
+): boolean => {
+  if (SECRET_PATHS.has(resolvedTarget)) return true;
+  if (!caseInsensitiveFs) return false;
+  const lowered = resolvedTarget.toLowerCase();
+  for (const secret of SECRET_PATHS) {
+    if (secret.toLowerCase() === lowered) return true;
+  }
+  return false;
+};
 const READ_PATH_FIELD: Record<string, string> = {
   Read: "file_path",
   NotebookRead: "notebook_path",
@@ -74,7 +106,11 @@ export type PermissionAsker = (tool: string, detail: string) => Promise<boolean>
  *     doesn't do that, so neither do we; a user allowlists the commands they
  *     want promptless in their settings.json exactly as in the terminal.
  */
-export function makeCanUseTool(workspaceDir: string, ask: PermissionAsker): CanUseTool {
+export function makeCanUseTool(
+  workspaceDir: string,
+  ask: PermissionAsker,
+  caseInsensitiveFs = CASE_INSENSITIVE_FS,
+): CanUseTool {
   const root = path.resolve(workspaceDir);
   const denied = (message: string) => ({ behavior: "deny" as const, message });
 
@@ -89,7 +125,7 @@ export function makeCanUseTool(workspaceDir: string, ask: PermissionAsker): CanU
     const readField = READ_PATH_FIELD[toolName];
     if (readField) {
       const target = input[readField];
-      if (typeof target === "string" && SECRET_PATHS.has(path.resolve(root, target))) {
+      if (typeof target === "string" && resolvesToSecretFile(path.resolve(root, target), caseInsensitiveFs)) {
         return denied("Reading the daemon's environment file is not permitted.");
       }
     }

--- a/server/sessions/bang-handlers.ts
+++ b/server/sessions/bang-handlers.ts
@@ -181,6 +181,11 @@ const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, 
             id,
           });
         }
+        // The transcript below starts a model turn of its own. Record that
+        // before bang_end derives fleet/gate state so there is no false-idle
+        // window, and so a bang beside an existing turn consumes the one
+        // queued-follow-up slot instead of silently adding another.
+        registry.markModelTurnStarted(e);
         registry.broadcast(e, { type: "bang_end", id, exitCode });
         applyCwdHandoff(registry, e, runCwd, cwdFile);
         // The transcript goes to the agent NOW, as its own turn — the

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -345,7 +345,9 @@ export function openConnection(
         break;
       case "rename":
         if (typeof msg.sessionId === "string" && typeof msg.name === "string") {
-          registry.rename(msg.sessionId, msg.name);
+          if (!registry.rename(msg.sessionId, msg.name)) {
+            sendError("Could not save the session name. The previous name is unchanged.");
+          }
         }
         break;
       case "end_session":

--- a/server/sessions/fs-explorer.test.ts
+++ b/server/sessions/fs-explorer.test.ts
@@ -91,10 +91,23 @@ test("listTree: the walk is node-bounded — a tree of empty dirs can't be walke
   const r = listTree(root, { maxNodes: 10 });
   assert.ok(!("error" in r));
   assert.equal(r.truncated, true, "the node cap must trip on a file-less tree");
-  // And a normal small tree with room to spare is NOT flagged truncated.
-  writeFileSync(path.join(root, "a.txt"), "a");
-  const ok = listTree(tmp());
+  // And a normal small tree with room to spare is NOT flagged truncated
+  // (2026-08-11 test-audit: this used to write into the already-capped `root`
+  // — a dead write — then list a FRESH EMPTY dir and assert only "no error",
+  // so the stated "not truncated" guarantee went untested; a bug that
+  // spuriously truncated a small tree would have passed).
+  const small = tmp();
+  writeFileSync(path.join(small, "a.txt"), "a");
+  mkdirSync(path.join(small, "sub"));
+  writeFileSync(path.join(small, "sub", "b.txt"), "b");
+  const ok = listTree(small);
   assert.ok(!("error" in ok));
+  assert.equal("error" in ok ? undefined : ok.truncated, false, "a small tree is not truncated");
+  assert.deepEqual(
+    "error" in ok ? [] : ok.entries.map((e) => e.path).sort(),
+    ["a.txt", "sub/b.txt"],
+    "the small tree lists in full",
+  );
 });
 
 test("listTree: unreadable root is the error case, not a throw", () => {

--- a/server/sessions/fs-explorer.test.ts
+++ b/server/sessions/fs-explorer.test.ts
@@ -70,6 +70,17 @@ test("listTree: path-byte cap trips honestly", () => {
   assert.ok(r.entries.length < 5);
 });
 
+test("listTree: path-byte admission counts UTF-8 bytes, not JavaScript characters", () => {
+  const root = tmp();
+  const name = "é.txt";
+  writeFileSync(path.join(root, name), "x");
+  assert.ok(Buffer.byteLength(name, "utf8") > name.length, "fixture distinguishes bytes from characters");
+  const r = listTree(root, { maxPathBytes: name.length });
+  assert.ok(!("error" in r));
+  assert.deepEqual(r.entries, [], "a path larger than the byte budget is never admitted");
+  assert.equal(r.truncated, true);
+});
+
 test("listTree: the walk is node-bounded — a tree of empty dirs can't be walked without limit (audit 2026-07-24)", () => {
   const root = tmp();
   // 30 sibling directories, each with a nested empty child — NO files, so the

--- a/server/sessions/fs-explorer.ts
+++ b/server/sessions/fs-explorer.ts
@@ -116,12 +116,13 @@ export function listTree(
         if (!SKIP_DIRS.has(d.name)) walk(path.join(dir, d.name), rel);
         continue;
       }
-      if (entries.length >= maxEntries || pathBytes + rel.length > maxPathBytes) {
+      const relBytes = Buffer.byteLength(rel, "utf8");
+      if (entries.length >= maxEntries || pathBytes + relBytes > maxPathBytes) {
         truncated = true;
         return;
       }
       entries.push({ path: rel });
-      pathBytes += Buffer.byteLength(rel, "utf8");
+      pathBytes += relBytes;
     }
   };
   walk(realRoot, "");

--- a/server/sessions/git.test.ts
+++ b/server/sessions/git.test.ts
@@ -1,9 +1,10 @@
 import { test, after } from "node:test";
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { cleanRelPath, decorateGitDir, findRepoRoot, parseStatusIgnoredZ, parseStatusZ } from "./git";
+import { cleanRelPath, decorateGitDir, findRepoRoot, gitTree, parseStatusIgnoredZ, parseStatusZ } from "./git";
 
 // E.2's pure parsing pins: the -z rename two-field trap, status collapsing,
 // and the textual path containment that guards `git show`. E2.3 adds the
@@ -193,4 +194,18 @@ test("findRepoRoot: nearest .git wins; no .git anywhere is null", () => {
     findRepoRoot(path.join(base, "worktree"), fixtureExists),
     path.join(base, "worktree"),
   );
+});
+
+test("gitTree: path-byte admission counts UTF-8 bytes, not JavaScript characters", async () => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "gittree-bytes-"));
+  after(() => rmSync(root, { recursive: true, force: true }));
+  execFileSync("git", ["init", "--quiet"], { cwd: root });
+  const name = "é.txt";
+  writeFileSync(path.join(root, name), "x");
+  assert.ok(Buffer.byteLength(name, "utf8") > name.length, "fixture distinguishes bytes from characters");
+  const result = await gitTree(root, { maxPathBytes: name.length });
+  assert.ok("entries" in result);
+  if (!("entries" in result)) return;
+  assert.deepEqual(result.entries, [], "a path larger than the byte budget is never admitted");
+  assert.equal(result.truncated, true);
 });

--- a/server/sessions/git.ts
+++ b/server/sessions/git.ts
@@ -136,7 +136,12 @@ export type GitTree =
  * trap). Staged deletions are gone from ls-files but still real: status-only
  * D paths are merged in, so a deleted file stays visible in the tree.
  */
-export async function gitTree(root: string): Promise<GitTree> {
+export async function gitTree(
+  root: string,
+  caps: { maxEntries?: number; maxPathBytes?: number } = {},
+): Promise<GitTree> {
+  const maxEntries = caps.maxEntries ?? FS_TREE_MAX_ENTRIES;
+  const maxPathBytes = caps.maxPathBytes ?? FS_TREE_MAX_PATH_BYTES;
   const ls = await runGit(root, ["ls-files", "--cached", "--others", "--exclude-standard", "-z"]);
   if (!ls.ok) return ls.notGit ? { notGit: true } : { error: gitErr("ls-files", ls) };
   const [status, prefixRes] = await Promise.all([
@@ -172,13 +177,14 @@ export async function gitTree(root: string): Promise<GitTree> {
   const push = (rel: string) => {
     if (rel === "" || seen.has(rel)) return;
     seen.add(rel);
-    if (entries.length >= FS_TREE_MAX_ENTRIES || pathBytes + rel.length > FS_TREE_MAX_PATH_BYTES) {
+    const relBytes = Buffer.byteLength(rel, "utf8");
+    if (entries.length >= maxEntries || pathBytes + relBytes > maxPathBytes) {
       truncated = true;
       return;
     }
     const status = statusByRel.get(rel) ?? (inUntrackedDir(rel) ? "U" : undefined);
     entries.push({ path: rel, ...(status ? { status } : {}) });
-    pathBytes += Buffer.byteLength(rel, "utf8");
+    pathBytes += relBytes;
   };
   for (const rel of String(ls.stdout).split("\0")) push(rel);
   // Status-only paths: staged deletes (and rename sources) missing from

--- a/server/sessions/registry.test.ts
+++ b/server/sessions/registry.test.ts
@@ -3,10 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { foldUsage, resolveCwd, SessionRegistry } from "./registry";
+import { expandHomePath, foldUsage, resolveCwd, SessionRegistry } from "./registry";
 import { PERMISSION_TIMEOUT_MS } from "../adapters/types";
 import type { Backend } from "../adapters";
 import type { WireMsg } from "../protocol";
+import { SessionCheckpointStore } from "./session-store";
 
 test("resolveCwd defaults to the process cwd", () => {
   assert.equal(resolveCwd(undefined), process.cwd());
@@ -19,6 +20,10 @@ test("resolveCwd resolves an existing dir to an absolute path", () => {
 
 test("resolveCwd expands a leading ~", () => {
   assert.equal(resolveCwd("~"), os.homedir());
+  assert.equal(
+    expandHomePath("~\\Projects\\mirafold", "C:\\Users\\Kyle"),
+    "C:\\Users\\Kyle\\Projects\\mirafold",
+  );
 });
 
 test("resolveCwd throws on a missing directory", () => {
@@ -55,6 +60,22 @@ function freshSession() {
   assert.equal(entry.nextSeq, 1);
   return { reg, entry };
 }
+
+test("an active rename rolls back when its checkpoint cannot be written", () => {
+  const store = new SessionCheckpointStore(mkdtempSync(path.join(os.tmpdir(), "genui-rename-store-")));
+  const reg = new SessionRegistry(MOCK_BACKEND, 0, store);
+  const dir = mkdtempSync(path.join(os.tmpdir(), "genui-rename-root-"));
+  const entry = reg.create({ cwd: dir });
+  const previous = entry.name;
+  (store as unknown as { write: () => void }).write = () => {
+    throw new Error("disk is read-only");
+  };
+
+  assert.equal(reg.rename(entry.id, "name that must not lie"), false);
+  assert.equal(entry.name, previous);
+  assert.equal(reg.summary().find((row) => row.sessionId === entry.id)?.name, previous);
+  reg.end(entry.id);
+});
 
 const delta = (): WireMsg => ({ type: "text_delta", text: "x" });
 
@@ -706,6 +727,52 @@ test("bang_end on an ask-free session still reads idle (the M.1 behavior stands)
   reg.broadcast(entry, { type: "bang_end", id: "b1", exitCode: 0 });
   assert.equal(entry.status, "idle");
   assert.equal(entry.activity, undefined);
+  reg.end(entry.id);
+});
+
+test("bang_end beside an active model turn stays working and never reopens the prompt gate", () => {
+  const { reg, entry } = freshSession();
+  assert.equal(reg.dispatchPrompt(entry, "first"), true);
+  assert.equal(entry.modelTurnsPending, 1);
+  assert.equal(reg.dispatchPrompt(entry, "queued"), true);
+  assert.equal(entry.modelTurnsPending, 2);
+  assert.equal(entry.midTurnPromptUsed, true);
+  assert.equal(reg.dispatchPrompt(entry, "refused before bang"), false);
+
+  reg.broadcast(entry, { type: "bang_start", command: "git status", id: "b1" });
+  reg.broadcast(entry, { type: "bang_end", id: "b1", exitCode: 0 });
+  assert.equal(entry.status, "working", "the original model turn still owns the session");
+  assert.equal(entry.modelTurnsPending, 2);
+  assert.equal(entry.midTurnPromptUsed, true, "bang lifecycle is not model turn grammar");
+  assert.equal(reg.dispatchPrompt(entry, "refused after bang"), false);
+
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.status, "working", "the queued turn becomes current without a false-idle boundary");
+  assert.equal(entry.modelTurnsPending, 1);
+  assert.equal(entry.midTurnPromptUsed, false, "the new current turn earns one queued-follow-up slot");
+  assert.equal(reg.dispatchPrompt(entry, "follow-up for queued turn"), true);
+  assert.equal(entry.modelTurnsPending, 2);
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.modelTurnsPending, 1);
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.status, "idle");
+  assert.equal(entry.modelTurnsPending, 0);
+  reg.end(entry.id);
+});
+
+test("an adapter error plus its turn_end completes one pending turn, not two", () => {
+  const { reg, entry } = freshSession();
+  assert.equal(reg.dispatchPrompt(entry, "first"), true);
+  assert.equal(reg.dispatchPrompt(entry, "queued"), true);
+  reg.broadcast(entry, { type: "error", message: "first failed" });
+  assert.equal(entry.modelTurnsPending, 1);
+  assert.equal(entry.status, "working");
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.modelTurnsPending, 1, "turn_end pairs with the preceding error");
+  assert.equal(entry.status, "working");
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.equal(entry.modelTurnsPending, 0);
+  assert.equal(entry.status, "idle");
   reg.end(entry.id);
 });
 

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -131,7 +131,7 @@ export type Viewport = (msg: WireMsg) => void;
  */
 export function resolveCwd(cwd?: string): string {
   if (!cwd) return process.cwd();
-  const expanded = cwd.replace(/^~(?=\/|$)/, os.homedir());
+  const expanded = expandHomePath(cwd);
   const dir = path.resolve(expanded);
   let stat;
   try {
@@ -141,6 +141,12 @@ export function resolveCwd(cwd?: string): string {
   }
   if (!stat.isDirectory()) throw new Error(`not a directory: ${dir}`);
   return dir;
+}
+
+/** Expand terminal-style home syntax without assuming the host separator.
+ * The optional home makes Windows-shaped behavior testable on every runner. */
+export function expandHomePath(cwd: string, home = os.homedir()): string {
+  return cwd.replace(/^~(?=[\\/]|$)/, home);
 }
 
 export type SessionEntry = {
@@ -190,8 +196,16 @@ export type SessionEntry = {
   // (each bang costs a model turn, so bursts burn tokens).
   lastBangAt?: number;
   // The prompt-burst gate (dispatchPrompt): has the running turn already
-  // accepted its one queued follow-up? Cleared where status returns to idle.
+  // accepted its one queued follow-up? Cleared only by model turn grammar.
   midTurnPromptUsed?: boolean;
+  // Enqueued + running model turns, independent from the composite fleet
+  // status: a permission hold or a `!` PTY can temporarily own `status` while
+  // model work remains underneath. Never persisted — recovery starts idle.
+  modelTurnsPending: number;
+  // Adapters emit error + turn_end for one failed turn. The error provides
+  // immediate terminal feedback; this marker keeps its following turn_end
+  // from decrementing the pending count a second time.
+  errorAwaitingTurnEnd?: boolean;
   // The live-tree doorbell (W.1): running exactly while viewports are
   // attached — first attach starts it, last detach (and end) stops it — so a
   // dormant session holds no inotify watches.
@@ -304,6 +318,7 @@ export class SessionRegistry {
       tailResumeSafe: true,
       name: path.basename(dir) || dir,
       status: "idle",
+      modelTurnsPending: 0,
       lastActivity: Date.now(),
       createdAt: Date.now(),
       permissions: [],
@@ -352,6 +367,7 @@ export class SessionRegistry {
       tailResumeSafe: false,
       name: stored.name,
       status: "idle",
+      modelTurnsPending: 0,
       lastActivity: stored.lastActivity,
       createdAt: stored.createdAt,
       permissions: [],
@@ -583,8 +599,18 @@ export class SessionRegistry {
     // until the turn moves again (4.6).
     const prev = entry.status;
     if (msg.type === "turn_end" || msg.type === "error") {
-      entry.status = "idle";
-      entry.midTurnPromptUsed = false; // the burst gate clears on the turn grammar, never a clock
+      if (msg.type === "error") {
+        if (!entry.errorAwaitingTurnEnd) {
+          entry.modelTurnsPending = Math.max(0, entry.modelTurnsPending - 1);
+        }
+        entry.errorAwaitingTurnEnd = true;
+      } else if (entry.errorAwaitingTurnEnd) {
+        entry.errorAwaitingTurnEnd = false;
+      } else {
+        entry.modelTurnsPending = Math.max(0, entry.modelTurnsPending - 1);
+      }
+      entry.midTurnPromptUsed = entry.modelTurnsPending > 1;
+      entry.status = entry.modelTurnsPending > 0 ? "working" : "idle";
     } else if (msg.type === "bang_end") {
       // The `!` PTY is its own lifecycle running BESIDE the model turn — its
       // end is NOT the turn reaching a terminal state. Treating it as one
@@ -592,7 +618,11 @@ export class SessionRegistry {
       // allow/deny while the ask was still live at the adapter — the
       // 2026-07-24 bug class through a different door) and re-opened the
       // mid-turn burst gate (2026-07-29 bughunt).
-      entry.status = entry.permissions.length ? "permission" : "idle";
+      entry.status = entry.permissions.length
+        ? "permission"
+        : entry.modelTurnsPending > 0
+          ? "working"
+          : "idle";
     } else if (msg.type === "permission_request") {
       entry.status = "permission";
     } else if (msg.type === "bang_start" || msg.type === "bang_output") {
@@ -692,10 +722,13 @@ export class SessionRegistry {
       if (entry.status === "permission" && entry.permissions.length === 0) {
         entry.status = "working";
       }
+    } else if (msg.type === "turn_end" || msg.type === "error") {
+      // The turn that owned these asks ended. A queued next turn may keep the
+      // session working, but none of the prior turn's approvals survive into it.
+      entry.permissions = [];
     } else if (entry.status === "idle") {
-      // turn_end / error: nothing can still be pending. (bang_end only lands
-      // here when no ask pends — the status derivation keeps "permission"
-      // through a bang, so a live ask is never wiped by one.)
+      // bang_end only lands here when no ask pends — the status derivation
+      // keeps "permission" through a bang, so a live ask is never wiped by one.
       entry.permissions = [];
     } else if (entry.permissions.length) {
       // The adapter auto-denies an unanswered ask at PERMISSION_TIMEOUT_MS
@@ -943,8 +976,12 @@ export class SessionRegistry {
     const clean = name.trim().slice(0, 60);
     if (!clean) return false;
     if (entry) {
+      const previous = entry.name;
       entry.name = clean;
-      this.checkpoint(entry);
+      if (this.store && !this.checkpoint(entry)) {
+        entry.name = previous;
+        return false;
+      }
     } else {
       const stored = this.dormant.get(id);
       if (!stored || !this.store) return false;
@@ -1009,18 +1046,29 @@ export class SessionRegistry {
    * turn; ONE more may arrive while it runs — the terminal agents queue
    * typed-mid-turn input, so refusing a single queued follow-up would break
    * parity (desktop Enter still sends while busy); anything past that is
-   * refused until a terminal event (turn_end / error / bang_end) clears the
+   * refused until a model-terminal event (turn_end / error) clears the
    * gate in broadcast(). Burn is capped near one turn per completed turn,
    * and no human pace — nor the suite's — can trip it.
    */
   dispatchPrompt(entry: SessionEntry, text: string): boolean {
-    if (entry.status !== "idle") {
-      if (entry.midTurnPromptUsed) return false;
-      entry.midTurnPromptUsed = true;
-    }
+    if (entry.modelTurnsPending > 1) return false;
+    entry.modelTurnsPending += 1;
+    entry.midTurnPromptUsed = entry.modelTurnsPending > 1;
+    entry.errorAwaitingTurnEnd = false;
     this.broadcast(entry, { type: "user_prompt", text });
     entry.session.pushPrompt(text);
     return true;
+  }
+
+  /** Record a model turn started outside dispatchPrompt — currently the
+   * transcript a completed `!` command sends directly to the adapter. If a
+   * turn is already active, that transcript consumes its queued-follow-up
+   * slot just like typed input would. */
+  markModelTurnStarted(entry: SessionEntry) {
+    if (this.entries.get(entry.id) !== entry) return;
+    entry.modelTurnsPending += 1;
+    entry.midTurnPromptUsed = entry.modelTurnsPending > 1;
+    entry.errorAwaitingTurnEnd = false;
   }
 
   /** Push a fresh snapshot to every watcher, coalescing bursts. */

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -44,8 +44,16 @@ export const isCurrentReply = (awaited: string | null, replyId: string): boolean
 
 /** The root row shows just the checked-out folder's NAME; the full ~-path
  *  stays in its tooltip. Pure, for Tier-1. */
-export const rootNameOf = (rootLabel?: string): string =>
-  rootLabel?.replace(/\/+$/, "").split("/").pop() || rootLabel || "files";
+export const rootNameOf = (rootLabel?: string): string => {
+  if (!rootLabel) return "files";
+  const windowsStyle =
+    /^[A-Za-z]:[\\/]/.test(rootLabel) || rootLabel.startsWith("\\\\") || rootLabel.startsWith("~\\");
+  const trimmed = windowsStyle
+    ? rootLabel.replace(/[\\/]+$/, "")
+    : rootLabel.replace(/\/+$/, "");
+  if (!trimmed || /^[A-Za-z]:$/.test(trimmed)) return rootLabel;
+  return trimmed.split(windowsStyle ? /[\\/]/ : /\//).pop() || rootLabel;
+};
 
 // The open-panel prefetch fetches the root's child dirs so their first
 // expand is instant — capped under the server's token bucket (default 32/s)

--- a/web/src/components/files/files-panel.test.ts
+++ b/web/src/components/files/files-panel.test.ts
@@ -14,8 +14,13 @@ test("isCurrentReply: only the awaited id is accepted", () => {
 test("rootNameOf: the root row carries the folder's name, not the path", () => {
   assert.equal(rootNameOf("~/Projects/mirafold/mirafold"), "mirafold");
   assert.equal(rootNameOf("~/Projects/x/"), "x", "trailing slash is ignored");
+  assert.equal(rootNameOf("C:\\Users\\Kyle\\Projects\\mirafold"), "mirafold");
+  assert.equal(rootNameOf("C:\\Users\\Kyle\\Projects\\x\\"), "x", "Windows trailing slash is ignored");
+  assert.equal(rootNameOf("~\\Projects\\mirafold"), "mirafold", "a tildified Windows path stays legible");
   assert.equal(rootNameOf("~"), "~", "home itself keeps the tilde");
   assert.equal(rootNameOf("/"), "/", "filesystem root stays legible");
+  assert.equal(rootNameOf("C:\\"), "C:\\", "Windows filesystem root stays legible");
+  assert.equal(rootNameOf("/tmp/folder\\name"), "folder\\name", "POSIX backslashes stay filename data");
   assert.equal(rootNameOf(undefined), "files", "no label yet → a neutral name");
 });
 

--- a/web/src/registry/Chart.test.ts
+++ b/web/src/registry/Chart.test.ts
@@ -3,14 +3,16 @@ import assert from "node:assert/strict";
 import { niceTicks, fmt, pieSlices, arcPath, stackSegments } from "./Chart";
 
 test("niceTicks spans the range and the top tick clears the data max", () => {
-  const ticks = niceTicks(0, 100);
-  assert.ok(ticks.length >= 2);
-  assert.equal(ticks[0], 0);
-  assert.ok(ticks[ticks.length - 1] >= 100);
+  // 2026-08-11 test-audit: exact output is deterministic and knowable, so pin
+  // it — the old `length>=2 / [0]===0 / last>=100` bounds survived a wrong step
+  // count or spacing.
+  assert.deepEqual(niceTicks(0, 100), [0, 50, 100]);
 });
 
 test("niceTicks tolerates a flat range", () => {
-  assert.ok(niceTicks(5, 5).length >= 1);
+  // A flat range must still yield a usable spread around the value, not a
+  // single degenerate tick (the old `length>=1` accepted `[5]`).
+  assert.deepEqual(niceTicks(5, 5), [4, 6]);
 });
 
 test("fmt abbreviates magnitudes", () => {

--- a/web/src/tildify.test.ts
+++ b/web/src/tildify.test.ts
@@ -5,11 +5,31 @@ import { tildify } from "./tildify";
 test("tildify replaces the home prefix with ~", () => {
   assert.equal(tildify("/home/kyle/proj", "/home/kyle"), "~/proj");
   assert.equal(tildify("/home/kyle", "/home/kyle"), "~");
+  assert.equal(tildify("C:\\Users\\Kyle\\Projects\\mirafold", "C:\\Users\\Kyle"), "~\\Projects\\mirafold");
+  assert.equal(
+    tildify("c:\\users\\kyle\\Projects", "C:\\Users\\Kyle"),
+    "~\\Projects",
+    "Windows home matching follows the filesystem's case-insensitive semantics",
+  );
+  assert.equal(
+    tildify("C:/Users/Kyle/Projects", "C:\\Users\\Kyle"),
+    "~/Projects",
+    "mixed Windows separators compare as the same path while preserving the path's suffix",
+  );
 });
 
 test("tildify only matches on a path boundary", () => {
   assert.equal(tildify("/home/kyleeee/x", "/home/kyle"), "/home/kyleeee/x");
   assert.equal(tildify("/var/log", "/home/kyle"), "/var/log");
+  assert.equal(
+    tildify("C:\\Users\\Kyleeee\\x", "C:\\Users\\Kyle"),
+    "C:\\Users\\Kyleeee\\x",
+  );
+  assert.equal(
+    tildify("/home/Kyle/project\\notes", "/home/kyle"),
+    "/home/Kyle/project\\notes",
+    "a legal POSIX backslash does not make the path case-insensitive",
+  );
 });
 
 test("tildify passes through when either input is missing", () => {

--- a/web/src/tildify.ts
+++ b/web/src/tildify.ts
@@ -1,6 +1,14 @@
 /** Render a path the way a terminal prompt would: the home prefix becomes ~. */
 export function tildify(p: string | undefined, home: string | undefined): string | undefined {
-  return p && home && (p === home || p.startsWith(home + "/"))
-    ? "~" + p.slice(home.length)
+  if (!p || !home) return p;
+  const windowsStyle = [p, home].some(
+    (value) => /^[A-Za-z]:[\\/]/.test(value) || value.startsWith("\\\\"),
+  );
+  const comparablePath = windowsStyle ? p.replaceAll("\\", "/").toLowerCase() : p;
+  const comparableHome = windowsStyle ? home.replaceAll("\\", "/").toLowerCase() : home;
+  if (!comparablePath.startsWith(comparableHome)) return p;
+  const suffix = p.slice(home.length);
+  return suffix === "" || suffix.startsWith("/") || suffix.startsWith("\\")
+    ? `~${suffix}`
     : p;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2577,10 +2577,10 @@ ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.16, nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 negotiator@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## Summary

- keep Gemini's queued worker alive after a turn-preparation failure and retry the Codex first-party default-model guard after transient catalog failures
- reject valid-JSON relay scalars, contain malformed auth cookies, and make active-session rename failures roll back visibly
- track model turns independently from bang lifecycle state, count UTF-8 path budgets correctly, and support Windows-shaped Explorer/home paths without changing POSIX semantics

## Regression coverage

- preparation failure and retry paths for Gemini and both Codex credential modes
- malformed relay envelopes and cookies
- active/queued model turns beside bang traffic, including paired error plus turn_end grammar
- failed durable active rename
- UTF-8 filesystem and Git path caps
- Windows drive, mixed-separator, tildified, root, boundary, and POSIX-backslash paths

## Verification

- 577/577 ordinary safe unit assertions; the aggregate-sensitive Codex catalog, Gemini catalog, and version files passed independently (17/17)
- 151/151 final affected-unit assertions
- 131/131 guarded server integration assertions
- 70/70 guarded headless-browser assertions
- TypeScript check and fresh guarded client/server production builds
- git diff --check

The dotenv-manufacturing unit/integration fixtures, launcher browser file, and Explorer/global-axe browser cases remain excluded under the repository's dotenv-opacity rule. No dependency was added. PR #34's failed CI assertion was corrected separately, its replacement DCO/Cloudflare/Tier 1/Tier 2+3 checks passed, and it is now merged into this branch's next base.
