### PR TITLE
Sync main into next after v0.3.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, or Gemini CLI — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Post-release sync (RELEASING.md step 7): brings the v0.3.7 version bump and release merge commit back into `next` so the next cycle's release PR doesn't conflict on `package.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)