### PR TITLE
Needs-you notifications: a hidden tab toasts when a session needs you

### DIFF
--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -8343,3 +8343,1604 @@ selected-code feedback path existed at that point.
   NO phone-override colocation yet — colocating would dismantle the
   one-phone-block convention and is a separately-verified decision for
   later. e2e 74/74 (changes/app/phone), Tier-1 672/672.
+
+## Moved 2026-08-12 (prune — completed bodies)
+
+A prune sweep: finished bodies moved verbatim out of PLAN.md's Phases
+4/R/A/Q, the 2026-07-27 security-audit section, and the stretch goals,
+each leaving a stub + pointer in place. Entries are in plan order.
+
+**From Phase 4, Step 4.13 (moved verbatim 2026-08-12):**
+
+- [x] **Step 4.13 — Phone-testing bug batch (unplanned, Kyle-driven)** — done
+  2026-07-28, all tiers green (458/139/70), every fix e2e-pinned +
+  mutation-tested. Three bugs from Kyle's manual phone/relay testing:
+  (1) **busy turns looked idle** — the transcript's activity line now stays
+  up the whole turn (`✳ working…` fallback between status frames), driven
+  by Shell's wire-derived busy flag; (2) **the permission strip's one-line
+  preview was unreadable on phone** — its body is now one tap target
+  opening the full command in a ModalCard (extracted to `PermBar.tsx` in
+  the same-day refactor); (3) **`exp://` links rendered as dead
+  empty-href anchors** (the about:blank tab) — Expo Go schemes now pass
+  the markdown URL allowlist as real links, and stripped schemes render
+  as text (`web/src/registry/Md.test.ts`). Same-day audit: exp:// hand-off
+  disclosed in SECURITY.md, interstitial planned as 4.12; the audit's
+  second finding — the permission `detail` string is uncapped end-to-end —
+  judged theoretical and **accepted, no action** (Kyle's call 2026-07-28:
+  real agents emit real commands, the card + scrollbar already show more
+  than the old strip ever did; don't re-litigate absent an engine that
+  emits huge payloads); user-facing
+  "know what you're running" paragraph added to the README top. Related
+  decision, same day: **relay port-tunneling** (phone reaches a dev server
+  on the laptop through the relay, no LAN/firewall dependence) was
+  explored and **parked by Kyle** — no roadmap item; the self-serve LAN
+  workaround stands, revisit only if phone-first app-building becomes a
+  real usage path. (The `192.168…` failure that started it was Kyle's ufw
+  dropping LAN SYNs — his machine, not repo state.)
+
+---
+
+**From Phase 4, Step 4.14 (moved verbatim 2026-08-12):**
+
+- [x] **Step 4.14 — The activity indicator, done right (Kyle-driven rework of
+  4.13's fix #1)** — done 2026-07-29, all tiers green (458/139/72), both new
+  guarantees mutation-tested. Kyle's requirement, verbatim in spirit: **at
+  all times while Mirafold is working with nothing painting, something
+  visibly alive says so** — the terminal agents' cycling asterisk is the
+  bar. 4.13's fix guaranteed only DOM presence and failed it four ways:
+  the `.status-line` pulse was dead CSS (the rise-animation list overrode
+  the `animation` shorthand at equal specificity — frozen text since at
+  least 2026-07-25), the label went stale (`Bash ⚙` through the post-tool
+  model round trip), the line lived inside the scrolling transcript (any
+  scroll-up = zero indication), and a queued mid-turn prompt blanked it at
+  the first turn's `turn_end` while the engine rolled into the queued turn.
+  The rework: `ActivityLine.tsx` — cycling thin→fat asterisk frames (JS,
+  reduced-motion honored) + label + ticking elapsed seconds — as
+  prompt-area chrome above the box; Shell owns the label (status frames /
+  announced tools, cleared on `tool_result` so it can't go stale) and an
+  open-turn counter (`user_prompt` up, `turn_end` down, replay-safe) so a
+  queued follow-up keeps busy across the boundary; the in-transcript
+  status line is gone, and the e2e now asserts aliveness (glyph frame
+  changes), on-screen-ness while scrolled up, and gaplessness across the
+  queued-turn boundary — not mere DOM presence.
+  - **⚠ Test-strength caveat, recorded 2026-07-29 (honest limits of the
+    queued-turn pin).** Of the three e2e guarantees, two are solidly
+    mutation-proven (the glyph must visibly cycle; a long label must not
+    widen the page). The THIRD — "no blank frame across the queued-turn
+    boundary" — is a reliable smoke test but NOT a dependable regression
+    pin: `MockSession` overlays a mid-turn prompt's scripted timers on the
+    running turn instead of queuing behind it, so turn 2's events usually
+    land within one 16 ms sample of turn 1's `turn_end`. Reverting the
+    `openTurns` counter therefore produces a gap too short to sample, and
+    the test passes on the broken code (verified — it caught the mutation
+    on some runs and not others). Chasing stability also cost several
+    false failures: a 2.2 s "blank" that was the product correctly idling
+    after a REFUSED follow-up (the registry allows exactly one queued
+    prompt; when it's spent the scenario never occurs), now handled by
+    retrying the whole scenario and asserting acceptance-while-busy first.
+    Options for a real pin, for whoever picks this up: give the mock an
+    explicit "queue, don't overlay" mode so the boundary has a measurable
+    gap, or pin `openTurns` directly in a Shell-level unit test (Tier 1
+    has no DOM harness today, so that's the larger lift). Until then,
+    treat the boundary behavior as verified by construction + manual
+    observation, not by an automated guard.
+    *2026-07-29 addendum (Step 4.16):* the counter now lives in a pure
+    reducer (`web/src/turn-busy.ts`) and `turn-busy.test.ts` pins the
+    queued-turn arithmetic directly — the caveat's asked-for unit pin,
+    without the DOM-harness lift. The e2e's sampling weakness stands as
+    recorded; the reducer pin is the dependable guard.
+
+---
+
+**From Phase 4, Step 4.15 (moved verbatim 2026-08-12):**
+
+- [x] **Step 4.15 — Beta-channel trust follow-ups (beta tester 002's
+  evaluation, 2026-07-28; triaged with Kyle 2026-07-29)** — **done
+  2026-07-29**: `SECURITY.md` ships in the package (`files` whitelist),
+  tarball repacked + cold-install re-verified + restaged as
+  `../beta/mirafold.tgz` (sha256 `c8a66f4c98e6…`, full value printed in
+  WELCOME.md + `/beta`), and WELCOME.md gained the fingerprint + a
+  "cautious first run" recipe (throwaway dir, credential-less scripted
+  demo first, honest note that the file browser is confined while the
+  agent keeps its terminal powers behind the permission prompts). ⚠ The
+  repack changed the artifact: if a `mirafold.tgz` was uploaded to Drive
+  before this, it must be re-uploaded. The now-actionable slice of the
+  evaluation (the provenance practice went to R.5b; the provenance +
+  install-command concerns otherwise dissolve at R.7's publish):
+  - Ship `SECURITY.md` in the npm package (add to the `files` whitelist;
+    the README cites it and the tarball is where a beta tester looks) —
+    then repack + restage `../beta/mirafold.tgz`.
+  - Publish the staged tarball's SHA-256 where testers can check it:
+    `beta/WELCOME.md` + the site's `/beta` page.
+  - A short "cautious first run" section in `beta/WELCOME.md` (disposable
+    repo with canary files, mock adapter first, relay off) — the
+    evaluation's pilot checklist, offered rather than left for each
+    tester to invent.
+  - Done when: a tester following the public trail finds the security doc
+    inside the artifact, a fingerprint to verify it, and a sane first-run
+    recipe.
+
+---
+
+**From Phase 4, Step 4.16 (moved verbatim 2026-08-12):**
+
+- [x] **Step 4.16 — Whole-repo bughunt batch (2026-07-29, Kyle: "do em
+  all")** — a six-subsystem correctness sweep (adapters / sessions / server
+  core+pty / relay / web core / web components), every finding verified with
+  a concrete failing scenario before reporting, all 27 approved and fixed
+  the same day, each with a pinned regression test (several
+  mutation-proven). The headliners, for the record: (1) an **oversized ws
+  frame crashed the whole daemon** — no per-socket `error` listener, so a
+  >1 MB paste tripped ws's maxPayload into uncaughtException (fix: listener
+  + Tier-2 pin; the socket now closes 1009 alone); (2) a **relay-gate-refused
+  CREATE leaked the session forever** (nothing arms the idle timer before a
+  first attach; 100 phone retries exhausted MAX_SESSIONS for local creates
+  too) — refused creates now reap what they minted; (3) a **viewport frame
+  >~1.5 MB killed the whole pairing** (daemon dial-out cap sat below the
+  relay's 8 MB viewport cap; ws closes the whole socket → dropAll) — cap
+  aligned + pinned against genui-relay's limits in the sibling itest;
+  (4) the **artifact update-in-place liveness race** (a stale navigation
+  deadline killed healthy updates; generation guard + a same-id mock
+  scenario the e2e now drives); (5) both **codex and gemini burned
+  RENDER_GUIDANCE on a failed first turn** (consumed before delivery → zero
+  render calls for the session's life); (6) **bang lifecycle masqueraded as
+  turn grammar** in the registry (a `!` during a pending ask wiped the
+  fleet's allow/deny — the 2026-07-24 bug class through a different door —
+  and a throttle-refused bang broadcast a fabricated `bang_end`);
+  (7) **ws.ts backoff reset on open**, so refused viewports redialed at
+  2 Hz forever (reset moved to the handshaken finishOpen; full relay-path
+  crypto now driven in ws.test); (8) **split/colon-form ANSI leaked through
+  the PTY cleaner** (stateful cross-chunk carry + ECMA-48 param class);
+  (9) replay re-fired **screen-reader announcements for historical turns**
+  on every reload (additive `replay: true` stamp on attach-replayed frames,
+  protocol.ts; Shell suppresses live-only side effects); (10) an
+  **env-misparse family** where garbage WIDENED policy (`MAX_WS_PAYLOAD`
+  NaN = unlimited, `WS_HEARTBEAT_MS` NaN = 1 ms reap-everything loop) —
+  `server/env.ts` envInt/envFlag now parse strictly, 34 sites swept. Plus:
+  checklist clear-to-empty (both adapters), mermaid quoted-comma labels,
+  chart end-label clipping, mock permission_resolved on interrupt,
+  workspace_ls dangling-symlink resilience, pairing-code charset refusal,
+  the sendTampered last-char no-op (the itest's tamper proof now actually
+  proves tamper rejection), stale pong deadline killing successor sockets,
+  the legacy pairing-store carry (newSessionHref), handshake-wedge deadline,
+  useArmedConfirm same-key re-arm, FilesPanel replay-burst coalescing, and
+  the ws.ts close-code mirror now REALLY pinned against genui-relay's
+  contract. One deliberate non-fix, recorded: no client-side prompt-size
+  cap was added (a feature call, not a bug) — a >cap paste now costs one
+  clean socket close instead of the daemon; add the cap only if that UX
+  bites. Full verified ledger: session scratchpad; findings' file:line
+  detail rides each fix's test comments.
+
+---
+
+**From Phase 4, Step 4.18 (moved verbatim 2026-08-12):**
+
+- [x] **Step 4.18 — Test-audit pass (2026-08-11)** — judged the tests, not the
+  product: read the tiering rules (README §8), ran Tier 1 (631/631, ~16s, x2
+  deterministic), Tier 2 (144/144, x3, ~3:48 each, zero flakiness), Tier 3
+  (e2e, 83/83, x2, ~3:20 each incl. build, zero flakiness), and **falsified 10
+  stated invariants by mutating the product** — the
+  E2E counter (replay/reorder), the tool-output cap, the replay-ring byte cap,
+  the fs-explorer realpath jail, checkpoint seq-monotonicity, the WS
+  origin guard, the ws backoff ladder, `cleanRelPath` traversal, and the
+  IP-exact loopback classifier all fail cleanly when their target breaks.
+  **Two real repairs, each mutation-proven after:** (1) `registry-spec.test.ts`'s
+  chart "old-client" test asserted on a hand-built `z.enum(["line","bar"])` — it
+  tested zod, not the product; rewritten to drive the real
+  `clientSchemas.chart`/`registrySchemas.chart` twins (now fails when the chart
+  kind enum changes). (2) `fs-explorer.test.ts`'s "small tree not truncated"
+  test wrote into the already-capped dir (a dead write), listed a fresh EMPTY
+  dir, and never asserted `truncated === false` — the guarantee was untested;
+  rewritten to list a real small tree and pin `truncated === false` + the entry
+  list (now fails on spurious truncation). **Three assertions tightened**
+  (loose bounds → exact, each proven to catch a regression the old form missed):
+  `niceTicks` ticks (Chart.test.ts) and the Gemini honest-model label.
+  **Left as-is, backstopped, reported not repaired** (deleting/weakening waits
+  for Kyle; each is redundant with a stronger test, not a gap):
+  `provider-policy.test.ts` "every cell is a boolean" (the exact agent×kind
+  truth matrix above it is stronger), `version.test.ts` semver-shape regex
+  (the `CLIENT_VERSION===VERSION` + launcher `--version` neighbors have the
+  teeth), the claude-code/gemini truncation *bounds* (exact byte math pinned in
+  `types.test.ts`), and `files-tree.test.ts`'s "too fast" substring. No product
+  bug surfaced; no test was deleted.
+
+---
+
+**From Phase R, Step R.2 (status body) (moved verbatim 2026-08-12):**
+
+- [x] **Step R.2 — The relay service, deployed** — completed 2026-08-09.
+  - Goal: the dumb forwarder, running in the world.
+  - Status: **DEPLOYED and verified in production.** The standalone
+    `mirafold-relay` repo (single source of truth since G.1) is a
+    dependency-light (`ws` only) portable Node process — a PURE forwarder:
+    parses no frames, stores nothing, serves NO app bundle (the phone app
+    loads from the separate static origin, then opens the encrypted
+    socket — the documented trust decision). Hardening: global + per-pair
+    + per-IP connection caps, frame rate limit, heartbeat reaper, max
+    payload, `/health` + 404-everything. Live at `genui-relay.fly.dev`,
+    under our name at **`wss://relay.mirafold.sh`** (cert issued; smoke
+    passes; a real daemon streamed a full turn while `fly logs` showed
+    only connection metadata — the "learned nothing" Done-when, observed
+    in production). Full build/deploy/rename history (incl. the GENUI® →
+    Mirafold naming story) → PLAN-ARCHIVE.md ("Step R.2 — status history"
+    + the 2026-07-17 move).
+  - Closure record: (1) the **cellular-phone pass** — ✅ **FIRST HALF
+    DONE 2026-07-30**: Kyle paired his phone and ran a session over
+    **cellular with wifi off**, on the fixed 0.3.0 build. Notable because
+    his house is rural with near-unusable data — he found one spot with
+    signal and it worked there, so the pass happened on a *marginal* link
+    rather than a strong one, which is the harder case. ✅ **SECOND HALF
+    DONE the same day**: the **wifi→LTE mid-turn flip, run twice** — wifi
+    dropped while a turn was streaming and the session recovered on its own
+    both times. **The cellular-phone pass is CLOSED.** (2) ✅ **Bake the
+    default `MIRAFOLD_RELAY_URL` — DONE 2026-07-30** (`43441ac`,
+    `server/relay/relay-url.ts`): unset now means the hosted relay
+    (`wss://relay.mirafold.sh`) — but ONLY when an entitlement is
+    configured; an unentitled daemon never dials (a gated relay would
+    refuse it 4007 on a widening retry forever) and gets one actionable
+    boot line instead. `MIRAFOLD_RELAY_URL=off` opts out; explicit URLs
+    keep pre-bake behavior verbatim (self-host + dev stub); the app origin
+    defaults to `https://app.mirafold.com` only when riding the baked
+    default. The bake-lands-WITH-the-gate constraint was satisfied — the
+    gate has been ON in production since 2026-07-22. Verified: 9 unit
+    tests (unentitled guard mutation-tested), Tiers 1+2 green, live boots
+    in all four modes. *Follow-up ✅ FIXED same day, Kyle-directed
+    (`92acd37`): production (Fly's proxy) delivers refusal closes ~5s
+    after open — locally 14ms — which defeated relay-client's 400ms
+    pair-confirm, so an invalid/lapsed license logged a false "paired",
+    reset backoff, and churned at ~6s forever. The confirm timer now
+    earns only the "paired" log; the backoff decision moved to close (a
+    refusal never resets, a confirmed ordinary drop still does).
+    Mutation-tested pin + live-verified against production: gaps double
+    1s→16s+ toward the 30s ceiling.* (3) ✅ **Rename completed 2026-08-09:**
+    the product package and GitHub repositories already carried the Mirafold
+    name; the local repositories are now `mirafold/` and `mirafold-relay/`,
+    with the sibling integration test, CI checkout layout, and current
+    workspace paths updated to match. The deployed Fly app names remain
+    `genui-relay` / `genui-relay-staging`, and the `genui-relay v1`
+    key-derivation salt remains frozen as a protocol contract. Verified after
+    the rename: Mirafold typecheck; Tier 1 563/563, Tier 2 143/143, Tier 3
+    82/82; relay typecheck and 38/38 relay tests. **Release-gate follow-up
+    (2026-08-09):** release PR #27 exposed a pre-existing test-only race: the
+    relay-handshake helper waited a fixed number of event-loop turns before
+    closing its healthy socket, so delayed WebCrypto work could miss the
+    backoff reset. The helper now waits for `SocketClient.onOpen()` — the
+    product state transition the assertion actually depends on. The exact
+    test went from 4/20 failures under concurrent load before the fix to 0/20
+    after it; the containing file passed 32/32, Tier 1 passed 563/563, and
+    typecheck passed.
+  - Done when: a phone on cellular (not the home wifi) drives a home
+    session through the deployed relay, and the relay's logs show it
+    learned nothing but connection metadata.
+
+---
+
+**From Step R.4l, item 1 (moved verbatim 2026-08-12):**
+
+    1. **Phone viewport styling + small UX issues** — ✅ **RESOLVED
+       2026-07-22** over three same-day rounds against Kyle's real phone
+       (full round-by-round detail → PLAN-ARCHIVE.md). Round 1: the app frame
+       is pinned (100dvh + `overflow-x: clip` + no overscroll — only the
+       render zone scrolls) and all focusable inputs are ≥16px, which was the
+       actual cause of the sideways drift (sub-16px made iOS zoom on focus
+       and LEAVE the page zoomed); viewport meta gained `viewport-fit=cover`
+       + `interactive-widget=resizes-content`. Round 2: the phone status bar
+       became ONE row with the agent name beside the dot, and **on phone
+       Enter NEVER submits** — newline only, with an in-box ↑ send button
+       (bottom-right, swaps with ■ esc while busy) as the one way to send;
+       desktop Enter-to-send unchanged. Round 3 (Kyle: the on-row fleet
+       folder read as clutter on BOTH platforms — the round-2 column was a
+       miss): **details-on-demand instead of persistent chrome** — the
+       settings card gained a **Session section** (agent, model, folder,
+       usage, session id, daemon version), reachable two zero-chrome ways
+       (the gear, and the **agent chip beside the dot is now a button**);
+       the fleet folder column was removed (desktop hover tooltip restored)
+       and the prompt cwd crumb is DESKTOP-ONLY. Pinned throughout in
+       `phone.e2e.ts`. **Kyle's real-phone look at round 3 came back
+       emphatically positive ("flabbergasted… looks incredible")** — the
+       styling core of this item is validated on the device that opened it.
+       *The theme pill is hidden on phone with the settings picker carrying
+       theme; the Phase S pill lock is desktop-scoped — Kyle confirmed.*
+
+---
+
+**From Step R.4l, item 4 (moved verbatim 2026-08-12):**
+
+    4. **Startup/onboarding flow — redesign discussion. BIG (Kyle's
+       word).** Kyle's sketch (2026-07-13, explicitly not settled — "im
+       not sure"): a staged flow — pick the agent first, then how it's
+       backed (subscription vs. API keys), then the model. Hard
+       requirements he voiced: (a) "simple af"; (b) surface what the
+       user ALREADY HAS — detected credentials make it obvious what they
+       can pick right now; (c) unavailable options stay VISIBLE but
+       clearly unavailable (gray out, not hide — it must read as "an
+       option if you want it"); (d) each unavailable option carries
+       how-to-get-it instructions inline. Raw material that already
+       exists: R.4b/R.4i/R.4k built live-credential detection, the
+       tri-state picker (`live`/`blocked`/`none`), per-row `detail`
+       labels, and where-to-get-it links — this redesign re-stages that
+       material, it doesn't start from zero. One constraint the
+       discussion must start from: the "subscription or keys" step
+       collides with the provider policy (`server/provider-policy.ts`) —
+       Claude/Gemini subscriptions are prohibited in writing (never a
+       choice), while Codex subscription is live locally only as a
+       disclosed gray area (the K.3 disclosed-uncertainty rule — its
+       caveat must ride the option), and no subscription ever rides the
+       relay; the flow has to present that honestly per agent rather
+       than offering a symmetric subscription-vs-keys fork. Also
+       new vs. today: a model-selection step (today model comes from
+       DEFAULT_MODEL/agent config, not the onboarding UI). Next action:
+       a dedicated design discussion with Kyle BEFORE any build.
+       **Status (2026-07-17): the design discussion HAPPENED and the build
+       is scheduled — this item's outcome is Phase N** (the two-step
+       agent → backing picker with probed local-server discovery; the four
+       hard requirements carried into Phase N's charter verbatim). This
+       item closes when Phase N ships; items 1–3 remain open intake.
+
+---
+
+**From Step R.4l, item 5 (moved verbatim 2026-08-12):**
+
+    5. **Pairing lands IN the session you paired from — ✅ DONE 2026-07-27,
+       exactly to the investigated shape (investigation text → PLAN-ARCHIVE.md).** The QR/copy link from a
+       session's status bar now carries `&s=<sessionId>` in the fragment;
+       `main.tsx` rewrites the path to `/s/<id>` before the router reads it,
+       **carrying `location.hash` through the rewrite** (the investigated trap —
+       mutation-tested: dropping the hash was watched to fail the phone e2e,
+       then restored). New pure parser `sessionHintFromFragment` in `ws.ts`
+       validates the id as a full `[\w-]+` token (hostile values dropped
+       whole, never truncated). Mission control's pair button passes no id
+       and keeps landing on the fleet — no special case. The hint is never
+       persisted (one-shot intent). The refused-subscription edge case was
+       decided as KEEP existing behavior: the device lands inside the
+       refused session, where the R.4i notice explains — not bounced to
+       mission control. Verified: unit tests beside the fragment tests, the
+       phone e2e now asserts the paired link lands on `/s/<id>` with no
+       fleet list, full Tier-1 (394) + Tier-3 (57) green.
+
+---
+
+**From Step R.4l, item 6 (moved verbatim 2026-08-12):**
+
+    6. **Phone session died after backgrounding — ✅ FIXED 2026-07-25
+       (`0c993e0`).** Kyle, on Chrome: session open on the phone, switch to
+       another app for a few minutes, come back, and the session was
+       effectively dead — welcome screen, no transcript, Explorer grayed,
+       no end button, prompts going nowhere — while the same session ran
+       fine on his desktop. Cause: the pairing code lived only in per-tab
+       storage, which does not survive a browser discarding a backgrounded
+       tab, and the rebuilt tab can't recover it from the URL either (the
+       fragment is scrubbed on first load, by design). The shell attached
+       to nothing and said nothing about it. Reproduced against a real
+       daemon over the relay on a phone-sized Chrome — freezing the page
+       (CDP `Page.setWebLifecycleState`) recovers, reloading with the store
+       intact recovers, reloading with it dropped gives Kyle's screen
+       symptom for symptom. Fix: the stash is the device's now, bounded by
+       a 7-day expiry (aged-out entries are deleted) on top of the existing
+       per-launch codes; per-tab storage is still read so an already-paired
+       tab keeps working. Pinned by 4 unit tests + a phone e2e that wipes
+       the store, reloads, and asserts the session comes back with its
+       transcript. **Note for whoever picks up item 5** (pair-into-the-
+       session): that work touches the same boot path, so re-run this e2e.
+
+---
+
+**From Step R.4l, item 7 (moved verbatim 2026-08-12):**
+
+    7. **Swipe-to-open the Explorer on phone — DECIDED AGAINST 2026-07-25
+       (Kyle).** Swipe right from the left edge to open the tree, left to
+       close. Mechanically easy (~30–45 min: the panel is already one
+       boolean, plus a touch hook beside `use-escape`/`use-is-phone`, no
+       dependency). Killed on one caveat: iOS reserves a left-edge swipe
+       for browser back-navigation and a page cannot reliably override it,
+       so the gesture would fire history-back instead of opening the panel
+       on iPhones. Kyle: "i dont want to do it if it wont work consistently
+       for iphones." Don't re-propose without a way around that.
+
+---
+
+**From Step R.4l, item 8 (moved verbatim 2026-08-12):**
+
+    8. **Leftovers from the 2026-07-28 whole-repo review — recorded, not
+       fixed (the rest of that review's bug list WAS fixed the same day,
+       eleven `fix:` commits).** Two items survive unfixed, each needing a
+       decision rather than a patch:
+       (a) **A daemon-initiated viewport drop reads as "desktop not
+       reachable" on the phone.** The daemon sends the relay `{t:"close"}`
+       for three distinct reasons — tampered frame, 90s idle reap,
+       viewport-cap refusal — and the relay (stub and sibling service
+       alike) closes the viewport with `CLOSE_BAD_CODE` ("no daemon paired
+       under that id"), which `ws.ts` maps to "Desktop not reachable — is
+       Mirafold running there?" So a live, healthy desktop that rejected a
+       frame tells the phone the desktop is down. Current behavior is
+       PINNED by relay.itest tests, so it may be intended; distinguishing
+       the reasons means a new close code in the relay envelope — a
+       cross-repo contract change (genui-relay's mirrored contract.ts) —
+       so it should ride the next deliberate envelope revision, not a
+       drive-by fix. **Triage (2026-07-28, Kyle): nice-to-have, not a big
+       deal — fix only if really easy, and it isn't (the close frame must
+       grow an optional code field, mirrored + both suites + a relay
+       redeploy). So: ride the next envelope revision, alongside the
+       pairing-id URL move's standing policy. Cheap head start when that
+       happens: the vocabulary already has the right code —
+       CLOSE_OVERLOADED 4004, which ws.ts already maps to a capacity
+       message — the daemon's cap-refusal close just can't name it yet.**
+       (b) **`ClaudeCodeSession.announcedTools` retains ids across
+       interrupted turns — ✅ RESOLVED 2026-07-28, Kyle's call.** Of the
+       three options (leave it; clear on interrupt(), which drops a
+       post-interrupt late result that today completes its row; clear at
+       the TURN BOUNDARY, which only drops a cross-turn straggler — a
+       result for a turn that already ended), Kyle picked the turn-
+       boundary variant. The clear lives with the other per-turn resets
+       in handleResultMsg; Tier-1 pins that a turn-2 result for turn 1's
+       announced id is dropped, never completing the old row.
+
+---
+
+**From Phase R, Step R.5b (the ratified + executed release record) (moved verbatim 2026-08-12):**
+
+- [x] **Step R.5b — Release strategy, locked (all three repos)** — ✅ **DONE
+  2026-07-31: ratified, and EXECUTED the same evening** (Friday 2026-07-31
+  public + publish · Sat–Mon quiet window · Tuesday 2026-08-04 announcement).
+  Full sequence, owners, and rollback levers in the RATIFIED block below.
+  *(a decision to make + write down, not a build; do before R.6's final
+  week)*
+  - Goal: one agreed, written release sequence so R.6/R.7 execute a plan
+    instead of improvising how each piece ships.
+  - Decide and record: (a) **shape of the release** — *first half DECIDED
+    (Kyle, 2026-07-22, in commissioning the R.5 build; sharpened the same
+    day): a **private beta precedes the public splash**, and it runs the
+    **full real billing flow** — NO sandbox, NO comped tokens. The beta
+    starts when the relay's entitlement gate flips ON (the `fly secrets set
+    RELAY_ENTITLEMENT_PUBLIC_KEY` moment) with live Paddle wired; Kyle's own
+    real-card purchase is the first end-to-end, then testers buy real
+    subscriptions riding the 7-day card-required trial ($0 if they cancel
+    in-window; Kyle personally reimburses anyone charged past day 7). The
+    mint script is ops/emergency tooling, not a beta access path.
+    **2026-07-22 (night): the gate is ON and the whole path is proven** —
+    Kyle's real purchase → license key → daemon token exchange → paired
+    through the closed gate; unentitled dials probed refusing 4007. **But
+    tester invites are explicitly gated on a phone-view UI pass first**
+    (Kyle: obvious flaws remain — see R.4l's phone-styling items; the
+    billing machinery being done does not make the product show-ready).
+    Still to decide here: beta size/who, its duration/exit criteria, and
+    how R.5c's user-testing round folds in — **ANSWERED by the 2026-07-31
+    ratification below: duration is Sunday 08-02 + Monday 08-03, the exit
+    criterion is "the public install path works and nothing breaks," and
+    the window IS R.5c's user-testing round; only the tester list itself
+    stays open;* remainder of (a) — staged
+    rollout vs. one splash for the PUBLIC release — **DECIDED 2026-07-25
+    (Kyle): ONE splash, as big as possible.** A soft/staged launch
+    (publish quietly, announce later) was considered and rejected: the
+    pre-public work gates going public at all, not announcing loudly, so
+    a quiet period pays nearly the full launch cost for almost none of
+    the audience; the channel list was instead expanded (R.6's
+    launch-channel prep + Product Hunt in R.7's sequence);
+    (b) **per-repo mechanics + order** — `genui-shell` (repo public + `npm
+    publish` + versioning/cadence), `genui-relay` (deploy pipeline, **when
+    the repo flips public — owed to K.1, which relicensed it MIT**, when the
+    entitlement gate flips ON, when the default `MIRAFOLD_RELAY_URL` bake
+    lands — see R.2), `mirafold-site` (checkout button flip, demo swap); (c)
+    **rollback / kill-switch** for each (the relay gate and per-daemon relay
+    URL are the levers) — *for the npm package the rollback move is
+    re-pointing the `latest` dist-tag at the previous good version
+    (+ `npm deprecate` on the bad one), never an unpublish (npm barely
+    permits it and installed users aren't affected either way); for the
+    relay it's `fly deploy --image <prev>` (already in
+    `mirafold-relay/DEPLOY.md`); for the site it's the Pages one-click
+    deployment rollback (KV does NOT roll back with it — see R.6's KV note)*; (d) how the codebase/npm/GitHub rename (R.2) is
+    sequenced into all of the above; (e) *already decided 2026-07-15
+    (K.9): contributor policy is **DCO**, not CLA* — `Signed-off-by` per
+    commit, CONTRIBUTING.md landed in both repos that day; what remains
+    for this step is only the mechanics: enable the GitHub DCO status
+    check on both repos as part of the public flip.
+  - **CI hardening at the flip (from the 2026-07-21 audit of the C.1 work):**
+    once a repo is public, any fork PR's test suite runs on the CI runner, so
+    the CI's trust posture matters. Already in place from C.1: the token is
+    `permissions: contents: read` (read-only — a malicious dependency install
+    script can't push to the repo) and no secrets are used (Tier 4 excluded,
+    credentials forced empty). Do AT the flip: (i) re-enable the cross-repo
+    relay itest now that `genui-relay` is public and checkout-able — drop the
+    `tsconfig.ci.json` exclusion + the Tier-2 `find` filter and add a sibling
+    checkout (see Phase C's carried-forward list + `tsconfig.ci.json`);
+    (ii) optionally SHA-pin the
+    `actions/checkout` / `actions/setup-node` steps (they're pinned to `@v4`
+    tags today — fine for GitHub's own official actions, stricter as a full
+    commit SHA). No secret was ever added, and none should be — the "no
+    provider credential in repo secrets" bound (C.1) is absolute.
+  - **Dependency-alert sweep at the flip (2026-07-22 audit):** before EACH
+    repo goes public, clear its open Dependabot alerts — open alerts on the
+    default branch become publicly visible the moment the repo does, and
+    they're a stranger's first impression of the project's hygiene. The
+    site repo already carries this in its pre-public hardening trio; this
+    line extends the same sweep to **this repo and `genui-relay`**. (Shell
+    repo swept 2026-07-22: `shell-quote` ≥1.9 + `@hono/node-server` ≥2.0.5
+    forced via yarn resolutions — the MCP SDK still pins hono 1.x upstream,
+    so the resolution stays until the SDK moves; all tiers green on 2.0.11.)
+    **2026-07-25: shell repo now at ZERO open alerts** — transitive
+    `postcss` 8.5.16 → 8.5.23 (GHSA-r28c-9q8g-f849, high, dev-scope; via
+    vite, so a lockfile re-resolve only, no resolution needed) landed as
+    `c660130`, typecheck + all tiers green (369/103/52), alert #4 verified
+    "fixed" via the GitHub API. The `genui-relay` half was verified the
+    same day: alerts confirmed ENABLED on that repo (API 204) with zero
+    open, and a local `npm audit` at `9f35e2d` found 0 vulnerabilities —
+    clean today; still RE-verify at its public flip, since new advisories
+    can land anytime.
+  - **EAR notification email at the flip (added 2026-07-27, from the K.11
+    amendment):** when the repos go public, send the one-time
+    §742.15(b) email to crypt@bis.doc.gov + enc@nsa.gov with the repo
+    URLs. $0, five minutes, settles the notification question regardless
+    of which reading of the 2021 rule is right (detail in K.11's note).
+  - **Gate on the relay flip (2026-07-15 audit): ✅ SATISFIED 2026-07-30.**
+    Before `genui-relay` goes public in (b), run a dedicated security-audit
+    pass over that repo — public security-marketed code gets adversarial
+    readers on day one. *Done: a dedicated isolated-adversarial read of all
+    ~850 lines (the checklist-driven 07-27 tri-repo audit and the 07-29
+    bughunt were a different lens each; this one asked only "hostile reader,
+    how do I hurt the service"). **No new exploitable findings** — the three
+    prior waves closed the real vectors (the malformed-URL process crash
+    07-27, the byte-rate + backpressure gaps 07-27, the per-frame
+    log/re-forward amplification 07-29); the entitlement verifier is
+    correctly ordered (no attacker JSON reaches the parser pre-signature),
+    every send is readyState-guarded or error-caught, and the prod
+    dependency surface is exactly `ws` with `npm audit` clean. Accepted
+    residuals, all safe: refused-log `origin` is verbatim-but-JSON-escaped
+    attacker text (ops-useful, size-capped); the churn-gate sweep needs the
+    heartbeat (ARCHITECTURE §10, off-by-default gate); the WS upgrade
+    completes before the capacity cap refuses (inherent to clean
+    close-codes, socket-cap bounded). Suite 38/38. The relay may flip on
+    schedule.*
+  - **Release provenance (adopted 2026-07-29, from beta tester 002's
+    evaluation):** a public repo alone doesn't let anyone verify the
+    published npm package was built FROM it — the two are separate uploads
+    with no link, and the package ships compiled bundles. Adopt as standing
+    release practice, first release included: (i) publish via a GitHub
+    Actions **release workflow** using npm **trusted publishing** (npmjs.com
+    configured to accept `mirafold` publishes only from that workflow —
+    identity-federated, NO stored npm token, so the no-secrets-in-CI bound
+    holds and a stolen npm password can't publish) with
+    `npm publish --provenance` (machine-signed attestation binding the
+    package to the exact public commit + workflow; users verify with
+    `npm audit signatures`, README gets the one-liner); (ii) a **signed git
+    tag** per release (SSH signing key — Kyle's, minutes to set up) with the
+    tarball's **SHA-256 in the tag message** and in the GitHub Release
+    notes. This changes R.7's publish move: Kyle pushes the signed tag and
+    the workflow publishes — no hand-run `npm publish`. Kyle's-hands parts:
+    the npmjs.com trusted-publisher form (~5 min, walked one step at a
+    time) and generating/registering the signing key. Caveat: provenance
+    requires a public repo, so the end-to-end proof fires at the first real
+    publish (launch morning) — same class as R.7's existing `npx` check;
+    everything short of that rehearses beforehand.
+    *Status 2026-07-30: the release workflow LANDED* —
+    `.github/workflows/release.yml` (`52ca799`): tag push (v*) → tag↔
+    version check → typecheck + Tier 1 → pack with the tarball SHA-256 in
+    the job summary (for the Release notes) → `npm publish --provenance`;
+    `contents: read` + `id-token: write` only, no stored token, fails
+    closed until the trusted-publisher form is done. `workflow_dispatch`
+    is the dry-run rehearsal; `npm pack` + `npm publish --dry-run` also
+    rehearsed locally on 0.2.0. *Both Kyle-hands parts ✅ DONE
+    2026-07-30:* the npmjs.com trusted-publisher form (GitHub Actions ·
+    `mirafold/mirafold` · `release.yml` · env blank · publish only,
+    stage off) and the dedicated ed25519 signing key (repo-local git
+    config signs all tags, sign smoke-tested; public half registered on
+    GitHub as a signing key). The publish path is fully set up; its
+    end-to-end proof fires at the first real publish, per the caveat
+    above.
+  - **DRAFT release sequence (2026-07-29, assistant — Kyle to ratify;
+    "launch asap" is the directive it serves):**
+    - *Preconditions, any order, all before T-0:* 4.15 ✓ (done);
+      provenance release workflow landed + build/pack rehearsed (publish
+      itself fires at T-0); npm trusted-publisher configured (Kyle,
+      npmjs.com form) + SSH signing key registered (Kyle); Dependabot
+      re-verified zero on BOTH code repos; the relay repo's dedicated
+      security-audit pass (gates its flip); tracked-docs disclosure review
+      (Kyle reads what goes public: BUSINESS.md, PLAN + archive, git
+      history); theme value guards landed ✅; Paddle payout details ✅ (set
+      up — confirmed 2026-07-30); launch copy + Product Hunt draft ready ✅;
+      R.6's real-hardware checks done.
+    - *T-0 morning, in order:* (1) `mirafold/mirafold` public → enable the
+      DCO check + re-enable the cross-repo relay itest in CI; (2)
+      `mirafold-relay` public (only if its audit passed); (3) Kyle pushes
+      the signed release tag → the workflow publishes to npm with
+      provenance over the 0.0.1 placeholder; (4) verify cold:
+      `npx mirafold` + `npm audit signatures`; (5) site stays as-is (its
+      install line `npm i -g mirafold` becomes true at step 3; checkout
+      already live); (6) the splash: X + Show HN + Product Hunt +
+      r/ClaudeAI + r/LocalLLaMA. Same week: newsletter submissions,
+      awesome-list PRs, the BIS §742.15(b) email, the provider-terms
+      re-check (R.7's standing item).
+    - *Rollback levers:* npm = re-point the `latest` dist-tag + deprecate
+      (never unpublish); relay = `fly deploy --image <prev>`; site = Pages
+      one-click rollback (KV does not roll back with it).
+    - *Rename (d): resolved* — the GitHub org/repo and the npm name are
+      already `mirafold`; the internal folder/Fly names are non-gating
+      (umbrella note 2026-07-11).
+    - **AMENDMENT (Kyle, 2026-07-29): the flip and the splash separate.**
+      Everything goes truly public QUIETLY first — repos public, signed
+      tag pushed, workflow publishes to npm, verifications run — then a
+      **live-fire window of AT MOST 2 days** with a few more personally-
+      invited testers installing via the real public path
+      (`npm i -g mirafold`), then the one big splash, unchanged in shape.
+      This amends (not reverses) the 2026-07-25 "ONE splash" decision:
+      what was rejected then was a quiet launch *strategy*; this is a
+      bounded smoke-test window with the single announcement event kept.
+      It also converts R.7's two publish-only checks (`npx mirafold`,
+      `npm audit signatures`) into pre-splash facts, and in practice it IS
+      R.5c's user-testing round — real users, real hardware, the exact
+      artifact the public gets. `/beta` is NOT removed at the flip: it
+      becomes a short "we're live — `npm i -g mirafold`" note, so the link
+      already printed in every tester's WELCOME.md keeps working and
+      upgrades them to the public path. Every pre-PUBLIC gate still
+      precedes the quiet flip (tracked-docs/history review, relay audit
+      before ITS flip, Dependabot re-verify, provenance setup) — quiet
+      defers only the announcement, never a gate.
+    - *Still Kyle's calls, marked open:* (i) ✅ **DECIDED 2026-07-30: the
+      public cut is 0.3.0** — bumped on main (`b63941c`); `v0.3.0` is the
+      launch tag; (ii) ✅ **DECIDED 2026-07-31: the dates — see the
+      ratification below.**
+  - ## ✅ RATIFIED 2026-07-31 (Kyle) — this is the plan, no longer a draft
+    Every precondition above is MET, each measured rather than read off a
+    doc: the release workflow rehearsed successfully (run `30630399899`,
+    `workflow_dispatch` on `main`, **success in 2m34s**, never
+    authenticated); npm trusted publisher + ed25519 signing key configured
+    2026-07-30; the relay repo's dedicated security-audit pass clean
+    2026-07-30; the tracked-docs disclosure read done 2026-07-31, with Kyle
+    deciding to **publish everything as tracked — no trims, no
+    move-private**; Dependabot zero open on both code repos (re-verified at
+    the flip, per the sweep note above); LTE phone pass, theme guards,
+    Paddle payout, launch copy + Product Hunt draft all done.
+
+    **The dates (moved EARLIER by one day — Kyle, 2026-07-31 evening, after
+    ratifying Saturday the same day; see the note below):**
+    - **Friday 2026-07-31, evening** — everything goes public and gets
+      published. No announcement.
+    - **Saturday 08-01 + Sunday 08-02 + Monday 08-03** — the quiet window. A
+      handful of personally-invited testers install via the real public path
+      (`npm i -g mirafold`) and use it. This IS R.5c's user-testing round.
+    - **Tuesday 2026-08-04, US morning** — the single announcement: X, Show
+      HN, Product Hunt, r/ClaudeAI, r/LocalLLaMA.
+
+    *On the window: it was first set at Saturday night → Tuesday (~2.5
+    days), then moved a day earlier to Friday night → Tuesday (~3.5 days)
+    when Kyle asked whether the longer gap hurt. It does not: the window
+    exists so invited testers exercise the real public install path before
+    strangers do, and more days serve that purpose rather than eroding it.
+    Nothing decays while it sits — the package is on npm, the repos are
+    public, and nobody is looking. Both figures stretch the amendment's "AT
+    MOST 2 days" bound, which was self-imposed; these dates supersede it.
+    Checked and dismissed as non-factors: staleness (neither Hacker News
+    nor Product Hunt weighs how long something has been available — Show HN
+    only requires that YOU are showing something people can try, and the
+    443-commit history was already public-facing either way) and
+    pre-emption (a stranger posting the link first is negligible; the one
+    plausible path is an invited tester, addressed by telling them it is
+    not announced until Tuesday). The residual risk, accepted: Hacker News
+    gives a URL roughly one shot, so if someone else posts it and it lands
+    well, that run is spent and Kyle would not be in the thread — the
+    fallback is that `mirafold.com` is a separate URL from the repo.*
+
+    ### ✅ EXECUTED — Friday 2026-07-31 evening. Mirafold is PUBLIC and LIVE.
+    Measured at each step, not assumed:
+    - Both repos **public** (API-confirmed): `mirafold/mirafold`,
+      `mirafold/mirafold-relay`. Dependabot **0 open on both** at the flip.
+    - DCO sign-off app installed on both (shows on PRs; it does not BLOCK a
+      merge until branch protection lands — deliberately deferred to after
+      Tuesday so launch weekend keeps a friction-free hotfix path).
+    - Signed tag **`v0.3.0`** pushed at commit
+      **`910cb246f04606a0e7f0274358122eabbbe43fea`**. Release run
+      **`30663563802`** — success in **1m32s**, every step green through
+      "Publish (tag push — provenance over trusted publishing)".
+    - **`mirafold@0.3.0` is on npm.** Published tarball SHA-256
+      **`804bd065ba51b156c59d8f2a7bf1e5a50bffa547a031c7830cf1164ee7f60518`**
+      (registry download re-hashed locally — matches CI byte for byte).
+      17 files, 5,063,377 bytes unpacked.
+    - **Provenance verified end-to-end**, which is the whole point of R.5b:
+      the SLSA attestation binds `pkg:npm/mirafold@0.3.0` to source
+      `git+https://github.com/mirafold/mirafold@refs/tags/v0.3.0`, commit
+      `910cb246…`, built by `.github/workflows/release.yml`. A skeptic can
+      now prove the package came from the public source. `npm audit
+      signatures` on a cold install: 116/116 verified registry signatures,
+      16 verified attestations, 0 invalid, 0 missing.
+    - **Cold-install proof** (fresh dir, package pulled from the public
+      registry, no repo checkout): `--version` → `0.3.0`; daemon boots,
+      serves `HTTP 200` with `<title>Mirafold</title>`; the per-launch auth
+      token → cookie redirect works; a busy port rolls to the next one; with
+      no license key it correctly says remote access is off. The
+      `@parcel/watcher` install-script warning appeared exactly as the
+      README documents.
+    - `mirafold.com/beta` rewritten to the public path and **verified live**
+      (site commit `7e46469`): `npm i -g mirafold`, `npm audit signatures`,
+      the new SHA-256, and a link to the now-public repo. Every tester's
+      existing WELCOME.md link keeps working and upgrades them.
+
+    **Still owed after this (see the resume list in ROADMAP.md):** the
+    GitHub Release for `v0.3.0` with the SHA-256 in the notes (Kyle's
+    hand-made step, per the workflow's own comment); re-enabling the
+    cross-repo relay itest in CI now that the relay is public; tester
+    invites for the quiet window; Tuesday's announcement; then branch
+    protection + the `next`/`release/x.y.z` model, and the BIS §742.15(b)
+    email.
+
+    **Launch-evening steps, in order, with owner.** Assistant runs 1, 5, 7, 8;
+    Kyle runs 2, 3, 4, 6 — all four are GitHub-settings or signing-key
+    actions, his hands by the privileged-mutation rule.
+    1. Confirm Dependabot still zero on BOTH code repos — *assistant*.
+    2. `mirafold/mirafold` → public — *Kyle* (GitHub settings).
+    3. `mirafold/mirafold-relay` → public — *Kyle* (GitHub settings).
+    4. Enable the DCO sign-off check on both repos — *Kyle*.
+    5. ~~Re-enable the cross-repo relay itest in CI~~ — ✅ **DONE 2026-08-02**
+       (*assistant*); see the resolution note under "Owed at the public flip"
+       below. ~~⬜ Not yet opened as a PR, so not yet exercised on a runner.~~
+       *(Stale — it WAS exercised: `f30a6dc` was pushed to `main` 2026-08-02
+       and its CI run passed on the real runner, sibling relay checkout and
+       all. Verified from the run list 2026-08-07.)*
+    6. Push the signed `v0.3.0` tag — *Kyle*. **This is the publish**: the
+       tag push triggers `release.yml`, which builds and runs
+       `npm publish --provenance`. No hand-run `npm publish`, ever. Expect
+       ~2m34s, per the rehearsal.
+    7. **Verify the same night, before bed — non-negotiable.** Cold install
+       the way a stranger would (`npx mirafold`) + `npm audit signatures` —
+       *assistant*. Publishing and sleeping unverified would leave a broken
+       package installable for hours undetected; the publish is the
+       irreversible move and this is what tells us whether it went wrong.
+    8. `mirafold-site` `/beta` becomes a short "we're live —
+       `npm i -g mirafold`" note, so the link already printed in every
+       tester's `WELCOME.md` keeps working and upgrades them to the public
+       path — *assistant*.
+
+    **Tuesday:** post everywhere. Before posting, search `hn.algolia.com`
+    for "mirafold" — thirty seconds, removes a variable. (The odds of a
+    stranger posting it first during the quiet window are negligible and
+    were overstated in an earlier draft of this note: `mirafold@0.0.1`
+    already exists on npm, so 0.3.0 is a version update rather than a
+    new-package feed event, and a zero-star repo going public is invisible
+    to the star-velocity scrapers. The one plausible leak is an invited
+    tester sharing it — so the invite says "not announced yet, please don't
+    post it anywhere until Tuesday.")
+
+    **Same week, after the announcement:** newsletter submissions,
+    awesome-list PRs, the BIS §742.15(b) email to crypt@bis.doc.gov +
+    enc@nsa.gov with the repo URLs, and R.7's standing provider-terms
+    re-check.
+
+    **Rollback levers, unchanged:** npm = re-point the `latest` dist-tag +
+    `npm deprecate` (NEVER unpublish); relay = `fly deploy --image <prev>`;
+    site = Pages one-click rollback (KV does not roll back with it).
+
+    **Still open, non-gating:** WHO the invited testers are for the Sunday/
+    Monday window — may simply be the existing beta testers, told to
+    reinstall via `npm i -g mirafold`. Kyle's call, answerable any time
+    before Saturday night.
+
+    **Understood and accepted:** step 6 is the first irreversible move in
+    this project. An npm publish cannot be withdrawn, and a public repo
+    exposes all 443 commits plus every tracked doc permanently.
+  - Done when: a written release-sequence exists that R.6 and R.7 just
+    follow, with no open "how do we actually ship this" questions —
+    ✅ **MET 2026-07-31** by the ratification above; only the non-gating
+    tester-list question remains.
+
+---
+
+**From Step R.5c, tester-002 closure (moved verbatim 2026-08-12):**
+
+  - **Tester-002 thread CLOSED 2026-07-30** (the point-by-point discussion
+    Kyle held open since 07-28; ROADMAP launch item 5). Remaining points
+    resolved, standard practice applied rather than bespoke decisions:
+    **"What is real"** — accurate, and re-verified in passing today (the
+    loopback bind and the `!` cwd confinement + caps both came up
+    independently); noted, NOT used as external validation, since the
+    tester never ran the product and citing a pre-install vetting doc as a
+    security review would overstate it. **Concern 2** (SECURITY.md/tests/
+    docs absent from the tarball) — SECURITY.md ships since 4.15; tests,
+    plans and build instructions deliberately do NOT ship in an npm
+    package, and the README's citations resolve when the repo goes public
+    at R.7. **Concern 3** (the trust boundary is large) — the actionable
+    half is now a **"Running it safely" section in `SECURITY.md`**, which
+    ships inside the package: leave the auth token on, never put the
+    daemon behind a proxy or a LAN bind (the relay is the one supported
+    remote path), treat `!` as your shell, open it somewhere you'd give an
+    agent a terminal, keys stay server-side. Their pilot-only cautions
+    (skip the relay, no keys in `.env`) were deliberately NOT parroted —
+    `.env` in the launch directory IS the supported place for keys.
+    **Recommended pilot preconditions** — all four are satisfied by the
+    launch mechanics already planned: public source at the exact commit
+    (R.7), a signed tag + published fingerprint (R.5b's signed `v0.3.0` +
+    `npm publish --provenance` over trusted publishing), SECURITY.md +
+    lockfile + build instructions in the public repo, and native-install
+    clarity — now written into the README's native-module note, which had
+    claimed no install scripts at all while every npm-12 user sees a
+    `@parcel/watcher` warning (measured: its script is a conditional
+    no-op, prebuilts ship for every mainstream platform). **Bottom line** —
+    their sole blocker was supply-chain provenance, which dissolves at the
+    flip; no separate work. *One item deliberately left alone: the site
+    claims open source in the present tense while the repos are private.
+    That is true-by-R.7 and Kyle has made no decision to change the copy;
+    it resolves itself at the flip.*
+
+---
+
+**From Step R.5c, finding #5 (Gemini 0.53.0) (moved verbatim 2026-08-12):**
+
+  - Finding #5 (assistant, 2026-07-30, R.6's live-Gemini check — **LAUNCH
+    BLOCKER, FIXED same day**): the `gemini-cli` adapter could not complete a
+    turn on Gemini CLI **0.53.0** (written against 0.51.0). It presented as
+    two failures — a refusal to run headless in an "untrusted" folder, and
+    `IneligibleTierError: This client is no longer supported for Gemini Code
+    Assist for individuals` — but they are **one cause**: 0.53.0 does not load
+    a project's `.gemini/settings.json` for an untrusted folder. That file is
+    where the adapter writes `security.auth.selectedType: "gemini-api-key"`,
+    so the selection was ignored and the CLI fell back to the USER-scope
+    choice; any user who ever logged in interactively (`oauth-personal`) then
+    died on the free-tier client path Google retired, while holding a valid
+    `GEMINI_API_KEY`.
+    **Fix (P.6b):** the workspace-trust question is asked ONCE per folder
+    through the shell's own permission strip — `permission_request` /
+    `permission_resolved`, both existing message types, so the wire protocol
+    is untouched and the ask is shell-owned (the agent can't paint or fake
+    it). A yes is remembered in a new daemon record,
+    `<state>/trusted-workspaces.json` (`server/sessions/workspace-trust.ts`),
+    and carried into the child as `GEMINI_CLI_TRUST_WORKSPACE=true`. A no runs
+    nothing and says why; the session stays usable. Asked once per workspace,
+    ever — matching what their own terminal `gemini` does.
+    **Measured negatives, both of which cost a round of wrong belief:**
+    `--skip-trust` is NOT equivalent — it lets the run proceed but still
+    doesn't load project settings, so auth falls back and the turn dies
+    (proven in a known-good workspace). And `GEMINI_DEFAULT_AUTH_TYPE=
+    gemini-api-key` does nothing at all on 0.53.0 — proven by the case with
+    no project settings + trust + that variable, which still failed. *An
+    earlier draft of this finding named that variable as the fix; it was
+    wrong, and only isolating one variable at a time exposed it.*
+    **Why (b) — reusing `trusted-repos.json` — was proposed and rejected:**
+    that list is the git-programs escape hatch, nothing in the product ever
+    writes it, and it is empty for essentially every project, so it would
+    have left Gemini broken while looking fixed.
+    **Verified:** a real Gemini turn end-to-end through the adapter (trust ask
+    → allow → `PROBE OK`, with usage), on Kyle's real home and its
+    `oauth-personal` login. Tests: `workspace-trust.test.ts` (containment,
+    persistence, malformed/disabled record) and two adapter tests pinning the
+    gate — nothing spawns before the answer, the yes reaches the child as the
+    trust env var and is remembered, a no runs nothing — mutation-checked
+    (defeating the gate fails both).
+    *Standing caveat: Gemini is the most volatile of the three engines —
+    0.51→0.53 both retired an auth path and added this gate in weeks. R.6's
+    live-Gemini check should re-run after Google releases; the other two
+    engines have needed nothing like it.*
+
+---
+
+**From Step R.5c, finding #4 (version-manager 404) (moved verbatim 2026-08-12):**
+
+  - Finding #4 (Kyle, 2026-07-30, his own machine — **LAUNCH BLOCKER, fixed
+    same day**): the first time Kyle installed the tarball the way testers
+    do (`npm i -g mirafold.tgz`) instead of running `yarn dev`, onboarding
+    died the moment it navigated to a session URL — a `NotFoundError` from
+    `send`, and no browser session could ever start. **Cause:**
+    `res.sendFile(path.join(DIST, "index.html"))` passes an ABSOLUTE path,
+    and send's default `dotfiles: "ignore"` policy inspects *every segment*
+    of it. `npm i -g` unpacks into the active Node's prefix, which for nvm
+    (`~/.nvm/…`), asdf, volta and fnm carries a dot-segment — so the SPA
+    fallback 404'd for every user on a version manager, i.e. most of the
+    target audience. `GET /` kept working (express.static passes a root, so
+    only the request path is checked), which is why it read as "some people
+    can't get past onboarding" rather than "the server is broken".
+    **Fixed:** `res.sendFile("index.html", { root: DIST })` in
+    `server/index.ts` and `server/relay/relay-stub.ts` — the policy then
+    applies to the relative part only. **Regression:** a Tier-3 test
+    (`server/testing/launcher.e2e.ts`) copies the built `dist/` +
+    `dist-server/` into a manufactured `.nvm-like/` directory, boots the
+    daemon from there and asserts `/s/:id` → 200 with the real app shell;
+    mutation-checked (restoring the old line reproduces the 404).
+    **Why three verification layers missed it:** the repo checkout has no
+    dot-segment so Tier 3 structurally cannot see it; `yarn dev` serves the
+    SPA from Vite, so the daemon's fallback route is never exercised in
+    dev; and the cold-install check booted the daemon and read `--version`
+    without fetching a session URL. The lesson is narrow and worth keeping:
+    **only exercising the packaged artifact from a realistic install path
+    proves the packaged artifact.** Re-packed and re-installed; Kyle
+    confirmed a real session with his Claude API key on the fixed build.
+    `beta/mirafold.tgz` re-cut (sha256 `8f829513…`, was `a9fe4152…`) and
+    `beta/WELCOME.md` updated to match; ⬜ the Drive copy still serves the
+    broken build until Kyle re-uploads.
+
+---
+
+**From Step R.5c, finding #3 (phone new-session hang) (moved verbatim 2026-08-12):**
+
+  - Finding #3 (Kyle, 2026-07-24, real phone — SERIOUS): starting a NEW
+    session on mobile hung on "connecting…" forever, picker never showed;
+    desktop fine. Root cause: the in-session "new" button opens a fresh tab
+    (`target="_blank" rel="noopener"`), and a noopener new tab inherits
+    neither the URL fragment nor sessionStorage — so on the relay path the
+    new tab had no pairing code, fell back to a daemon-less local ws://, and
+    hung. Desktop's local fallback IS the daemon (worked); mobile resume
+    worked (fleet links stay in-tab). Diagnosed from the daemon
+    flight-recorder + relay structured logs. Fixed: `newSessionHref()`
+    re-encodes the relay target into the new tab's fragment (PR #6, merged
+    to main; unit 322 + round-trip invariant test). DEPLOYED: the
+    git-integrated Cloudflare Pages project auto-rebuilt on merge —
+    app.mirafold.com now serves the fixed bundle (index-D2UVf2h9.js,
+    confirmed live). Awaiting Kyle's real-phone confirmation.
+
+---
+
+**From Step R.5c, finding #2 + the same-day overlay sweep (moved verbatim 2026-08-12):**
+
+  - Finding #2 (Kyle, 2026-07-23, his MacBook): the onboarding picker sat
+    flush against the browser window's top/bottom on a short viewport (a
+    ~600px un-maximized Mac Chrome window) instead of floating as a nested
+    modal. Root cause: `.onb-card` had `max-width` but no `max-height`, so
+    it overflowed the centered overlay. Fixed same day: `max-height: 100%`
+    + internal scroll as the hard floor (the overlay's 24px gutter is now
+    always visible), plus an `@media (max-height: 700px)` compact layout
+    (44px glyph, tighter paddings) so typical content FITS at ~600px.
+    Verified by computed-style probe at 607px and 769px viewports + all
+    tiers green; worst-case content (3 credential-less agents, longest
+    hints) scrolls internally with the gutter intact at any height.
+    *(Superseded 2026-07-25: the fleet page's `zoom: 1.15` — a cockpit
+    polish landing — inflated the card 15% while this breakpoint kept
+    measuring the real viewport, so the scrollbar showed at every height
+    under ~890px. The binary compact tier is replaced by a fluid
+    `--onb-squeeze` driver: every vertical metric interpolates full→compact
+    with window height (zoom factor divided out of the vh math), the
+    credentialed picker fits scroll-free down to ~645px real, and scroll
+    remains the last resort for hint-heavy or tiny-window states. E2e pins
+    the ramp — an all-rows-ready daemon swept through it, asserting no
+    internal scroll AND that the glyph actually compressed. `d8abc62`.)*
+  - Finding #3 (proactive sweep after #2, same day): the settings and pair
+    dialogs share the exact defect #2 found in the onboarding card — the
+    S.4 card idiom had `max-width` but no `max-height`. Measured live at a
+    560px viewport: settings (583px natural — the theme list) overflowed
+    the window by 11px top AND bottom; pair (430px) fit but was one short
+    window from the same. Fixed with the same two-line cap on the shared
+    idiom (`max-height: 100%` + internal scroll — inert until a card would
+    overflow). Sweep completeness: these were the ONLY three
+    fixed-position overlay surfaces in the shell (onboarding, settings,
+    pair); the in-session model picker, question component, permission
+    bar, and demo banner are all in-flow and immune. Probed at 560/769,
+    e2e + unit green. NOT done (deliberately): a compact-styles pass for
+    the settings card at short heights — it would touch the theme picker's
+    layout, which is Kyle-locked territory; internal scroll is the
+    accepted behavior there.
+
+---
+
+**From Step R.5c, beta-tarball era mechanics + status (2026-07-23 → 07-25) (moved verbatim 2026-08-12):**
+
+  - **Opened 2026-07-23.** Mechanics locked with Kyle: distribution is a
+    hand-sent `npm pack` tarball (v0.1.0, shell @ 50950a7 / relay @ 3f92992
+    deployed) — NOT npm; testers subscribe FOR REAL via the direct `/pay`
+    link (never comped — Kyle's standing rule; 7-day refund is the out);
+    feedback arrives ad hoc in any form — Kyle collects and forwards it in
+    clusters, so intake here means triaging those clusters as they land,
+    not policing a channel. Welcome note drafted (install incl. the
+    node-pty/npm-scripts fix, credentials, phone-over-cellular ask, the
+    never-paste-boot-output rule, log-file-is-safe-to-attach). That gate CLEARED
+    same day: Kyle lifted the blackout entirely — the full site is public
+    again, all pages verified 200, and the welcome note now lives on-brand
+    at mirafold.com/beta (noindex, unlinked; testers get the direct link).
+    The tarball was also rebuilt on the @lydell/node-pty swap, so install
+    is two commands with no workaround. NOTHING blocks the first invite.
+  - **First finding, fixed same day (2026-07-23):** Kyle, running Codex via
+    OpenRouter, saw the literal stand-in "codex" in the status bar's model
+    slot (Claude showed "default", Gemini "gemini" — same pattern). Kyle's
+    call: a temporary model name that isn't true is dishonest — show
+    NOTHING until the real one is known. Landed as shell @ 003388c:
+    `modelName` is undefined until configured/engine-reported, the wire's
+    usage + fleet-row `model` fields went optional, and the status bar +
+    fleet row render the slot only when known. Gemini's "auto" stays (a
+    genuine configured router-mode value, still refined per turn). All
+    three tiers verified; tarball rebuilt at that commit.
+  - **2026-07-25 status:** version bumped to **0.2.0** with the `engines`
+    Node floor raised to **>=22** (`52ffdaf` — the floor now matches what
+    we actually develop and test on; README, mirafold.com's install note,
+    /beta, and the beta-folder WELCOME.md all state Node 22+ and name
+    `mirafold-0.2.0.tgz`). Tarball rebuilt at `d8abc62` (includes the
+    phone rail fix + onboarding squeeze), staged at
+    `../beta/mirafold-0.2.0.tgz`, cold-install + boot smoke-tested.
+    **Distribution channel (external fact):** testers get it via Kyle's
+    Google Drive link — replace-in-place version upload keeps the link
+    stable; Drive keeps the old display name on content swaps, so the
+    rename to `mirafold-0.2.0.tgz` is a manual step (advised, link
+    survives it). **Uptake (Kyle, 2026-07-25): almost no testers have
+    actually tried it yet** — the stable-link swap was chosen so the
+    already-sent link serves the new build. Also flagged on push: GitHub
+    reports 1 HIGH Dependabot alert on the default branch (dependabot/4);
+    a dependency bump was already in flight in a parallel session the
+    same afternoon. *(Resolved same day: that bump landed as `c660130` —
+    alert #4 "fixed", zero open alerts on the repo; detail in R.5b's
+    sweep note.)*
+  - *(An interim 2026-07-25 evening rebuild — postcss-only delta, verified
+    cold-install — was superseded by the session-end rebuild below; note →
+    PLAN-ARCHIVE.md.)*
+  - **npm-audit noise on install — investigated and settled
+    (2026-07-25):** installing the tarball into a *local project
+    directory* reports 4 moderate advisories, all one chain
+    (`@hono/node-server` <2.0.5 — Windows-only path traversal in
+    `serve-static` — reached transitively via `@modelcontextprotocol/sdk`,
+    which `@anthropic-ai/claude-agent-sdk` also requires as a peer).
+    **Testers never see it: npm skips audit on global installs**, so the
+    documented `npm i -g ./mirafold-0.2.0.tgz` prints no advisory at all
+    (verified against a clean prefix). And it cannot be fixed from our
+    side anyway: the MCP SDK still declares `^1.19.9` at its latest
+    (1.29.0), hono 1.x has no patched release (1.19.15 is the last), a
+    published package's own `overrides` field is ignored by npm (verified
+    by packing one and installing it), and **npm v12 no longer reads an
+    `npm-shrinkwrap.json` shipped inside a tarball** — the one mechanism
+    that used to pin a consumer's transitive tree. `bundleDependencies`,
+    npm's suggested replacement, is a non-starter here: `@lydell/node-pty`
+    and the agent SDK ship per-platform optional binaries. What DID land:
+    `package.json` gains an `overrides` block mirroring the existing yarn
+    `resolutions`, so an `npm install` from source resolves the same tree
+    yarn does (`npm install --package-lock-only` → 0 vulnerabilities);
+    it has no effect on the tarball. Our own testing keeps running the
+    forced 2.0.11, as R.5b's sweep note records.
+  - **Tarball rebuilt once more at session end (2026-07-25), shell
+    `b97f85d`** — still **0.2.0**, Kyle's call ("don't bother updating the
+    version number"). Staged at `../beta/mirafold-0.2.0.tgz` (335,280 bytes,
+    sha256 `69c84f6d…`). Carries everything from that evening: the
+    flat-outline gear, the readable pairing card with copy as its one action,
+    the phone Explorer fixes, the browser bundle no longer shipping
+    package.json, and the discarded-tab pairing fix. Verified by cold
+    `npm i -g` into a throwaway prefix — `--version` 0.2.0, boots, serves
+    HTTP 200 — and by grepping the packed bundle to confirm it actually
+    carries that work rather than trusting the pack. ⬜ **Kyle still owes the
+    replace-in-place upload to Drive.**
+  - **Where the version lives, for whenever it IS bumped (swept
+    2026-07-25):** `mirafold/package.json` is the single source of truth —
+    `bin/mirafold.js` reads it at runtime for `--version` and the boot banner,
+    `web/src/version.ts` imports it at build time for the version the browser
+    announces, and `npm pack` names the tarball from it. Since 2026-07-29
+    NO hand-written copy of the version remains anywhere: the Drive
+    artifact is the version-free `../beta/mirafold.tgz` (adopted in
+    practice 2026-07-28, confirmed by Kyle 2026-07-29 — Drive
+    replace-in-place keeps the link AND the documented filename stable),
+    and `beta/WELCOME.md` + `mirafold-site/public/beta.html` both
+    instruct `npm i -g ./mirafold.tgz` (updated 2026-07-29). The
+    marketing site's own install line is `npm i -g mirafold` and the
+    README uses a `mirafold-*.tgz` wildcard, both already version-free.
+    So a version bump touches package.json and nothing else — `npm pack`
+    emits `mirafold-<v>.tgz`, rename it to `mirafold.tgz` when staging.
+
+---
+
+**From Phase R, Step R.5d (moved verbatim 2026-08-12):**
+
+- [x] **Step R.5d — Relay staging (nonprod) environment** — **DONE
+  2026-07-23** (the day the private release went live, per the sequencing).
+  `genui-relay-staging` on Fly from the same Dockerfile via
+  `fly.staging.toml` (auto-stop, idles at zero, ungated); the Deploy
+  workflow gained the environment dropdown (default staging) with
+  per-environment app-scoped FLY_API_TOKENs (staging's token cannot touch
+  production); first staging deploy dispatched through the new path and
+  the full smoke PASSED against `wss://genui-relay-staging.fly.dev`
+  (pairing + byte-identical round-trip + refusals). Runbook: DEPLOY.md §6.
+  Why it exists: the relay is the only component that needs a nonprod — the
+  shell's "production" is the user's own machine and the site already has
+  Pages previews. Staging exercises what local runs can't: real TLS, the
+  `fly-client-ip` header the rate limiter trusts, real network behavior, Fly
+  machine lifecycle. The flow it buys: deploy a ref to staging → point a local
+  shell at it (`MIRAFOLD_RELAY_URL=wss://genui-relay-staging.fly.dev`) → smoke
+  + phone pairing check → dispatch the same ref to production. Original step
+  spec → PLAN-ARCHIVE.md.
+
+---
+
+**From Phase A, the A.4 not-live correction note (moved verbatim 2026-08-12):**
+
+> **Correction 2026-07-30 — A.4's page was NOT live, for nine days.** The
+> public accessibility statement was written and committed 2026-07-21 into the
+> site repo's `staged/` (site `b42c286`), and never made it into `public/`
+> when the blackout lifted on 07-23. `mirafold.com/accessibility` 404'd, no
+> footer linked it, the sitemap didn't list it — while this plan recorded the
+> step as done and live. Restored, linked from every page's footer, and added
+> to the sitemap 2026-07-30 (site `c4426df`); **measured live: 200.** The
+> lesson is the umbrella's own: a page's existence is a fact about the world,
+> not about a plan, and the plan is exactly as current as the last time
+> someone typed. *Also refreshed on restore*: a new known limitation states
+> plainly that the last hands-on keyboard/screen-reader audit was 2026-07-21,
+> that the automated axe gate covers newer surfaces where they appear in it
+> (onboarding, transcript, Explorer, settings, connect-device, fleet, cockpit
+> desktop + phone — `assertAxeClean` call sites), and that the `!` input bar,
+> the pin dock and the ⤢ enlarged file view have not yet had the same pass.
+
+---
+
+**From Phase Q, the follow-tail re-arm watch item (moved verbatim 2026-08-12):**
+
+- [x] **WATCH ITEM (2026-07-24): the follow-tail re-arm race — closed
+  2026-08-08 by N3.3.** Seen once on the
+  CI runner (app.e2e.ts "re-follows once back at the bottom", sat 188px above
+  the tail), green on rerun and on every local run; root-caused same day.
+  Mechanism: re-arming depended on `use-follow-tail.ts`'s `onScroll`
+  measuring within `BOTTOM_SLACK_PX` (24) of the bottom, but scroll events
+  fire a frame after the scroll — under load the stream can paint >24px in
+  that gap, so a reader (or the test's single programmatic jump) landing at
+  the bottom mid-stream measures as "not at bottom" and follow never re-arms.
+  A real product race, not only test fragility. Downward wheel/touch intent
+  that reaches the current bottom now re-arms synchronously against pre-input
+  geometry; the existing instant-follow and input-detach decisions remain.
+  Pure boundary tests and a controlled real-wheel browser scenario pin it.
+
+---
+
+**From Guidance tuning (the prose exit ramp) (moved verbatim 2026-08-12):**
+
+## Guidance tuning — the prose exit ramp (✅ 2026-07-27)
+
+One bullet in `RENDER_GUIDANCE` (`server/render-tools.ts`, commit `9330ded`),
+from a live report: a recipe ask rendered as plain markdown. Probed against
+the real engine with the adapter's exact setup first — pipeline healthy (a
+table-shaped prompt tool-searches and paints; render tools ARE deferred
+behind the SDK's tool search, noted, deliberately left alone), so the cause
+was the old "plain markdown remains right for long-form prose" bullet
+filing whole prose-shaped answers under markdown. New bullet: markdown is
+connective tissue; find and render the answer's structured core (recipe and
+prose-buried comparison as worked examples). Measured on the recipe prompt:
+0/2 renders → 2/3, ingredients + steps as components; diagnostic-prose
+control stays 0/2 (no over-rendering). Confirmed in the real UI end-to-end.
+Ported to mirafold-chat the same day (its `090d29f`) with its own probe.
+
+---
+
+**From 2026-07-27 audit section: header, shipped list, deploy state (moved verbatim 2026-08-12):**
+
+## Open from the 2026-07-27 security audit (three repos, checked against a
+## "pre-launch checklist" post Kyle brought in)
+
+**Shipped that day** (each landed with a test whose guard was broken and
+watched to fail before restoring): relay `new URL` crash guard · daemon
+exact-origin WebSocket check · credential scrubber on both log sinks ·
+site cross-site guard on the waitlist form POST · site `no-store` on
+credential responses · site `HEAD /api/health` · daemon `connect-src`
+narrowed off the `ws:`/`wss:` wildcards · daemon refuses a malformed
+`MIRAFOLD_RELAY_URL` instead of crashing at boot.
+
+**Deploy state (2026-07-28).** The relay crash guard is **LIVE in
+production** — Fly `v9`, ref `f01a765`, staging `v2` first per the
+documented flow. Verified on both by firing the real payload at the live
+host and reading the logs: `{"event":"bad_request_target"}` with no restart
+between it and the preceding `listening` event, health `ok` on four probes
+after. That deploy also shipped the relay's `HEAD /health` (confirmed `200`
+live), which had been sitting undeployed since 07-23. The site fixes went
+live with the push (Cloudflare Pages builds on push to main). **The daemon
+fixes ship with the next release** — they only reach users when the package
+does. Note the relay does NOT auto-deploy: `deploy.yml` is
+`workflow_dispatch` only, so relay code sitting on `main` is NOT live until
+someone dispatches it.
+
+---
+
+**From 2026-07-27 audit section: the relay.e2e test-3 flake (moved verbatim 2026-08-12):**
+
+### ✅ RESOLVED 2026-07-28 — the `relay.e2e.ts` test 3 flake
+
+`assert.ok(tapped.length > 50)` (`server/relay/relay.e2e.ts:91`) was a
+hardcoded frame-count threshold and it was **load-sensitive**. Sampled
+2026-07-27 in isolation: **1 pass / 3 fail**, failing at exactly `saw 50`.
+The comment directly above it already documented the same failure a week
+earlier — *"the 'saw 40' flake, reproduced 2/20 under saturation
+2026-07-19"* — so the earlier fix (keying the wait on turn completion)
+did not remove the underlying brittleness, only moved the number.
+
+Mechanism: `DELTA_COALESCE_MS` (33ms) merges streamed deltas, so the number
+of frames the tap sees depends on machine load — under saturation more
+deltas merge, fewer frames cross, and the count drops under the threshold.
+
+**The owed isolation run was run 2026-07-28 and CLEARED the 07-27
+`server/index.ts` change**: 6 samples on HEAD (0 pass / 6 fail, `saw`
+43–50) vs. 6 samples with `server/index.ts` reverted to `5e0abe4^`
+(0 pass / 6 fail, `saw` 44–49) — identical distributions, so the flake is
+fully explained by the threshold, no second problem. (Note the fail rate
+on this machine had drifted to 6/6 — the tally sat permanently just under
+50, i.e. the threshold was not merely flaky but effectively broken.)
+
+**Fix (same day):** the count was only ever a guard against the ciphertext
+loop below it passing vacuously over zero frames. Replaced the total-frame
+tally with growth-during-the-turn: capture `tapped.length` before the
+remote prompt, assert it grew by ≥2 after both viewports saw `turn_end` —
+the prompt itself must cross the tap upstream (c2d) and the `turn_end`
+that detaches the stop buttons must cross downstream (d2c), and delta
+coalescing can never merge either away. Deterministic under any load.
+Mutation-tested (both tap `frame` calls dropped from `relay-stub.ts` →
+fails `saw 0 new frames over 0` → restored); verified 6/6 passing
+unpinned and 3/3 passing under single-core CPU pinning (`taskset -c 0`),
+the condition that originally reproduced the flake.
+
+---
+
+**From 2026-07-27 audit section: the per-session prompt gate redo (moved verbatim 2026-08-12):**
+
+### ✅ REDONE 2026-07-28 — per-session prompt gate, keyed on the turn grammar
+
+History: a 400ms per-session gate on `prompt` / `prompt_session` /
+component `action{kind:prompt}` was written 2026-07-27 and **reverted the
+same day** — it measured time since the last *accepted* prompt, which
+punishes legitimate back-to-back turns and broke four e2e tests (`shell
+picker`, `notice badging`, `navigating artifact`, `chart stretch`). The
+threat is real: nothing bounded a client that bursts prompts, each of which
+costs a model turn, and the artifact bridge reaches `action{kind:prompt}`
+with no user gesture (its 400ms gate is client-side — a hostile client
+simply wouldn't run it).
+
+The redo implements the corrected design with one parity-driven refinement.
+All three model-driving paths now enter through ONE seam,
+`registry.dispatchPrompt` (echo + push behind the gate); the gate is
+cleared in `broadcast()` by the same terminal events that flip status back
+to idle (`turn_end` / `error` / `bang_end`) — no timer anywhere. The
+refinement: a prompt while idle starts the turn, and **one more** may
+arrive while it runs, because the terminal agents queue typed-mid-turn
+input (the Claude Code adapter literally `queue.push`es it) and the desktop
+prompt box still sends on Enter while busy — a strict refuse-while-busy
+gate would have refused a legitimate human flow. Anything past that one
+queued follow-up is refused with the shared `PROMPT_GATE_REFUSAL` line
+(sent only to the offending viewport — never broadcast, so it can't touch
+session status or other viewports' busy state). Burn is capped near one
+turn per completed turn; no human pace, and none of the four e2e tests,
+can trip it.
+
+Pinned in `hostile-client.itest.ts` (burst of 5 → exactly 2 echoes + 3
+refusals → gate clears at turn_end and a fresh prompt completes);
+mutation-tested (gate forced open → the pin fails on 5 echoes / 0
+refusals → restored). Tier-1 443/443, Tier-2 137/137 with the gate in.
+
+---
+
+**From 2026-07-27 audit section: the three ranked items (1 + 2) (moved verbatim 2026-08-12):**
+
+### ✅ The three ranked items — ALL RESOLVED 2026-07-28 (relay changes await a deploy)
+
+1. **Relay caps vs. machine memory + missing backpressure — FIXED.**
+   Defaults lowered to launch scale (`maxConnections` 2000→256, `maxSockets`
+   2400→320, `maxPairs` 1000→128 — env-raisable per-deploy). **Send-side
+   backpressure added** on both forwarding paths: a receiver whose socket
+   buffers past `RELAY_MAX_BUFFERED_BYTES` (64 MB — sized so a maxed-ring
+   attach-replay, ~43 MB sealed, survives) is closed `CLOSE_OVERLOADED`;
+   closing rather than dropping keeps the stream gapless (a re-attach
+   replays). **Byte-rate cap added** to the per-connection window
+   (`RELAY_RATE_MAX_BYTES`, 64 MB/s — the frame cap alone left ~3.8 GB/s
+   legal). No contract change: existing close codes only, so the mirror and
+   the contract-guard itest are untouched. Both pinned in the relay's
+   standalone suite (a stalled-socket test and a big-frame test), both
+   mutation-tested (each guard neutered → its pin fails/hangs → restored).
+2. **Pairing id in the URL query — wording fixed, exposure MEASURED.**
+   `SECURITY.md`, `README.md`, and `log.ts` no longer call it "a bearer
+   secret" — it is `b64url(SHA-256(code)[0..16))`, a rendezvous id that
+   decrypts nothing (verified against `relay-crypto.ts`); its exposure
+   enables slot squatting/DoS, not disclosure. The Fly question was
+   **verified live 2026-07-28** instead of assumed: a marker-id probe
+   dialed at the production relay produced NO proxy log line at all —
+   Fly's edge logs `request.url` **only on proxy-error lines**, so the
+   pairing id does not reach platform logs on the happy path. Conclusion:
+   moving the id to a header/`Sec-WebSocket-Protocol` (a both-repo
+   contract change) stays unjustified; SECURITY.md now states the
+   deployment-layer caveat honestly.
+
+---
+
+**From 2026-07-27 audit section: ranked item 3 + the v10 deploy note (moved verbatim 2026-08-12):**
+
+3. **Stale `mirafold-relay/dist/` — deleted**, and `npm start` now runs a
+   `prestart` build, so a local run can never again execute months-old
+   code (verified: `npm start` rebuilt dist with the new limits in it).
+
+**Deploy note — RESOLVED same day:** Kyle dispatched production directly
+from `main` (~13:12 UTC, no staging run this time; v9 did staging first) —
+Fly **`v10`**, ref `6b83ded`, the exact audit commit. Verified live:
+workflow run green, health `200`, and his entitled daemon re-paired
+through the new build 6s after `listening`. The new guards themselves
+aren't safely probe-able against production (they'd need a real flood or
+stall); their proof is the pinned + mutation-tested suite behind the ref.
+
+---
+
+**From 2026-07-27 audit section: visible refusal reason on the phone (moved verbatim 2026-08-12):**
+
+### ✅ 2026-07-28 — the refusal reason is VISIBLE on the phone (Kyle's call)
+
+A relay refusal's why (no daemon 4003 / at capacity 4004 / bad origin
+4006, mapped in `web/src/ws.ts` `viewportRefusalReason`) reached the
+StatusBar only as the dot's `title` — a hover tooltip no touch device can
+reveal, on the remote path built for phones. Kyle chose the middle option
+of the recorded three (tooltip-only / visible line / banner): a **visible
+line beside the dot**, shown only when the connection is down WITH a known
+reason — an ordinary blip keeps the quiet dot and plain "reconnecting…"
+tooltip. `.sb-conn-note`: warn-colored to match the off-dot it explains,
+ellipsis-bounded so it can't push the phone row's controls off. No live
+region on it — Shell's Announcer already speaks the transition (A.1); this
+is the visible copy of the same words. Wording kept from the provisional
+strings (they already said the right things: the no-daemon line points at
+the desktop as the fix; "at capacity" stays true for the new mid-session
+backpressure shed, which uses the same close code). Pinned end-to-end in
+`relay.e2e.ts` test 4 — the daemon is killed mid-pairing and headless
+Chrome must show the exact 4003 string beside the dot — and
+mutation-tested (render neutered → the pin fails → restored). **LIVE on
+the remote path same day**: the git-integrated Pages project rebuilt on
+the push; verified by fetching the served assets (`.sb-conn-note` in both
+the live JS and CSS at app.mirafold.com). Local users get it with the
+next package release, like every daemon-side change.
+
+Also noted, not acted on: `mirafold-site/PLAN.md`'s "Remote viewport app
+origin" item still reads as though the bundle hasn't shipped (it is live at
+`app.mirafold.com`); the site repo's `CLAUDE.md` had the same staleness and
+was corrected 2026-07-27.
+
+---
+
+**From 2026-07-27 audit section: cross-viewport permission sync (moved verbatim 2026-08-12):**
+
+### ✅ 2026-07-28 — permission answers sync across viewports (Kyle's phone bug)
+
+Kyle's report: allow/deny tapped on the phone looked like it worked (its own
+bar cleared) but "nothing actually happens" — the desktop's copy of the same
+ask stayed up and the phone hung; and an answer given ON the desktop didn't
+reliably clear the phone's bar either. Root cause (reproduced with a local +
+relay-stub two-viewport harness before touching anything): **nothing on the
+wire ever announced a permission's resolution.** Each viewport dropped an ask
+only when it was itself clicked, or at `turn_end`; the fleet mirror was kept
+honest (`answerPermission` + clock-aging) but attached session viewports were
+not. So the second device kept showing an ask that had already been answered
+elsewhere — or auto-denied by the adapter's 60s `PERMISSION_TIMEOUT_MS` — and
+a tap on that stale bar is, by design, a silent no-op at the adapter. Exactly
+"the phone just hangs there." The relay was innocent: a fresh
+`permission_response` from the remote path resolves fine (proven in the
+repro); it was the stale-bar window that made phone answers look dead.
+
+The fix (additive wire message, no relay/contract change — the relay never
+parses frames): **`permission_resolved { id, allow }`** is broadcast on the
+session stream for EVERY resolution path. Emitted from the one place all
+paths funnel through — the adapter's ask `finish` (answer from any viewport,
+timeout auto-deny, interrupt/close deny-all) in `claude-code.ts`, mirrored in
+`mock.ts`; adapters that emit `permission_request` MUST emit this
+(protocol.ts). Registry: `captureCockpit` drops exactly that id from the
+fleet mirror (the timeout path only this catches — `answerPermission` never
+ran) and releases the `permission` status hold only when nothing is still
+pending; `deliver`'s blanket working-flip skips the new type so a second
+pending ask keeps the hold. Client (`Shell.tsx`): drops the ask by id the
+moment the broadcast lands — with a polite announcement when the ask was
+still showing here (it resolved elsewhere), silent when this viewport's own
+click already removed it. Replay benefits for free: the buffer now carries
+request→resolved, so a reloaded viewport can't repaint a stale bar mid-turn.
+
+Pinned in all three tiers and each pin mutation-tested (guard broken → exact
+pin fails → restored): Tier-1 — adapter emits on answer AND on the
+interrupt deny-all (`claude-code.test.ts`), registry drop + hold-until-none-
+pend (`registry.test.ts`), protocol fixture. Tier-2 — the second viewport's
+very NEXT frame after the answer is the resolution, before the allowed
+tool's frames (`session.itest.ts`); the timeout announces `allow:false`
+before `turn_end` (ibid.); and Kyle's exact scenario, answered FROM the
+phone through the encrypted relay path with the local viewport hearing it
+(`relay.itest.ts`). Tier-3 — desktop answers, the PHONE's bar must drop
+while the turn is still streaming, not at `turn_end` (`phone.e2e.ts`, the
+count-pinned "restarted cleanly" discriminator). Tier-1 454/454, Tier-2
+139/139, Tier-3 67/67. No relay deploy involved (the relay never parses
+frames). **Client half LIVE on the remote path same day** — the Pages
+project rebuilt on the push; verified by fetching the served bundle
+(`permission_resolved` in app.mirafold.com's JS). Local daemons get the
+daemon half with the next package release, like every daemon-side change.
+
+---
+
+**From Stretch goals, Step S.1 (pie) (moved verbatim 2026-08-12):**
+
+- [x] **Step S.1 — `chart` kind: pie (donut)** ✅ 2026-07-27 (Kyle-directed,
+  branch `claude/next-registry-components-lyrbrq`, with S.2 same sitting).
+  Built to spec: `pie` on the kind enum; slices = `x` names ×
+  `series[0].values`; size-ordered, past 6 the tail folds into ONE "other"
+  (top 5 + other — the fixed-slot palette always suffices, never cycled);
+  donut with the total in the hole, a per-slice direct-label list
+  (chip + name + value + share, no around-the-donut collisions by
+  construction) and hover tooltip. The one-series rule is enforced in the
+  RENDERER by throw → RenderBlock's error boundary → the raw-props fallback
+  (the schema's raw shapes can't carry cross-field refinements through the
+  generic strict/tolerant derivation; the describe strings state the rule for
+  the agent). Done-when observed in headless Chrome: 8-category mock pie →
+  6 slices incl. "other"; 2-series pie → legible fallback with the good
+  charts unharmed; verified at desktop and phone widths, both fine (0px
+  side-scroll).
+  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+
+---
+
+**From Stretch goals, Step S.2 (stacked/horizontal) (moved verbatim 2026-08-12):**
+
+- [x] **Step S.2 — chart ergonomics: `stacked`, `horizontal`, histogram
+  hint** ✅ 2026-07-27 (with S.1, same sitting). Optional `stacked` +
+  `horizontal` booleans, bar-only, quiet no-ops on line/pie (and on a
+  single-series stack), composable with each other; the kind `.describe()`
+  now tells the agent to pre-bin distributions into labeled bar buckets.
+  Stacked: cumulative columns in palette-slot order, surface-stroke gaps
+  between segments, only the data end rounded, y-scale spans column TOTALS,
+  negatives dropped (no stacking geometry). Horizontal: bars rightward,
+  category labels whole down the left (the vertical axis clips at 12 chars —
+  the point), height grows with category count; the value-unit label moved
+  top-right after the screenshot pass caught it overlapping the last tick.
+  Old-client degradation pinned by test: a rebuilt "yesterday" tolerant
+  schema strips both flags to a plain grouped/vertical bar, and yesterday's
+  kind enum rejects `pie` whole into the fallback. Verified at desktop and
+  phone widths in headless Chrome.
+  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+
+---
+
+**From Stretch goals, the 2026-07-27 component-work security audit (moved verbatim 2026-08-12):**
+
+- [x] **Security audit of the 2026-07-27 component work** ✅ same day, all
+  three approved fixes landed with pinned, mutation-tested regressions:
+  1. **Session replay buffer capped by BYTES** (`SESSION_BUFFER_MAX_BYTES`,
+     32 MB) beside the existing 4000-message count cap. The count cap
+     assumed text-only messages; `image` made one message worth megabytes
+     from a short path, with no permission prompt. Measured open: 40 renders
+     retained 96 MB, ~10 GB at the count ceiling. Re-probed closed: 200
+     renders now plateau at 32.9 MB. Full note in SECURITY.md.
+  2. **Workspace dir is a REQUIRED argument** on `makeRenderServer` and
+     `generativeUIMsg` — it jails the image read, and optional meant a
+     future adapter could skip containment by forgetting it.
+  3. **`mermaid` moved to devDependencies** — the runtime is inlined into
+     `dist/` at build time and nothing shipped loads it from `node_modules`
+     (verified), so it was costing every user 84 MB and 62 transitive
+     packages of install + supply-chain surface for zero runtime use.
+     Kyle's zero-passengers rule, applied.
+  Clean on everything else probed: image containment (symlink/traversal/
+  `.env`/wrong-bytes/oversize all refused, mutation-tested), every new
+  parser against pathological input (worst case 56 ms, no hangs, clamps
+  hold), the diagram sandbox, supply chain (0 advisories/248 pkgs, no
+  install scripts), and repo hygiene (no secrets in the session's commits).
+
+---
+
+**From Stretch goals, the console/image/diagram batch (moved verbatim 2026-08-12):**
+
+- [x] **Workflow-gap batch (Kyle-directed 2026-07-27, same branch): `console`,
+  `image`, `diagram`** ✅ — the three glaring terminal-agent workflow gaps
+  from the 2026-07-27 survey, each through the full seam, one commit apiece:
+  - **`console`** — quoted terminal output (build logs, failing tests, stack
+    traces): command header, exit badge, copy; a self-written SGR-subset
+    parser turns ANSI colors into class spans (16 fg colors on a pinned
+    palette, other escapes stripped; text rides React as text nodes).
+  - **`image`** — the visual-verification gap. Agent authors a WORKSPACE
+    PATH; the daemon inlines the bytes at the WireMsg synthesis point (all
+    three adapters; the stdio stub stays file-access-free). Explorer-grade
+    posture: `inside()` realpath containment (mutation-tested), secret
+    denial, 2 MB raw cap (sealed relay frame ≈1.8×, relay ceiling 8 MB;
+    replay ring is count-capped so per-image bytes are the bound), raster
+    magic-byte allowlist, NO svg. Client accepts `src` only as a
+    strict-shaped data:image/raster URI — anything else → raw-props
+    fallback. Refusals render their reason.
+  - **`diagram`** — mermaid (flowchart/sequence/state/class/ER), rendered in
+    the ARTIFACT-grade sandbox, never the shell origin: shell-supplied
+    runtime (securityLevel strict) inlined in an opaque-origin no-network
+    iframe; agent source arrives by postMessage only (no interpolation slot
+    — pinned by test); nonce-stamped ready/height/error channel. New dep
+    `mermaid` (^11, deep-spec verdict): ~3.6 MB lazy chunk, first diagram
+    only. Broken source shows the error beside the source.
+  **Deliberately NOT built: structured input beyond `question`** (multi-value
+  forms, editable commit messages). Free-text input inside agent-authored UI
+  collides with the trusted-shell rule that input surfaces are shell-owned —
+  it needs a design conversation with Kyle first, not a batch add.
+
+---
+
+**From Stretch goals, Step S.3 (stat) + code + status-list (moved verbatim 2026-08-12):**
+
+- [x] **Step S.3 — `stat` registry component (KPI tile)** ✅ 2026-07-27
+  (Kyle-directed, on branch `claude/next-registry-components-lyrbrq`; built to
+  this spec exactly — `label`/`value`/optional `delta {value, direction,
+  good}`/optional `footer`, delta tone follows `good` never the raw direction,
+  the arrow glyph carries direction so state never rides on color alone,
+  proportional figures per the dataviz stat-tile contract). Done-when observed
+  in headless Chrome: the mock `kpi` turn renders the tile, an update-in-place
+  re-send on the same wire id moves the number (one tile, never a stack), and
+  it pins to the dock and back. **Same sitting, same seam, Kyle-directed —
+  two MORE registry components** (all three across both transports via
+  `RENDER_TOOL_COMPONENT`, display-only, no ACTION_TOOLS changes):
+  - **`code`** — display code that is NOT a change (the tool description
+    steers code-vs-diff explicitly): filename/lang header, copy button,
+    client-side tokenizing of plain text through the same
+    react-markdown + rehype-highlight pipeline as turn fences (hast → React,
+    never raw HTML; the fence always outruns any backtick run inside), and
+    optional 1-based highlight ranges clamped to the code's own length. Line
+    emphasis is PINNED-surface styling (neutral lift + code-fg bar) because
+    per-theme tints go pale under the pinned-dark code surface's light text —
+    caught by the both-themes screenshot pass.
+  - **`status-list`** — labeled rows with a pass/fail/warn/pending/skip
+    verdict pill (glyph + word, existing semantic tokens; a Tier-1 test pins
+    glyph↔enum so vocabulary drift fails loudly).
+  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+
+## Moved 2026-08-12 (prune addendum — verified-stale items)
+
+Removed at Kyle's direction after verification, not archived as merely
+finished: the two Tier-3 flake-watch entries were superseded the same day
+they were written by the 2026-07-30 artifact-chain root-cause fix (same
+test, probe-proven mechanism matching their traces, 0/8 post-fix failures,
+every recorded Tier-3 run since green), and K.4's pending-review status
+was stale — both Paddle reviews passed 2026-07-19 and the step's Done-when
+was met live 2026-07-22. Entries verbatim:
+
+**From Phase R (between R.6 and R.7), flake watch A (removed verbatim 2026-08-12):**
+
+- [ ] **Flake watch — one unterminated turn in the artifact chain (Tier-3
+  test `update-in-place artifacts survive the liveness tripwire`).** STILL
+  OPEN, and NOT the bug above: the captured trace shows **21 `user_prompt`
+  against 20 `turn_end`, with ZERO `error` and ZERO `bang_end` frames** —
+  a turn with no terminal frame of any kind. FIFO attribution points at
+  `burst-alpha`, the prompt the artifact iframe's bridge issues, though
+  interleaving makes that name the weakest part of the finding.
+  - **Ruled out by probe, not by reading:** the replay floor on an idle
+    reload (three rounds, clean); the burst gate inflating the count (it
+    refuses BEFORE broadcasting `user_prompt`); mid-turn queueing in general
+    (a socket probe sending a prompt 300ms into a running turn returns
+    `{ups: 2, ends: 2}`); and every mock artifact scenario — `playArtifact`,
+    `playBridgeArtifact`, `playUpdatingArtifact` all call `endTurn`.
+  - **The tool for next time already exists:** `web/src/turn-trace.ts` is
+    armed by the e2e harness and `waitTurnIdle` dumps it on any wedge —
+    frame types, replay flags, counts, and the prompt prefix. Reproduce with
+    `node --import tsx --test server/testing/app.e2e.ts` after a `yarn
+    build` (~64% per run in isolation, far higher than in a full Tier-3).
+  - **Cost note (Kyle, 2026-07-30):** this consumed a large share of a
+    session. If it recurs, read the dumped trace — do not re-derive it.
+
+---
+
+**From Phase R (between R.6 and R.7), flake watch B (removed verbatim 2026-08-12):**
+
+- [ ] **Flake watch — Tier-3 test 36 wedges on a stuck activity indicator
+  (2026-07-30; IDENTIFIED, cause not yet proven — do not chase blind).**
+  - **The test:** `2026-07-29 update-in-place artifacts survive the liveness
+    tripwire` (`server/testing/app.e2e.ts`). It fails in its PRECONDITION,
+    not its subject: the wait for the previous turn's activity indicator to
+    clear. Rate ~1 in 4–7 full runs.
+  - **What the instrumentation caught** (`waitTurnIdle`, added same day —
+    diagnostic only, changes no assertion): `activity: "✢working…(30s)"`,
+    i.e. the indicator polled visible for the entire 30s, WHILE the polite
+    live region already held the finished response — and that region only
+    speaks at `turn_end`. So the turn ended and the indicator did not clear.
+    That rules out "a turn never ended" and puts it on the shell's
+    open-turn counter. Prompt box was enabled; last five transcript entries
+    were the artifact tests' turns (`show me a navigating artifact`, then
+    the iframe-issued `burst-alpha`).
+  - **Falsified:** the obvious reading of `web/src/turn-busy.ts`'s replay
+    floor (`replayed && ACTIVITY_TYPES → max(current, 1)`) — that a plain
+    attach-with-replay of an IDLE session forces the count to 1 with no
+    `turn_end` to follow. Probed directly against the built daemon: turn,
+    idle, reload, ×3 — indicator clear every time. Not it, at least not on
+    the straight-line path.
+  - **Still open, and where to look next:** the failing sequence involves
+    artifact turns plus an iframe-issued prompt (`burst-alpha`) whose
+    sibling (`burst-beta`) is deliberately dropped by the 400ms bridge rate
+    limit. `turn-busy.ts`'s own comment names this exact hazard — "a LIVE
+    straggler after a final turn_end … must not re-open a closed turn, or
+    busy wedges on with no turn_end ever coming". The next diagnostic is
+    the frame sequence itself: record every `(type, replayed)` the client
+    applies plus the running count, and read it back at the wedge. Do NOT
+    "fix" the floor rule without that — it was written to close a real gap
+    (a queued follow-up losing the indicator across an engine roll-in), and
+    an unproven change would trade one wedge for that one.
+  - **Not caused by 2026-07-30's work:** the extended axe sweep runs later
+    in the file with its own daemon and page, and the `FilesPanel`
+    tabIndex/role change touches the Explorer's scroll container. The
+    failure predates both.
+
+---
+
+**From Phase K, Step K.4 (the 2026-07-17 pending-review status) (removed verbatim 2026-08-12):**
+
+- [ ] **Step K.4 — Merchant-of-record billing** — 🟡 vendor locked: **PADDLE**
+  (investigation 2026-07-15; every hard requirement from BUSINESS §7 + R.5
+  verified native against Paddle's docs: card-required 7-day trial,
+  cancel-at-period-end, $12/mo · $99/yr, signed `trialing`/`active`
+  lifecycle webhooks that map verbatim onto the Ed25519 minting rule,
+  hosted checkout from a static page, MoR tax; fees 5% + 50¢, accepted.
+  Field comparison — Lemon Squeezy / Stripe Managed Payments / Polar /
+  Creem — and the FTC-rule→ROSCA citation correction: → PLAN-ARCHIVE.md).
+  Account created 2026-07-16 as **individual/sole trader** (no entity
+  required — the finding that deferred K.2). **2026-07-17: both Paddle
+  reviews submitted and pending** — domain approval (`mirafold.com`,
+  Pending at `/request-domain-approval`) and account verification (the
+  KYC form, completed + in review; sole prop, trading name Mirafold,
+  business start 2026-07-11, pricing URL `mirafold.com/#pricing`).
+  Payout/bank details: an anytime-before-revenue dashboard item. Full
+  status history → PLAN-ARCHIVE.md.
+  - Done when: both reviews pass and R.5's checkout → webhook →
+    entitlement-minting build runs against the account.

--- a/PLAN.md
+++ b/PLAN.md
@@ -155,7 +155,9 @@ Archive passes, each a section header in PLAN-ARCHIVE.md you can navigate to:
 lifted out of the still-open Phase R steps) · "Moved 2026-07-27" (Phases
 E2/W step bodies, the Phase E/M narrative passes, the R.4l item-5
 investigation, the CI-flake breakdown, and finished stretch-goal specs) ·
-"Moved 2026-08-09" (Phase UX).
+"Moved 2026-08-09" (Phase UX) · "Moved 2026-08-12 (prune — completed
+bodies)" (a sweep of finished bodies across Phases 4/R/A/Q, the 2026-07-27
+audit section, and the stretch goals).
 
 ---
 
@@ -242,152 +244,36 @@ records of later unplanned polish batches.
   including an e2e pin (tap → card shows raw target → confirm opens,
   dismiss doesn't).
 
-- [x] **Step 4.13 — Phone-testing bug batch (unplanned, Kyle-driven)** — done
-  2026-07-28, all tiers green (458/139/70), every fix e2e-pinned +
-  mutation-tested. Three bugs from Kyle's manual phone/relay testing:
-  (1) **busy turns looked idle** — the transcript's activity line now stays
-  up the whole turn (`✳ working…` fallback between status frames), driven
-  by Shell's wire-derived busy flag; (2) **the permission strip's one-line
-  preview was unreadable on phone** — its body is now one tap target
-  opening the full command in a ModalCard (extracted to `PermBar.tsx` in
-  the same-day refactor); (3) **`exp://` links rendered as dead
-  empty-href anchors** (the about:blank tab) — Expo Go schemes now pass
-  the markdown URL allowlist as real links, and stripped schemes render
-  as text (`web/src/registry/Md.test.ts`). Same-day audit: exp:// hand-off
-  disclosed in SECURITY.md, interstitial planned as 4.12; the audit's
-  second finding — the permission `detail` string is uncapped end-to-end —
-  judged theoretical and **accepted, no action** (Kyle's call 2026-07-28:
-  real agents emit real commands, the card + scrollbar already show more
-  than the old strip ever did; don't re-litigate absent an engine that
-  emits huge payloads); user-facing
-  "know what you're running" paragraph added to the README top. Related
-  decision, same day: **relay port-tunneling** (phone reaches a dev server
-  on the laptop through the relay, no LAN/firewall dependence) was
-  explored and **parked by Kyle** — no roadmap item; the self-serve LAN
-  workaround stands, revisit only if phone-first app-building becomes a
-  real usage path. (The `192.168…` failure that started it was Kyle's ufw
-  dropping LAN SYNs — his machine, not repo state.)
+- [x] **Step 4.13 — Phone-testing bug batch (unplanned, Kyle-driven)** —
+  done 2026-07-28; three phone/relay bugs fixed, e2e-pinned +
+  mutation-tested (busy-turn activity line, tappable permission strip,
+  `exp://` links). Standing: the uncapped permission `detail` is accepted,
+  no action (Kyle 2026-07-28 — don't re-litigate absent an engine emitting
+  huge payloads); relay port-tunneling explored and parked (revisit only if
+  phone-first app-building becomes real usage). Full record → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-- [x] **Step 4.14 — The activity indicator, done right (Kyle-driven rework of
-  4.13's fix #1)** — done 2026-07-29, all tiers green (458/139/72), both new
-  guarantees mutation-tested. Kyle's requirement, verbatim in spirit: **at
-  all times while Mirafold is working with nothing painting, something
-  visibly alive says so** — the terminal agents' cycling asterisk is the
-  bar. 4.13's fix guaranteed only DOM presence and failed it four ways:
-  the `.status-line` pulse was dead CSS (the rise-animation list overrode
-  the `animation` shorthand at equal specificity — frozen text since at
-  least 2026-07-25), the label went stale (`Bash ⚙` through the post-tool
-  model round trip), the line lived inside the scrolling transcript (any
-  scroll-up = zero indication), and a queued mid-turn prompt blanked it at
-  the first turn's `turn_end` while the engine rolled into the queued turn.
-  The rework: `ActivityLine.tsx` — cycling thin→fat asterisk frames (JS,
-  reduced-motion honored) + label + ticking elapsed seconds — as
-  prompt-area chrome above the box; Shell owns the label (status frames /
-  announced tools, cleared on `tool_result` so it can't go stale) and an
-  open-turn counter (`user_prompt` up, `turn_end` down, replay-safe) so a
-  queued follow-up keeps busy across the boundary; the in-transcript
-  status line is gone, and the e2e now asserts aliveness (glyph frame
-  changes), on-screen-ness while scrolled up, and gaplessness across the
-  queued-turn boundary — not mere DOM presence.
-  - **⚠ Test-strength caveat, recorded 2026-07-29 (honest limits of the
-    queued-turn pin).** Of the three e2e guarantees, two are solidly
-    mutation-proven (the glyph must visibly cycle; a long label must not
-    widen the page). The THIRD — "no blank frame across the queued-turn
-    boundary" — is a reliable smoke test but NOT a dependable regression
-    pin: `MockSession` overlays a mid-turn prompt's scripted timers on the
-    running turn instead of queuing behind it, so turn 2's events usually
-    land within one 16 ms sample of turn 1's `turn_end`. Reverting the
-    `openTurns` counter therefore produces a gap too short to sample, and
-    the test passes on the broken code (verified — it caught the mutation
-    on some runs and not others). Chasing stability also cost several
-    false failures: a 2.2 s "blank" that was the product correctly idling
-    after a REFUSED follow-up (the registry allows exactly one queued
-    prompt; when it's spent the scenario never occurs), now handled by
-    retrying the whole scenario and asserting acceptance-while-busy first.
-    Options for a real pin, for whoever picks this up: give the mock an
-    explicit "queue, don't overlay" mode so the boundary has a measurable
-    gap, or pin `openTurns` directly in a Shell-level unit test (Tier 1
-    has no DOM harness today, so that's the larger lift). Until then,
-    treat the boundary behavior as verified by construction + manual
-    observation, not by an automated guard.
-    *2026-07-29 addendum (Step 4.16):* the counter now lives in a pure
-    reducer (`web/src/turn-busy.ts`) and `turn-busy.test.ts` pins the
-    queued-turn arithmetic directly — the caveat's asked-for unit pin,
-    without the DOM-harness lift. The e2e's sampling weakness stands as
-    recorded; the reducer pin is the dependable guard.
+- [x] **Step 4.14 — The activity indicator, done right (Kyle-driven rework
+  of 4.13's fix #1)** — done 2026-07-29; Kyle's bar: at all times while
+  Mirafold works with nothing painting, something visibly alive says so.
+  `ActivityLine.tsx` chrome above the prompt box + Shell-owned label +
+  replay-safe open-turn counter — now the pure reducer
+  `web/src/turn-busy.ts`, whose Tier-1 pin is the dependable guard (the
+  e2e's queued-turn boundary assertion remains a smoke test; its
+  honest-limits caveat is preserved verbatim in the archive). Full record →
+  PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 - [x] **Step 4.15 — Beta-channel trust follow-ups (beta tester 002's
-  evaluation, 2026-07-28; triaged with Kyle 2026-07-29)** — **done
-  2026-07-29**: `SECURITY.md` ships in the package (`files` whitelist),
-  tarball repacked + cold-install re-verified + restaged as
-  `../beta/mirafold.tgz` (sha256 `c8a66f4c98e6…`, full value printed in
-  WELCOME.md + `/beta`), and WELCOME.md gained the fingerprint + a
-  "cautious first run" recipe (throwaway dir, credential-less scripted
-  demo first, honest note that the file browser is confined while the
-  agent keeps its terminal powers behind the permission prompts). ⚠ The
-  repack changed the artifact: if a `mirafold.tgz` was uploaded to Drive
-  before this, it must be re-uploaded. The now-actionable slice of the
-  evaluation (the provenance practice went to R.5b; the provenance +
-  install-command concerns otherwise dissolve at R.7's publish):
-  - Ship `SECURITY.md` in the npm package (add to the `files` whitelist;
-    the README cites it and the tarball is where a beta tester looks) —
-    then repack + restage `../beta/mirafold.tgz`.
-  - Publish the staged tarball's SHA-256 where testers can check it:
-    `beta/WELCOME.md` + the site's `/beta` page.
-  - A short "cautious first run" section in `beta/WELCOME.md` (disposable
-    repo with canary files, mock adapter first, relay off) — the
-    evaluation's pilot checklist, offered rather than left for each
-    tester to invent.
-  - Done when: a tester following the public trail finds the security doc
-    inside the artifact, a fingerprint to verify it, and a sane first-run
-    recipe.
+  evaluation)** — done 2026-07-29; SECURITY.md ships in the package, the
+  tarball fingerprint is published where testers look, and WELCOME.md
+  carries a "cautious first run" recipe. Full record → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 - [x] **Step 4.16 — Whole-repo bughunt batch (2026-07-29, Kyle: "do em
-  all")** — a six-subsystem correctness sweep (adapters / sessions / server
-  core+pty / relay / web core / web components), every finding verified with
-  a concrete failing scenario before reporting, all 27 approved and fixed
-  the same day, each with a pinned regression test (several
-  mutation-proven). The headliners, for the record: (1) an **oversized ws
-  frame crashed the whole daemon** — no per-socket `error` listener, so a
-  >1 MB paste tripped ws's maxPayload into uncaughtException (fix: listener
-  + Tier-2 pin; the socket now closes 1009 alone); (2) a **relay-gate-refused
-  CREATE leaked the session forever** (nothing arms the idle timer before a
-  first attach; 100 phone retries exhausted MAX_SESSIONS for local creates
-  too) — refused creates now reap what they minted; (3) a **viewport frame
-  >~1.5 MB killed the whole pairing** (daemon dial-out cap sat below the
-  relay's 8 MB viewport cap; ws closes the whole socket → dropAll) — cap
-  aligned + pinned against genui-relay's limits in the sibling itest;
-  (4) the **artifact update-in-place liveness race** (a stale navigation
-  deadline killed healthy updates; generation guard + a same-id mock
-  scenario the e2e now drives); (5) both **codex and gemini burned
-  RENDER_GUIDANCE on a failed first turn** (consumed before delivery → zero
-  render calls for the session's life); (6) **bang lifecycle masqueraded as
-  turn grammar** in the registry (a `!` during a pending ask wiped the
-  fleet's allow/deny — the 2026-07-24 bug class through a different door —
-  and a throttle-refused bang broadcast a fabricated `bang_end`);
-  (7) **ws.ts backoff reset on open**, so refused viewports redialed at
-  2 Hz forever (reset moved to the handshaken finishOpen; full relay-path
-  crypto now driven in ws.test); (8) **split/colon-form ANSI leaked through
-  the PTY cleaner** (stateful cross-chunk carry + ECMA-48 param class);
-  (9) replay re-fired **screen-reader announcements for historical turns**
-  on every reload (additive `replay: true` stamp on attach-replayed frames,
-  protocol.ts; Shell suppresses live-only side effects); (10) an
-  **env-misparse family** where garbage WIDENED policy (`MAX_WS_PAYLOAD`
-  NaN = unlimited, `WS_HEARTBEAT_MS` NaN = 1 ms reap-everything loop) —
-  `server/env.ts` envInt/envFlag now parse strictly, 34 sites swept. Plus:
-  checklist clear-to-empty (both adapters), mermaid quoted-comma labels,
-  chart end-label clipping, mock permission_resolved on interrupt,
-  workspace_ls dangling-symlink resilience, pairing-code charset refusal,
-  the sendTampered last-char no-op (the itest's tamper proof now actually
-  proves tamper rejection), stale pong deadline killing successor sockets,
-  the legacy pairing-store carry (newSessionHref), handshake-wedge deadline,
-  useArmedConfirm same-key re-arm, FilesPanel replay-burst coalescing, and
-  the ws.ts close-code mirror now REALLY pinned against genui-relay's
-  contract. One deliberate non-fix, recorded: no client-side prompt-size
-  cap was added (a feature call, not a bug) — a >cap paste now costs one
-  clean socket close instead of the daemon; add the cap only if that UX
-  bites. Full verified ledger: session scratchpad; findings' file:line
-  detail rides each fix's test comments.
+  all")** — 27 verified findings across six subsystems (adapters, sessions,
+  server core+pty, relay, web core, web components), all fixed same day,
+  each with a pinned regression (several mutation-proven). One deliberate
+  non-fix stands: no client-side prompt-size cap (a feature call — a >cap
+  paste costs one clean socket close; add only if that UX bites). Full
+  finding ledger → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 - [ ] **Step 4.17 — Relay hello freshness (deferred hardening, 2026-08-11
   audit)** — the daemon's relay hello (`relay-crypto.ts` / `relay-client.ts`)
@@ -407,34 +293,12 @@ records of later unplanned polish batches.
   today (it's ours). Sized ~half a day incl. a sibling-itest pin (recorded
   hello + fresh challenge → refused).
 
-- [x] **Step 4.18 — Test-audit pass (2026-08-11)** — judged the tests, not the
-  product: read the tiering rules (README §8), ran Tier 1 (631/631, ~16s, x2
-  deterministic), Tier 2 (144/144, x3, ~3:48 each, zero flakiness), Tier 3
-  (e2e, 83/83, x2, ~3:20 each incl. build, zero flakiness), and **falsified 10
-  stated invariants by mutating the product** — the
-  E2E counter (replay/reorder), the tool-output cap, the replay-ring byte cap,
-  the fs-explorer realpath jail, checkpoint seq-monotonicity, the WS
-  origin guard, the ws backoff ladder, `cleanRelPath` traversal, and the
-  IP-exact loopback classifier all fail cleanly when their target breaks.
-  **Two real repairs, each mutation-proven after:** (1) `registry-spec.test.ts`'s
-  chart "old-client" test asserted on a hand-built `z.enum(["line","bar"])` — it
-  tested zod, not the product; rewritten to drive the real
-  `clientSchemas.chart`/`registrySchemas.chart` twins (now fails when the chart
-  kind enum changes). (2) `fs-explorer.test.ts`'s "small tree not truncated"
-  test wrote into the already-capped dir (a dead write), listed a fresh EMPTY
-  dir, and never asserted `truncated === false` — the guarantee was untested;
-  rewritten to list a real small tree and pin `truncated === false` + the entry
-  list (now fails on spurious truncation). **Three assertions tightened**
-  (loose bounds → exact, each proven to catch a regression the old form missed):
-  `niceTicks` ticks (Chart.test.ts) and the Gemini honest-model label.
-  **Left as-is, backstopped, reported not repaired** (deleting/weakening waits
-  for Kyle; each is redundant with a stronger test, not a gap):
-  `provider-policy.test.ts` "every cell is a boolean" (the exact agent×kind
-  truth matrix above it is stronger), `version.test.ts` semver-shape regex
-  (the `CLIENT_VERSION===VERSION` + launcher `--version` neighbors have the
-  teeth), the claude-code/gemini truncation *bounds* (exact byte math pinned in
-  `types.test.ts`), and `files-tree.test.ts`'s "too fast" substring. No product
-  bug surfaced; no test was deleted.
+- [x] **Step 4.18 — Test-audit pass (2026-08-11)** — all three tiers
+  repeated clean; 10 stated invariants falsified by product mutation; two
+  tests genuinely repaired (chart old-client, fs-explorer small-tree),
+  three assertions tightened. The redundant-but-backstopped tests it chose
+  to report rather than delete still await Kyle's call — the list is
+  preserved in the archive. Full record → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ---
 
@@ -528,7 +392,7 @@ and K.6's site pass. Detail in the K.2 / K.4 / K.5 / K.7 notes below.
 
 - [x] **Step K.3 — Provider-terms re-verification** — done 2026-07-15; every row pinned to a dated primary source: the Anthropic ban verbatim, Gemini individual-account service ended 2026-06-18 (API keys continue; Antigravity succession check → R.6), and the codex row settled as allowed-locally under the standing **disclosed-uncertainty rule** (no written permission exists, posture visibly permissive; canonical statement in `server/provider-policy.ts`). All four tiers green, twice. → PLAN-ARCHIVE.md.
 
-- [ ] **Step K.4 — Merchant-of-record billing** — 🟡 vendor locked: **PADDLE**
+- [x] **Step K.4 — Merchant-of-record billing** — vendor: **PADDLE**
   (investigation 2026-07-15; every hard requirement from BUSINESS §7 + R.5
   verified native against Paddle's docs: card-required 7-day trial,
   cancel-at-period-end, $12/mo · $99/yr, signed `trialing`/`active`
@@ -536,16 +400,16 @@ and K.6's site pass. Detail in the K.2 / K.4 / K.5 / K.7 notes below.
   hosted checkout from a static page, MoR tax; fees 5% + 50¢, accepted.
   Field comparison — Lemon Squeezy / Stripe Managed Payments / Polar /
   Creem — and the FTC-rule→ROSCA citation correction: → PLAN-ARCHIVE.md).
-  Account created 2026-07-16 as **individual/sole trader** (no entity
-  required — the finding that deferred K.2). **2026-07-17: both Paddle
-  reviews submitted and pending** — domain approval (`mirafold.com`,
-  Pending at `/request-domain-approval`) and account verification (the
-  KYC form, completed + in review; sole prop, trading name Mirafold,
-  business start 2026-07-11, pricing URL `mirafold.com/#pricing`).
-  Payout/bank details: an anytime-before-revenue dashboard item. Full
-  status history → PLAN-ARCHIVE.md.
-  - Done when: both reviews pass and R.5's checkout → webhook →
-    entitlement-minting build runs against the account.
+  Account created 2026-07-16 as individual/sole trader (the finding that
+  deferred K.2). **Closed 2026-08-12 as long since satisfied:** both
+  Paddle reviews PASSED 2026-07-19 (KYC verified + `mirafold.com` domain
+  approved + SaaS taxable category — Kyle's dashboard read), and the
+  Done-when was met live 2026-07-22 when R.5's checkout → webhook →
+  entitlement-minting build ran against the account end-to-end on Kyle's
+  real purchase, through the closed relay gate. Payout/bank details set
+  up (confirmed 2026-07-30). Full status history → PLAN-ARCHIVE.md; the
+  superseded pending-review text → PLAN-ARCHIVE.md, "Moved 2026-08-12
+  (prune addendum — verified-stale items)."
 
 - [x] **Step K.5 — ToS + Privacy Policy (from a written data inventory)** —
   done: four pages LIVE on mirafold.com 2026-07-16 (`/terms` `/privacy`
@@ -692,69 +556,18 @@ notifications are **not** part of the launch and are not sold until built.
 - [x] **Step R.1 — Relay envelope + daemon dial-out** — done 2026-07-07; the relay envelope + outbound WSS dial-out, remote viewports multiplexed as ordinary Connections, verified across all tiers against the in-repo stub. Full status → PLAN-ARCHIVE.md.
 
 - [x] **Step R.2 — The relay service, deployed** — completed 2026-08-09.
-  - Goal: the dumb forwarder, running in the world.
-  - Status: **DEPLOYED and verified in production.** The standalone
-    `mirafold-relay` repo (single source of truth since G.1) is a
-    dependency-light (`ws` only) portable Node process — a PURE forwarder:
-    parses no frames, stores nothing, serves NO app bundle (the phone app
-    loads from the separate static origin, then opens the encrypted
-    socket — the documented trust decision). Hardening: global + per-pair
-    + per-IP connection caps, frame rate limit, heartbeat reaper, max
-    payload, `/health` + 404-everything. Live at `genui-relay.fly.dev`,
-    under our name at **`wss://relay.mirafold.sh`** (cert issued; smoke
-    passes; a real daemon streamed a full turn while `fly logs` showed
-    only connection metadata — the "learned nothing" Done-when, observed
-    in production). Full build/deploy/rename history (incl. the GENUI® →
-    Mirafold naming story) → PLAN-ARCHIVE.md ("Step R.2 — status history"
-    + the 2026-07-17 move).
-  - Closure record: (1) the **cellular-phone pass** — ✅ **FIRST HALF
-    DONE 2026-07-30**: Kyle paired his phone and ran a session over
-    **cellular with wifi off**, on the fixed 0.3.0 build. Notable because
-    his house is rural with near-unusable data — he found one spot with
-    signal and it worked there, so the pass happened on a *marginal* link
-    rather than a strong one, which is the harder case. ✅ **SECOND HALF
-    DONE the same day**: the **wifi→LTE mid-turn flip, run twice** — wifi
-    dropped while a turn was streaming and the session recovered on its own
-    both times. **The cellular-phone pass is CLOSED.** (2) ✅ **Bake the
-    default `MIRAFOLD_RELAY_URL` — DONE 2026-07-30** (`43441ac`,
-    `server/relay/relay-url.ts`): unset now means the hosted relay
-    (`wss://relay.mirafold.sh`) — but ONLY when an entitlement is
-    configured; an unentitled daemon never dials (a gated relay would
-    refuse it 4007 on a widening retry forever) and gets one actionable
-    boot line instead. `MIRAFOLD_RELAY_URL=off` opts out; explicit URLs
-    keep pre-bake behavior verbatim (self-host + dev stub); the app origin
-    defaults to `https://app.mirafold.com` only when riding the baked
-    default. The bake-lands-WITH-the-gate constraint was satisfied — the
-    gate has been ON in production since 2026-07-22. Verified: 9 unit
-    tests (unentitled guard mutation-tested), Tiers 1+2 green, live boots
-    in all four modes. *Follow-up ✅ FIXED same day, Kyle-directed
-    (`92acd37`): production (Fly's proxy) delivers refusal closes ~5s
-    after open — locally 14ms — which defeated relay-client's 400ms
-    pair-confirm, so an invalid/lapsed license logged a false "paired",
-    reset backoff, and churned at ~6s forever. The confirm timer now
-    earns only the "paired" log; the backoff decision moved to close (a
-    refusal never resets, a confirmed ordinary drop still does).
-    Mutation-tested pin + live-verified against production: gaps double
-    1s→16s+ toward the 30s ceiling.* (3) ✅ **Rename completed 2026-08-09:**
-    the product package and GitHub repositories already carried the Mirafold
-    name; the local repositories are now `mirafold/` and `mirafold-relay/`,
-    with the sibling integration test, CI checkout layout, and current
-    workspace paths updated to match. The deployed Fly app names remain
-    `genui-relay` / `genui-relay-staging`, and the `genui-relay v1`
-    key-derivation salt remains frozen as a protocol contract. Verified after
-    the rename: Mirafold typecheck; Tier 1 563/563, Tier 2 143/143, Tier 3
-    82/82; relay typecheck and 38/38 relay tests. **Release-gate follow-up
-    (2026-08-09):** release PR #27 exposed a pre-existing test-only race: the
-    relay-handshake helper waited a fixed number of event-loop turns before
-    closing its healthy socket, so delayed WebCrypto work could miss the
-    backoff reset. The helper now waits for `SocketClient.onOpen()` — the
-    product state transition the assertion actually depends on. The exact
-    test went from 4/20 failures under concurrent load before the fix to 0/20
-    after it; the containing file passed 32/32, Tier 1 passed 563/563, and
-    typecheck passed.
-  - Done when: a phone on cellular (not the home wifi) drives a home
-    session through the deployed relay, and the relay's logs show it
-    learned nothing but connection metadata.
+  DEPLOYED and verified in production: the standalone `mirafold-relay` repo
+  (single source of truth since G.1), a `ws`-only pure forwarder, live at
+  **`wss://relay.mirafold.sh`** — a real daemon streamed a full turn while
+  the logs showed only connection metadata (the Done-when, observed). The
+  cellular-phone pass closed 2026-07-30 (marginal rural LTE + the wifi→LTE
+  mid-turn flip, twice); the default `MIRAFOLD_RELAY_URL` bake landed
+  2026-07-30 (entitled daemons only — an unentitled daemon never dials;
+  `off` opts out) with the same-day false-"paired" backoff fix; the rename
+  completed 2026-08-09 — the deployed Fly app names (`genui-relay*`) and
+  the `genui-relay v1` key-derivation salt stay frozen as protocol
+  contracts. Full build/deploy/closure history → PLAN-ARCHIVE.md ("Step
+  R.2 — status history" + "Moved 2026-08-12 (prune — completed bodies)").
 
 - [x] **Step R.3 — Per-pair E2E encryption** — done 2026-07-07; WebCrypto AES-GCM, per-connection directional keys off the pairing code, fail-closed on tamper/replay/reorder; the relay sees only ciphertext. → PLAN-ARCHIVE.md.
 
@@ -833,30 +646,12 @@ with it. Both sequence BEFORE R.5.**
     on Kyle's own findings.
   - Known items so far (all reported 2026-07-13; each needs Kyle's
     concrete enumeration before it's actionable):
-    1. **Phone viewport styling + small UX issues** — ✅ **RESOLVED
-       2026-07-22** over three same-day rounds against Kyle's real phone
-       (full round-by-round detail → PLAN-ARCHIVE.md). Round 1: the app frame
-       is pinned (100dvh + `overflow-x: clip` + no overscroll — only the
-       render zone scrolls) and all focusable inputs are ≥16px, which was the
-       actual cause of the sideways drift (sub-16px made iOS zoom on focus
-       and LEAVE the page zoomed); viewport meta gained `viewport-fit=cover`
-       + `interactive-widget=resizes-content`. Round 2: the phone status bar
-       became ONE row with the agent name beside the dot, and **on phone
-       Enter NEVER submits** — newline only, with an in-box ↑ send button
-       (bottom-right, swaps with ■ esc while busy) as the one way to send;
-       desktop Enter-to-send unchanged. Round 3 (Kyle: the on-row fleet
-       folder read as clutter on BOTH platforms — the round-2 column was a
-       miss): **details-on-demand instead of persistent chrome** — the
-       settings card gained a **Session section** (agent, model, folder,
-       usage, session id, daemon version), reachable two zero-chrome ways
-       (the gear, and the **agent chip beside the dot is now a button**);
-       the fleet folder column was removed (desktop hover tooltip restored)
-       and the prompt cwd crumb is DESKTOP-ONLY. Pinned throughout in
-       `phone.e2e.ts`. **Kyle's real-phone look at round 3 came back
-       emphatically positive ("flabbergasted… looks incredible")** — the
-       styling core of this item is validated on the device that opened it.
-       *The theme pill is hidden on phone with the settings picker carrying
-       theme; the Phase S pill lock is desktop-scoped — Kyle confirmed.*
+    1. **Phone viewport styling + small UX issues** — ✅ RESOLVED
+       2026-07-22 over three same-day rounds on Kyle's real phone
+       ("flabbergasted… looks incredible"); pinned in `phone.e2e.ts`. The
+       theme pill is hidden on phone (the settings picker carries theme) —
+       the Phase S pill lock is desktop-scoped, Kyle confirmed. Round
+       detail → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
     2. **Desktop styling issues too** — "from the session to the
        fleetview": the session view AND FleetView both have styling
        problems in Kyle's eyes. Details owed; enumerate screen by screen
@@ -894,114 +689,31 @@ with it. Both sequence BEFORE R.5.**
        is stored), then close each gap or document the divergence as a
        deliberate, disclosed exception. Specifics owed from Kyle: which
        agent(s) and which prompt flows he saw diverge.
-    4. **Startup/onboarding flow — redesign discussion. BIG (Kyle's
-       word).** Kyle's sketch (2026-07-13, explicitly not settled — "im
-       not sure"): a staged flow — pick the agent first, then how it's
-       backed (subscription vs. API keys), then the model. Hard
-       requirements he voiced: (a) "simple af"; (b) surface what the
-       user ALREADY HAS — detected credentials make it obvious what they
-       can pick right now; (c) unavailable options stay VISIBLE but
-       clearly unavailable (gray out, not hide — it must read as "an
-       option if you want it"); (d) each unavailable option carries
-       how-to-get-it instructions inline. Raw material that already
-       exists: R.4b/R.4i/R.4k built live-credential detection, the
-       tri-state picker (`live`/`blocked`/`none`), per-row `detail`
-       labels, and where-to-get-it links — this redesign re-stages that
-       material, it doesn't start from zero. One constraint the
-       discussion must start from: the "subscription or keys" step
-       collides with the provider policy (`server/provider-policy.ts`) —
-       Claude/Gemini subscriptions are prohibited in writing (never a
-       choice), while Codex subscription is live locally only as a
-       disclosed gray area (the K.3 disclosed-uncertainty rule — its
-       caveat must ride the option), and no subscription ever rides the
-       relay; the flow has to present that honestly per agent rather
-       than offering a symmetric subscription-vs-keys fork. Also
-       new vs. today: a model-selection step (today model comes from
-       DEFAULT_MODEL/agent config, not the onboarding UI). Next action:
-       a dedicated design discussion with Kyle BEFORE any build.
-       **Status (2026-07-17): the design discussion HAPPENED and the build
-       is scheduled — this item's outcome is Phase N** (the two-step
-       agent → backing picker with probed local-server discovery; the four
-       hard requirements carried into Phase N's charter verbatim). This
-       item closes when Phase N ships; items 1–3 remain open intake.
-    5. **Pairing lands IN the session you paired from — ✅ DONE 2026-07-27,
-       exactly to the investigated shape (investigation text → PLAN-ARCHIVE.md).** The QR/copy link from a
-       session's status bar now carries `&s=<sessionId>` in the fragment;
-       `main.tsx` rewrites the path to `/s/<id>` before the router reads it,
-       **carrying `location.hash` through the rewrite** (the investigated trap —
-       mutation-tested: dropping the hash was watched to fail the phone e2e,
-       then restored). New pure parser `sessionHintFromFragment` in `ws.ts`
-       validates the id as a full `[\w-]+` token (hostile values dropped
-       whole, never truncated). Mission control's pair button passes no id
-       and keeps landing on the fleet — no special case. The hint is never
-       persisted (one-shot intent). The refused-subscription edge case was
-       decided as KEEP existing behavior: the device lands inside the
-       refused session, where the R.4i notice explains — not bounced to
-       mission control. Verified: unit tests beside the fragment tests, the
-       phone e2e now asserts the paired link lands on `/s/<id>` with no
-       fleet list, full Tier-1 (394) + Tier-3 (57) green.
-    6. **Phone session died after backgrounding — ✅ FIXED 2026-07-25
-       (`0c993e0`).** Kyle, on Chrome: session open on the phone, switch to
-       another app for a few minutes, come back, and the session was
-       effectively dead — welcome screen, no transcript, Explorer grayed,
-       no end button, prompts going nowhere — while the same session ran
-       fine on his desktop. Cause: the pairing code lived only in per-tab
-       storage, which does not survive a browser discarding a backgrounded
-       tab, and the rebuilt tab can't recover it from the URL either (the
-       fragment is scrubbed on first load, by design). The shell attached
-       to nothing and said nothing about it. Reproduced against a real
-       daemon over the relay on a phone-sized Chrome — freezing the page
-       (CDP `Page.setWebLifecycleState`) recovers, reloading with the store
-       intact recovers, reloading with it dropped gives Kyle's screen
-       symptom for symptom. Fix: the stash is the device's now, bounded by
-       a 7-day expiry (aged-out entries are deleted) on top of the existing
-       per-launch codes; per-tab storage is still read so an already-paired
-       tab keeps working. Pinned by 4 unit tests + a phone e2e that wipes
-       the store, reloads, and asserts the session comes back with its
-       transcript. **Note for whoever picks up item 5** (pair-into-the-
-       session): that work touches the same boot path, so re-run this e2e.
+    4. **Startup/onboarding flow redesign** — ✅ CLOSED: the design
+       discussion happened and its outcome shipped as Phase N (2026-07-17),
+       the four hard requirements carried into that charter verbatim.
+       Original sketch + constraints → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+    5. **Pairing lands IN the session you paired from** — ✅ DONE
+       2026-07-27 to the investigated shape (`&s=<id>` fragment hint,
+       hash carried through the rewrite — mutation-tested). Decided: a
+       refused-subscription device still lands IN the session, where the
+       R.4i notice explains — never bounced to mission control. →
+       PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+    6. **Phone session died after backgrounding** — ✅ FIXED 2026-07-25
+       (`0c993e0`): the pairing stash is the device's, bounded by a 7-day
+       expiry, so a browser-discarded backgrounded tab recovers its
+       session with transcript. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
     7. **Swipe-to-open the Explorer on phone — DECIDED AGAINST 2026-07-25
-       (Kyle).** Swipe right from the left edge to open the tree, left to
-       close. Mechanically easy (~30–45 min: the panel is already one
-       boolean, plus a touch hook beside `use-escape`/`use-is-phone`, no
-       dependency). Killed on one caveat: iOS reserves a left-edge swipe
-       for browser back-navigation and a page cannot reliably override it,
-       so the gesture would fire history-back instead of opening the panel
-       on iPhones. Kyle: "i dont want to do it if it wont work consistently
-       for iphones." Don't re-propose without a way around that.
-    8. **Leftovers from the 2026-07-28 whole-repo review — recorded, not
-       fixed (the rest of that review's bug list WAS fixed the same day,
-       eleven `fix:` commits).** Two items survive unfixed, each needing a
-       decision rather than a patch:
-       (a) **A daemon-initiated viewport drop reads as "desktop not
-       reachable" on the phone.** The daemon sends the relay `{t:"close"}`
-       for three distinct reasons — tampered frame, 90s idle reap,
-       viewport-cap refusal — and the relay (stub and sibling service
-       alike) closes the viewport with `CLOSE_BAD_CODE` ("no daemon paired
-       under that id"), which `ws.ts` maps to "Desktop not reachable — is
-       Mirafold running there?" So a live, healthy desktop that rejected a
-       frame tells the phone the desktop is down. Current behavior is
-       PINNED by relay.itest tests, so it may be intended; distinguishing
-       the reasons means a new close code in the relay envelope — a
-       cross-repo contract change (genui-relay's mirrored contract.ts) —
-       so it should ride the next deliberate envelope revision, not a
-       drive-by fix. **Triage (2026-07-28, Kyle): nice-to-have, not a big
-       deal — fix only if really easy, and it isn't (the close frame must
-       grow an optional code field, mirrored + both suites + a relay
-       redeploy). So: ride the next envelope revision, alongside the
-       pairing-id URL move's standing policy. Cheap head start when that
-       happens: the vocabulary already has the right code —
-       CLOSE_OVERLOADED 4004, which ws.ts already maps to a capacity
-       message — the daemon's cap-refusal close just can't name it yet.**
-       (b) **`ClaudeCodeSession.announcedTools` retains ids across
-       interrupted turns — ✅ RESOLVED 2026-07-28, Kyle's call.** Of the
-       three options (leave it; clear on interrupt(), which drops a
-       post-interrupt late result that today completes its row; clear at
-       the TURN BOUNDARY, which only drops a cross-turn straggler — a
-       result for a turn that already ended), Kyle picked the turn-
-       boundary variant. The clear lives with the other per-turn resets
-       in handleResultMsg; Tier-1 pins that a turn-2 result for turn 1's
-       announced id is dropped, never completing the old row.
+       (Kyle):** iOS reserves a left-edge swipe for browser back-navigation
+       and a page cannot reliably override it. Don't re-propose without a
+       way around that. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+    8. **2026-07-28 whole-repo review leftovers** — (a) a daemon-initiated
+       viewport drop reads as "desktop not reachable" on the phone; triaged
+       nice-to-have (Kyle): ride the NEXT deliberate envelope revision,
+       never a drive-by (head start: CLOSE_OVERLOADED 4004 already maps to
+       a capacity message client-side). (b) `announcedTools` cross-turn
+       retention — ✅ RESOLVED 2026-07-28, Kyle's call: turn-boundary
+       clear, Tier-1-pinned. Full detail → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
   - Done when: each item above is enumerated concretely with Kyle,
     triaged (fix now / R.6 pre-release blocker / post-launch), and either
     fixed or explicitly scheduled — and the permissions fidelity item has
@@ -1105,346 +817,25 @@ with it. Both sequence BEFORE R.5.**
     "sandbox-mode purchase" — superseded by the 2026-07-22 no-sandbox
     decision above.)*
 
-- [x] **Step R.5b — Release strategy, locked (all three repos)** — ✅ **DONE
-  2026-07-31: ratified, and EXECUTED the same evening** (Friday 2026-07-31
-  public + publish · Sat–Mon quiet window · Tuesday 2026-08-04 announcement).
-  Full sequence, owners, and rollback levers in the RATIFIED block below.
-  *(a decision to make + write down, not a build; do before R.6's final
-  week)*
-  - Goal: one agreed, written release sequence so R.6/R.7 execute a plan
-    instead of improvising how each piece ships.
-  - Decide and record: (a) **shape of the release** — *first half DECIDED
-    (Kyle, 2026-07-22, in commissioning the R.5 build; sharpened the same
-    day): a **private beta precedes the public splash**, and it runs the
-    **full real billing flow** — NO sandbox, NO comped tokens. The beta
-    starts when the relay's entitlement gate flips ON (the `fly secrets set
-    RELAY_ENTITLEMENT_PUBLIC_KEY` moment) with live Paddle wired; Kyle's own
-    real-card purchase is the first end-to-end, then testers buy real
-    subscriptions riding the 7-day card-required trial ($0 if they cancel
-    in-window; Kyle personally reimburses anyone charged past day 7). The
-    mint script is ops/emergency tooling, not a beta access path.
-    **2026-07-22 (night): the gate is ON and the whole path is proven** —
-    Kyle's real purchase → license key → daemon token exchange → paired
-    through the closed gate; unentitled dials probed refusing 4007. **But
-    tester invites are explicitly gated on a phone-view UI pass first**
-    (Kyle: obvious flaws remain — see R.4l's phone-styling items; the
-    billing machinery being done does not make the product show-ready).
-    Still to decide here: beta size/who, its duration/exit criteria, and
-    how R.5c's user-testing round folds in — **ANSWERED by the 2026-07-31
-    ratification below: duration is Sunday 08-02 + Monday 08-03, the exit
-    criterion is "the public install path works and nothing breaks," and
-    the window IS R.5c's user-testing round; only the tester list itself
-    stays open;* remainder of (a) — staged
-    rollout vs. one splash for the PUBLIC release — **DECIDED 2026-07-25
-    (Kyle): ONE splash, as big as possible.** A soft/staged launch
-    (publish quietly, announce later) was considered and rejected: the
-    pre-public work gates going public at all, not announcing loudly, so
-    a quiet period pays nearly the full launch cost for almost none of
-    the audience; the channel list was instead expanded (R.6's
-    launch-channel prep + Product Hunt in R.7's sequence);
-    (b) **per-repo mechanics + order** — `genui-shell` (repo public + `npm
-    publish` + versioning/cadence), `genui-relay` (deploy pipeline, **when
-    the repo flips public — owed to K.1, which relicensed it MIT**, when the
-    entitlement gate flips ON, when the default `MIRAFOLD_RELAY_URL` bake
-    lands — see R.2), `mirafold-site` (checkout button flip, demo swap); (c)
-    **rollback / kill-switch** for each (the relay gate and per-daemon relay
-    URL are the levers) — *for the npm package the rollback move is
-    re-pointing the `latest` dist-tag at the previous good version
-    (+ `npm deprecate` on the bad one), never an unpublish (npm barely
-    permits it and installed users aren't affected either way); for the
-    relay it's `fly deploy --image <prev>` (already in
-    `mirafold-relay/DEPLOY.md`); for the site it's the Pages one-click
-    deployment rollback (KV does NOT roll back with it — see R.6's KV note)*; (d) how the codebase/npm/GitHub rename (R.2) is
-    sequenced into all of the above; (e) *already decided 2026-07-15
-    (K.9): contributor policy is **DCO**, not CLA* — `Signed-off-by` per
-    commit, CONTRIBUTING.md landed in both repos that day; what remains
-    for this step is only the mechanics: enable the GitHub DCO status
-    check on both repos as part of the public flip.
-  - **CI hardening at the flip (from the 2026-07-21 audit of the C.1 work):**
-    once a repo is public, any fork PR's test suite runs on the CI runner, so
-    the CI's trust posture matters. Already in place from C.1: the token is
-    `permissions: contents: read` (read-only — a malicious dependency install
-    script can't push to the repo) and no secrets are used (Tier 4 excluded,
-    credentials forced empty). Do AT the flip: (i) re-enable the cross-repo
-    relay itest now that `genui-relay` is public and checkout-able — drop the
-    `tsconfig.ci.json` exclusion + the Tier-2 `find` filter and add a sibling
-    checkout (see Phase C's carried-forward list + `tsconfig.ci.json`);
-    (ii) optionally SHA-pin the
-    `actions/checkout` / `actions/setup-node` steps (they're pinned to `@v4`
-    tags today — fine for GitHub's own official actions, stricter as a full
-    commit SHA). No secret was ever added, and none should be — the "no
-    provider credential in repo secrets" bound (C.1) is absolute.
-  - **Dependency-alert sweep at the flip (2026-07-22 audit):** before EACH
-    repo goes public, clear its open Dependabot alerts — open alerts on the
-    default branch become publicly visible the moment the repo does, and
-    they're a stranger's first impression of the project's hygiene. The
-    site repo already carries this in its pre-public hardening trio; this
-    line extends the same sweep to **this repo and `genui-relay`**. (Shell
-    repo swept 2026-07-22: `shell-quote` ≥1.9 + `@hono/node-server` ≥2.0.5
-    forced via yarn resolutions — the MCP SDK still pins hono 1.x upstream,
-    so the resolution stays until the SDK moves; all tiers green on 2.0.11.)
-    **2026-07-25: shell repo now at ZERO open alerts** — transitive
-    `postcss` 8.5.16 → 8.5.23 (GHSA-r28c-9q8g-f849, high, dev-scope; via
-    vite, so a lockfile re-resolve only, no resolution needed) landed as
-    `c660130`, typecheck + all tiers green (369/103/52), alert #4 verified
-    "fixed" via the GitHub API. The `genui-relay` half was verified the
-    same day: alerts confirmed ENABLED on that repo (API 204) with zero
-    open, and a local `npm audit` at `9f35e2d` found 0 vulnerabilities —
-    clean today; still RE-verify at its public flip, since new advisories
-    can land anytime.
-  - **EAR notification email at the flip (added 2026-07-27, from the K.11
-    amendment):** when the repos go public, send the one-time
-    §742.15(b) email to crypt@bis.doc.gov + enc@nsa.gov with the repo
-    URLs. $0, five minutes, settles the notification question regardless
-    of which reading of the 2021 rule is right (detail in K.11's note).
-  - **Gate on the relay flip (2026-07-15 audit): ✅ SATISFIED 2026-07-30.**
-    Before `genui-relay` goes public in (b), run a dedicated security-audit
-    pass over that repo — public security-marketed code gets adversarial
-    readers on day one. *Done: a dedicated isolated-adversarial read of all
-    ~850 lines (the checklist-driven 07-27 tri-repo audit and the 07-29
-    bughunt were a different lens each; this one asked only "hostile reader,
-    how do I hurt the service"). **No new exploitable findings** — the three
-    prior waves closed the real vectors (the malformed-URL process crash
-    07-27, the byte-rate + backpressure gaps 07-27, the per-frame
-    log/re-forward amplification 07-29); the entitlement verifier is
-    correctly ordered (no attacker JSON reaches the parser pre-signature),
-    every send is readyState-guarded or error-caught, and the prod
-    dependency surface is exactly `ws` with `npm audit` clean. Accepted
-    residuals, all safe: refused-log `origin` is verbatim-but-JSON-escaped
-    attacker text (ops-useful, size-capped); the churn-gate sweep needs the
-    heartbeat (ARCHITECTURE §10, off-by-default gate); the WS upgrade
-    completes before the capacity cap refuses (inherent to clean
-    close-codes, socket-cap bounded). Suite 38/38. The relay may flip on
-    schedule.*
-  - **Release provenance (adopted 2026-07-29, from beta tester 002's
-    evaluation):** a public repo alone doesn't let anyone verify the
-    published npm package was built FROM it — the two are separate uploads
-    with no link, and the package ships compiled bundles. Adopt as standing
-    release practice, first release included: (i) publish via a GitHub
-    Actions **release workflow** using npm **trusted publishing** (npmjs.com
-    configured to accept `mirafold` publishes only from that workflow —
-    identity-federated, NO stored npm token, so the no-secrets-in-CI bound
-    holds and a stolen npm password can't publish) with
-    `npm publish --provenance` (machine-signed attestation binding the
-    package to the exact public commit + workflow; users verify with
-    `npm audit signatures`, README gets the one-liner); (ii) a **signed git
-    tag** per release (SSH signing key — Kyle's, minutes to set up) with the
-    tarball's **SHA-256 in the tag message** and in the GitHub Release
-    notes. This changes R.7's publish move: Kyle pushes the signed tag and
-    the workflow publishes — no hand-run `npm publish`. Kyle's-hands parts:
-    the npmjs.com trusted-publisher form (~5 min, walked one step at a
-    time) and generating/registering the signing key. Caveat: provenance
-    requires a public repo, so the end-to-end proof fires at the first real
-    publish (launch morning) — same class as R.7's existing `npx` check;
-    everything short of that rehearses beforehand.
-    *Status 2026-07-30: the release workflow LANDED* —
-    `.github/workflows/release.yml` (`52ca799`): tag push (v*) → tag↔
-    version check → typecheck + Tier 1 → pack with the tarball SHA-256 in
-    the job summary (for the Release notes) → `npm publish --provenance`;
-    `contents: read` + `id-token: write` only, no stored token, fails
-    closed until the trusted-publisher form is done. `workflow_dispatch`
-    is the dry-run rehearsal; `npm pack` + `npm publish --dry-run` also
-    rehearsed locally on 0.2.0. *Both Kyle-hands parts ✅ DONE
-    2026-07-30:* the npmjs.com trusted-publisher form (GitHub Actions ·
-    `mirafold/mirafold` · `release.yml` · env blank · publish only,
-    stage off) and the dedicated ed25519 signing key (repo-local git
-    config signs all tags, sign smoke-tested; public half registered on
-    GitHub as a signing key). The publish path is fully set up; its
-    end-to-end proof fires at the first real publish, per the caveat
-    above.
-  - **DRAFT release sequence (2026-07-29, assistant — Kyle to ratify;
-    "launch asap" is the directive it serves):**
-    - *Preconditions, any order, all before T-0:* 4.15 ✓ (done);
-      provenance release workflow landed + build/pack rehearsed (publish
-      itself fires at T-0); npm trusted-publisher configured (Kyle,
-      npmjs.com form) + SSH signing key registered (Kyle); Dependabot
-      re-verified zero on BOTH code repos; the relay repo's dedicated
-      security-audit pass (gates its flip); tracked-docs disclosure review
-      (Kyle reads what goes public: BUSINESS.md, PLAN + archive, git
-      history); theme value guards landed ✅; Paddle payout details ✅ (set
-      up — confirmed 2026-07-30); launch copy + Product Hunt draft ready ✅;
-      R.6's real-hardware checks done.
-    - *T-0 morning, in order:* (1) `mirafold/mirafold` public → enable the
-      DCO check + re-enable the cross-repo relay itest in CI; (2)
-      `mirafold-relay` public (only if its audit passed); (3) Kyle pushes
-      the signed release tag → the workflow publishes to npm with
-      provenance over the 0.0.1 placeholder; (4) verify cold:
-      `npx mirafold` + `npm audit signatures`; (5) site stays as-is (its
-      install line `npm i -g mirafold` becomes true at step 3; checkout
-      already live); (6) the splash: X + Show HN + Product Hunt +
-      r/ClaudeAI + r/LocalLLaMA. Same week: newsletter submissions,
-      awesome-list PRs, the BIS §742.15(b) email, the provider-terms
-      re-check (R.7's standing item).
-    - *Rollback levers:* npm = re-point the `latest` dist-tag + deprecate
-      (never unpublish); relay = `fly deploy --image <prev>`; site = Pages
-      one-click rollback (KV does not roll back with it).
-    - *Rename (d): resolved* — the GitHub org/repo and the npm name are
-      already `mirafold`; the internal folder/Fly names are non-gating
-      (umbrella note 2026-07-11).
-    - **AMENDMENT (Kyle, 2026-07-29): the flip and the splash separate.**
-      Everything goes truly public QUIETLY first — repos public, signed
-      tag pushed, workflow publishes to npm, verifications run — then a
-      **live-fire window of AT MOST 2 days** with a few more personally-
-      invited testers installing via the real public path
-      (`npm i -g mirafold`), then the one big splash, unchanged in shape.
-      This amends (not reverses) the 2026-07-25 "ONE splash" decision:
-      what was rejected then was a quiet launch *strategy*; this is a
-      bounded smoke-test window with the single announcement event kept.
-      It also converts R.7's two publish-only checks (`npx mirafold`,
-      `npm audit signatures`) into pre-splash facts, and in practice it IS
-      R.5c's user-testing round — real users, real hardware, the exact
-      artifact the public gets. `/beta` is NOT removed at the flip: it
-      becomes a short "we're live — `npm i -g mirafold`" note, so the link
-      already printed in every tester's WELCOME.md keeps working and
-      upgrades them to the public path. Every pre-PUBLIC gate still
-      precedes the quiet flip (tracked-docs/history review, relay audit
-      before ITS flip, Dependabot re-verify, provenance setup) — quiet
-      defers only the announcement, never a gate.
-    - *Still Kyle's calls, marked open:* (i) ✅ **DECIDED 2026-07-30: the
-      public cut is 0.3.0** — bumped on main (`b63941c`); `v0.3.0` is the
-      launch tag; (ii) ✅ **DECIDED 2026-07-31: the dates — see the
-      ratification below.**
-  - ## ✅ RATIFIED 2026-07-31 (Kyle) — this is the plan, no longer a draft
-    Every precondition above is MET, each measured rather than read off a
-    doc: the release workflow rehearsed successfully (run `30630399899`,
-    `workflow_dispatch` on `main`, **success in 2m34s**, never
-    authenticated); npm trusted publisher + ed25519 signing key configured
-    2026-07-30; the relay repo's dedicated security-audit pass clean
-    2026-07-30; the tracked-docs disclosure read done 2026-07-31, with Kyle
-    deciding to **publish everything as tracked — no trims, no
-    move-private**; Dependabot zero open on both code repos (re-verified at
-    the flip, per the sweep note above); LTE phone pass, theme guards,
-    Paddle payout, launch copy + Product Hunt draft all done.
-
-    **The dates (moved EARLIER by one day — Kyle, 2026-07-31 evening, after
-    ratifying Saturday the same day; see the note below):**
-    - **Friday 2026-07-31, evening** — everything goes public and gets
-      published. No announcement.
-    - **Saturday 08-01 + Sunday 08-02 + Monday 08-03** — the quiet window. A
-      handful of personally-invited testers install via the real public path
-      (`npm i -g mirafold`) and use it. This IS R.5c's user-testing round.
-    - **Tuesday 2026-08-04, US morning** — the single announcement: X, Show
-      HN, Product Hunt, r/ClaudeAI, r/LocalLLaMA.
-
-    *On the window: it was first set at Saturday night → Tuesday (~2.5
-    days), then moved a day earlier to Friday night → Tuesday (~3.5 days)
-    when Kyle asked whether the longer gap hurt. It does not: the window
-    exists so invited testers exercise the real public install path before
-    strangers do, and more days serve that purpose rather than eroding it.
-    Nothing decays while it sits — the package is on npm, the repos are
-    public, and nobody is looking. Both figures stretch the amendment's "AT
-    MOST 2 days" bound, which was self-imposed; these dates supersede it.
-    Checked and dismissed as non-factors: staleness (neither Hacker News
-    nor Product Hunt weighs how long something has been available — Show HN
-    only requires that YOU are showing something people can try, and the
-    443-commit history was already public-facing either way) and
-    pre-emption (a stranger posting the link first is negligible; the one
-    plausible path is an invited tester, addressed by telling them it is
-    not announced until Tuesday). The residual risk, accepted: Hacker News
-    gives a URL roughly one shot, so if someone else posts it and it lands
-    well, that run is spent and Kyle would not be in the thread — the
-    fallback is that `mirafold.com` is a separate URL from the repo.*
-
-    ### ✅ EXECUTED — Friday 2026-07-31 evening. Mirafold is PUBLIC and LIVE.
-    Measured at each step, not assumed:
-    - Both repos **public** (API-confirmed): `mirafold/mirafold`,
-      `mirafold/mirafold-relay`. Dependabot **0 open on both** at the flip.
-    - DCO sign-off app installed on both (shows on PRs; it does not BLOCK a
-      merge until branch protection lands — deliberately deferred to after
-      Tuesday so launch weekend keeps a friction-free hotfix path).
-    - Signed tag **`v0.3.0`** pushed at commit
-      **`910cb246f04606a0e7f0274358122eabbbe43fea`**. Release run
-      **`30663563802`** — success in **1m32s**, every step green through
-      "Publish (tag push — provenance over trusted publishing)".
-    - **`mirafold@0.3.0` is on npm.** Published tarball SHA-256
-      **`804bd065ba51b156c59d8f2a7bf1e5a50bffa547a031c7830cf1164ee7f60518`**
-      (registry download re-hashed locally — matches CI byte for byte).
-      17 files, 5,063,377 bytes unpacked.
-    - **Provenance verified end-to-end**, which is the whole point of R.5b:
-      the SLSA attestation binds `pkg:npm/mirafold@0.3.0` to source
-      `git+https://github.com/mirafold/mirafold@refs/tags/v0.3.0`, commit
-      `910cb246…`, built by `.github/workflows/release.yml`. A skeptic can
-      now prove the package came from the public source. `npm audit
-      signatures` on a cold install: 116/116 verified registry signatures,
-      16 verified attestations, 0 invalid, 0 missing.
-    - **Cold-install proof** (fresh dir, package pulled from the public
-      registry, no repo checkout): `--version` → `0.3.0`; daemon boots,
-      serves `HTTP 200` with `<title>Mirafold</title>`; the per-launch auth
-      token → cookie redirect works; a busy port rolls to the next one; with
-      no license key it correctly says remote access is off. The
-      `@parcel/watcher` install-script warning appeared exactly as the
-      README documents.
-    - `mirafold.com/beta` rewritten to the public path and **verified live**
-      (site commit `7e46469`): `npm i -g mirafold`, `npm audit signatures`,
-      the new SHA-256, and a link to the now-public repo. Every tester's
-      existing WELCOME.md link keeps working and upgrades them.
-
-    **Still owed after this (see the resume list in ROADMAP.md):** the
-    GitHub Release for `v0.3.0` with the SHA-256 in the notes (Kyle's
-    hand-made step, per the workflow's own comment); re-enabling the
-    cross-repo relay itest in CI now that the relay is public; tester
-    invites for the quiet window; Tuesday's announcement; then branch
-    protection + the `next`/`release/x.y.z` model, and the BIS §742.15(b)
-    email.
-
-    **Launch-evening steps, in order, with owner.** Assistant runs 1, 5, 7, 8;
-    Kyle runs 2, 3, 4, 6 — all four are GitHub-settings or signing-key
-    actions, his hands by the privileged-mutation rule.
-    1. Confirm Dependabot still zero on BOTH code repos — *assistant*.
-    2. `mirafold/mirafold` → public — *Kyle* (GitHub settings).
-    3. `mirafold/mirafold-relay` → public — *Kyle* (GitHub settings).
-    4. Enable the DCO sign-off check on both repos — *Kyle*.
-    5. ~~Re-enable the cross-repo relay itest in CI~~ — ✅ **DONE 2026-08-02**
-       (*assistant*); see the resolution note under "Owed at the public flip"
-       below. ~~⬜ Not yet opened as a PR, so not yet exercised on a runner.~~
-       *(Stale — it WAS exercised: `f30a6dc` was pushed to `main` 2026-08-02
-       and its CI run passed on the real runner, sibling relay checkout and
-       all. Verified from the run list 2026-08-07.)*
-    6. Push the signed `v0.3.0` tag — *Kyle*. **This is the publish**: the
-       tag push triggers `release.yml`, which builds and runs
-       `npm publish --provenance`. No hand-run `npm publish`, ever. Expect
-       ~2m34s, per the rehearsal.
-    7. **Verify the same night, before bed — non-negotiable.** Cold install
-       the way a stranger would (`npx mirafold`) + `npm audit signatures` —
-       *assistant*. Publishing and sleeping unverified would leave a broken
-       package installable for hours undetected; the publish is the
-       irreversible move and this is what tells us whether it went wrong.
-    8. `mirafold-site` `/beta` becomes a short "we're live —
-       `npm i -g mirafold`" note, so the link already printed in every
-       tester's `WELCOME.md` keeps working and upgrades them to the public
-       path — *assistant*.
-
-    **Tuesday:** post everywhere. Before posting, search `hn.algolia.com`
-    for "mirafold" — thirty seconds, removes a variable. (The odds of a
-    stranger posting it first during the quiet window are negligible and
-    were overstated in an earlier draft of this note: `mirafold@0.0.1`
-    already exists on npm, so 0.3.0 is a version update rather than a
-    new-package feed event, and a zero-star repo going public is invisible
-    to the star-velocity scrapers. The one plausible leak is an invited
-    tester sharing it — so the invite says "not announced yet, please don't
-    post it anywhere until Tuesday.")
-
-    **Same week, after the announcement:** newsletter submissions,
-    awesome-list PRs, the BIS §742.15(b) email to crypt@bis.doc.gov +
-    enc@nsa.gov with the repo URLs, and R.7's standing provider-terms
-    re-check.
-
-    **Rollback levers, unchanged:** npm = re-point the `latest` dist-tag +
+- [x] **Step R.5b — Release strategy, locked + EXECUTED (all three
+  repos)** — ratified 2026-07-31 (every precondition measured, not read off
+  a doc) and executed the same evening: both repos public, signed `v0.3.0`
+  tag pushed → the provenance release workflow published
+  **`mirafold@0.3.0`** (tarball sha256 `804bd065…`, SLSA attestation
+  verified end-to-end, cold-install proven), quiet tester window Sat–Mon,
+  the single announcement Tuesday 2026-08-04. The full ratified sequence,
+  per-step execution record, and decision history (real-billing beta shape,
+  ONE-splash, the quiet-flip amendment, CI/DCO/dependency-sweep/EAR flip
+  mechanics, release provenance via npm trusted publishing) →
+  PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - **Rollback levers, standing:** npm = re-point the `latest` dist-tag +
     `npm deprecate` (NEVER unpublish); relay = `fly deploy --image <prev>`;
     site = Pages one-click rollback (KV does not roll back with it).
-
-    **Still open, non-gating:** WHO the invited testers are for the Sunday/
-    Monday window — may simply be the existing beta testers, told to
-    reinstall via `npm i -g mirafold`. Kyle's call, answerable any time
-    before Saturday night.
-
-    **Understood and accepted:** step 6 is the first irreversible move in
-    this project. An npm publish cannot be withdrawn, and a public repo
-    exposes all 443 commits plus every tracked doc permanently.
-  - Done when: a written release-sequence exists that R.6 and R.7 just
-    follow, with no open "how do we actually ship this" questions —
-    ✅ **MET 2026-07-31** by the ratification above; only the non-gating
-    tester-list question remains.
+  - **Tails recorded as owed at execution** (verify current state before
+    acting on either): the hand-made GitHub Release for `v0.3.0` carrying
+    the tarball SHA-256, and the BIS §742.15(b) email. The other execution
+    tails (cross-repo relay itest, branch protection) are recorded done in
+    Phase C.
 
 - [ ] **Step R.5c — User-testing round before release (Kyle-led)** *(needs
   R.2 deployed + the phone experience end-to-end; gates R.7)*
@@ -1459,258 +850,45 @@ with it. Both sequence BEFORE R.5.**
   - Done when: the testing round is complete, every finding is written down,
     and each must-fix item is either fixed or explicitly scheduled as a
     Phase R blocker ahead of R.7.
-  - **Tester-002 thread CLOSED 2026-07-30** (the point-by-point discussion
-    Kyle held open since 07-28; ROADMAP launch item 5). Remaining points
-    resolved, standard practice applied rather than bespoke decisions:
-    **"What is real"** — accurate, and re-verified in passing today (the
-    loopback bind and the `!` cwd confinement + caps both came up
-    independently); noted, NOT used as external validation, since the
-    tester never ran the product and citing a pre-install vetting doc as a
-    security review would overstate it. **Concern 2** (SECURITY.md/tests/
-    docs absent from the tarball) — SECURITY.md ships since 4.15; tests,
-    plans and build instructions deliberately do NOT ship in an npm
-    package, and the README's citations resolve when the repo goes public
-    at R.7. **Concern 3** (the trust boundary is large) — the actionable
-    half is now a **"Running it safely" section in `SECURITY.md`**, which
-    ships inside the package: leave the auth token on, never put the
-    daemon behind a proxy or a LAN bind (the relay is the one supported
-    remote path), treat `!` as your shell, open it somewhere you'd give an
-    agent a terminal, keys stay server-side. Their pilot-only cautions
-    (skip the relay, no keys in `.env`) were deliberately NOT parroted —
-    `.env` in the launch directory IS the supported place for keys.
-    **Recommended pilot preconditions** — all four are satisfied by the
-    launch mechanics already planned: public source at the exact commit
-    (R.7), a signed tag + published fingerprint (R.5b's signed `v0.3.0` +
-    `npm publish --provenance` over trusted publishing), SECURITY.md +
-    lockfile + build instructions in the public repo, and native-install
-    clarity — now written into the README's native-module note, which had
-    claimed no install scripts at all while every npm-12 user sees a
-    `@parcel/watcher` warning (measured: its script is a conditional
-    no-op, prebuilts ship for every mainstream platform). **Bottom line** —
-    their sole blocker was supply-chain provenance, which dissolves at the
-    flip; no separate work. *One item deliberately left alone: the site
-    claims open source in the present tense while the repos are private.
-    That is true-by-R.7 and Kyle has made no decision to change the copy;
-    it resolves itself at the flip.*
-  - Finding #5 (assistant, 2026-07-30, R.6's live-Gemini check — **LAUNCH
-    BLOCKER, FIXED same day**): the `gemini-cli` adapter could not complete a
-    turn on Gemini CLI **0.53.0** (written against 0.51.0). It presented as
-    two failures — a refusal to run headless in an "untrusted" folder, and
-    `IneligibleTierError: This client is no longer supported for Gemini Code
-    Assist for individuals` — but they are **one cause**: 0.53.0 does not load
-    a project's `.gemini/settings.json` for an untrusted folder. That file is
-    where the adapter writes `security.auth.selectedType: "gemini-api-key"`,
-    so the selection was ignored and the CLI fell back to the USER-scope
-    choice; any user who ever logged in interactively (`oauth-personal`) then
-    died on the free-tier client path Google retired, while holding a valid
-    `GEMINI_API_KEY`.
-    **Fix (P.6b):** the workspace-trust question is asked ONCE per folder
-    through the shell's own permission strip — `permission_request` /
-    `permission_resolved`, both existing message types, so the wire protocol
-    is untouched and the ask is shell-owned (the agent can't paint or fake
-    it). A yes is remembered in a new daemon record,
-    `<state>/trusted-workspaces.json` (`server/sessions/workspace-trust.ts`),
-    and carried into the child as `GEMINI_CLI_TRUST_WORKSPACE=true`. A no runs
-    nothing and says why; the session stays usable. Asked once per workspace,
-    ever — matching what their own terminal `gemini` does.
-    **Measured negatives, both of which cost a round of wrong belief:**
-    `--skip-trust` is NOT equivalent — it lets the run proceed but still
-    doesn't load project settings, so auth falls back and the turn dies
-    (proven in a known-good workspace). And `GEMINI_DEFAULT_AUTH_TYPE=
-    gemini-api-key` does nothing at all on 0.53.0 — proven by the case with
-    no project settings + trust + that variable, which still failed. *An
-    earlier draft of this finding named that variable as the fix; it was
-    wrong, and only isolating one variable at a time exposed it.*
-    **Why (b) — reusing `trusted-repos.json` — was proposed and rejected:**
-    that list is the git-programs escape hatch, nothing in the product ever
-    writes it, and it is empty for essentially every project, so it would
-    have left Gemini broken while looking fixed.
-    **Verified:** a real Gemini turn end-to-end through the adapter (trust ask
-    → allow → `PROBE OK`, with usage), on Kyle's real home and its
-    `oauth-personal` login. Tests: `workspace-trust.test.ts` (containment,
-    persistence, malformed/disabled record) and two adapter tests pinning the
-    gate — nothing spawns before the answer, the yes reaches the child as the
-    trust env var and is remembered, a no runs nothing — mutation-checked
-    (defeating the gate fails both).
-    *Standing caveat: Gemini is the most volatile of the three engines —
-    0.51→0.53 both retired an auth path and added this gate in weeks. R.6's
-    live-Gemini check should re-run after Google releases; the other two
-    engines have needed nothing like it.*
-  - Finding #4 (Kyle, 2026-07-30, his own machine — **LAUNCH BLOCKER, fixed
-    same day**): the first time Kyle installed the tarball the way testers
-    do (`npm i -g mirafold.tgz`) instead of running `yarn dev`, onboarding
-    died the moment it navigated to a session URL — a `NotFoundError` from
-    `send`, and no browser session could ever start. **Cause:**
-    `res.sendFile(path.join(DIST, "index.html"))` passes an ABSOLUTE path,
-    and send's default `dotfiles: "ignore"` policy inspects *every segment*
-    of it. `npm i -g` unpacks into the active Node's prefix, which for nvm
-    (`~/.nvm/…`), asdf, volta and fnm carries a dot-segment — so the SPA
-    fallback 404'd for every user on a version manager, i.e. most of the
-    target audience. `GET /` kept working (express.static passes a root, so
-    only the request path is checked), which is why it read as "some people
-    can't get past onboarding" rather than "the server is broken".
-    **Fixed:** `res.sendFile("index.html", { root: DIST })` in
-    `server/index.ts` and `server/relay/relay-stub.ts` — the policy then
-    applies to the relative part only. **Regression:** a Tier-3 test
-    (`server/testing/launcher.e2e.ts`) copies the built `dist/` +
-    `dist-server/` into a manufactured `.nvm-like/` directory, boots the
-    daemon from there and asserts `/s/:id` → 200 with the real app shell;
-    mutation-checked (restoring the old line reproduces the 404).
-    **Why three verification layers missed it:** the repo checkout has no
-    dot-segment so Tier 3 structurally cannot see it; `yarn dev` serves the
-    SPA from Vite, so the daemon's fallback route is never exercised in
-    dev; and the cold-install check booted the daemon and read `--version`
-    without fetching a session URL. The lesson is narrow and worth keeping:
-    **only exercising the packaged artifact from a realistic install path
-    proves the packaged artifact.** Re-packed and re-installed; Kyle
-    confirmed a real session with his Claude API key on the fixed build.
-    `beta/mirafold.tgz` re-cut (sha256 `8f829513…`, was `a9fe4152…`) and
-    `beta/WELCOME.md` updated to match; ⬜ the Drive copy still serves the
-    broken build until Kyle re-uploads.
-  - Finding #3 (Kyle, 2026-07-24, real phone — SERIOUS): starting a NEW
-    session on mobile hung on "connecting…" forever, picker never showed;
-    desktop fine. Root cause: the in-session "new" button opens a fresh tab
-    (`target="_blank" rel="noopener"`), and a noopener new tab inherits
-    neither the URL fragment nor sessionStorage — so on the relay path the
-    new tab had no pairing code, fell back to a daemon-less local ws://, and
-    hung. Desktop's local fallback IS the daemon (worked); mobile resume
-    worked (fleet links stay in-tab). Diagnosed from the daemon
-    flight-recorder + relay structured logs. Fixed: `newSessionHref()`
-    re-encodes the relay target into the new tab's fragment (PR #6, merged
-    to main; unit 322 + round-trip invariant test). DEPLOYED: the
-    git-integrated Cloudflare Pages project auto-rebuilt on merge —
-    app.mirafold.com now serves the fixed bundle (index-D2UVf2h9.js,
-    confirmed live). Awaiting Kyle's real-phone confirmation.
-  - Finding #2 (Kyle, 2026-07-23, his MacBook): the onboarding picker sat
-    flush against the browser window's top/bottom on a short viewport (a
-    ~600px un-maximized Mac Chrome window) instead of floating as a nested
-    modal. Root cause: `.onb-card` had `max-width` but no `max-height`, so
-    it overflowed the centered overlay. Fixed same day: `max-height: 100%`
-    + internal scroll as the hard floor (the overlay's 24px gutter is now
-    always visible), plus an `@media (max-height: 700px)` compact layout
-    (44px glyph, tighter paddings) so typical content FITS at ~600px.
-    Verified by computed-style probe at 607px and 769px viewports + all
-    tiers green; worst-case content (3 credential-less agents, longest
-    hints) scrolls internally with the gutter intact at any height.
-    *(Superseded 2026-07-25: the fleet page's `zoom: 1.15` — a cockpit
-    polish landing — inflated the card 15% while this breakpoint kept
-    measuring the real viewport, so the scrollbar showed at every height
-    under ~890px. The binary compact tier is replaced by a fluid
-    `--onb-squeeze` driver: every vertical metric interpolates full→compact
-    with window height (zoom factor divided out of the vh math), the
-    credentialed picker fits scroll-free down to ~645px real, and scroll
-    remains the last resort for hint-heavy or tiny-window states. E2e pins
-    the ramp — an all-rows-ready daemon swept through it, asserting no
-    internal scroll AND that the glyph actually compressed. `d8abc62`.)*
-  - Finding #3 (proactive sweep after #2, same day): the settings and pair
-    dialogs share the exact defect #2 found in the onboarding card — the
-    S.4 card idiom had `max-width` but no `max-height`. Measured live at a
-    560px viewport: settings (583px natural — the theme list) overflowed
-    the window by 11px top AND bottom; pair (430px) fit but was one short
-    window from the same. Fixed with the same two-line cap on the shared
-    idiom (`max-height: 100%` + internal scroll — inert until a card would
-    overflow). Sweep completeness: these were the ONLY three
-    fixed-position overlay surfaces in the shell (onboarding, settings,
-    pair); the in-session model picker, question component, permission
-    bar, and demo banner are all in-flow and immune. Probed at 560/769,
-    e2e + unit green. NOT done (deliberately): a compact-styles pass for
-    the settings card at short heights — it would touch the theme picker's
-    layout, which is Kyle-locked territory; internal scroll is the
-    accepted behavior there.
-  - **Opened 2026-07-23.** Mechanics locked with Kyle: distribution is a
-    hand-sent `npm pack` tarball (v0.1.0, shell @ 50950a7 / relay @ 3f92992
-    deployed) — NOT npm; testers subscribe FOR REAL via the direct `/pay`
-    link (never comped — Kyle's standing rule; 7-day refund is the out);
-    feedback arrives ad hoc in any form — Kyle collects and forwards it in
-    clusters, so intake here means triaging those clusters as they land,
-    not policing a channel. Welcome note drafted (install incl. the
-    node-pty/npm-scripts fix, credentials, phone-over-cellular ask, the
-    never-paste-boot-output rule, log-file-is-safe-to-attach). That gate CLEARED
-    same day: Kyle lifted the blackout entirely — the full site is public
-    again, all pages verified 200, and the welcome note now lives on-brand
-    at mirafold.com/beta (noindex, unlinked; testers get the direct link).
-    The tarball was also rebuilt on the @lydell/node-pty swap, so install
-    is two commands with no workaround. NOTHING blocks the first invite.
-  - **First finding, fixed same day (2026-07-23):** Kyle, running Codex via
-    OpenRouter, saw the literal stand-in "codex" in the status bar's model
-    slot (Claude showed "default", Gemini "gemini" — same pattern). Kyle's
-    call: a temporary model name that isn't true is dishonest — show
-    NOTHING until the real one is known. Landed as shell @ 003388c:
-    `modelName` is undefined until configured/engine-reported, the wire's
-    usage + fleet-row `model` fields went optional, and the status bar +
-    fleet row render the slot only when known. Gemini's "auto" stays (a
-    genuine configured router-mode value, still refined per turn). All
-    three tiers verified; tarball rebuilt at that commit.
-  - **2026-07-25 status:** version bumped to **0.2.0** with the `engines`
-    Node floor raised to **>=22** (`52ffdaf` — the floor now matches what
-    we actually develop and test on; README, mirafold.com's install note,
-    /beta, and the beta-folder WELCOME.md all state Node 22+ and name
-    `mirafold-0.2.0.tgz`). Tarball rebuilt at `d8abc62` (includes the
-    phone rail fix + onboarding squeeze), staged at
-    `../beta/mirafold-0.2.0.tgz`, cold-install + boot smoke-tested.
-    **Distribution channel (external fact):** testers get it via Kyle's
-    Google Drive link — replace-in-place version upload keeps the link
-    stable; Drive keeps the old display name on content swaps, so the
-    rename to `mirafold-0.2.0.tgz` is a manual step (advised, link
-    survives it). **Uptake (Kyle, 2026-07-25): almost no testers have
-    actually tried it yet** — the stable-link swap was chosen so the
-    already-sent link serves the new build. Also flagged on push: GitHub
-    reports 1 HIGH Dependabot alert on the default branch (dependabot/4);
-    a dependency bump was already in flight in a parallel session the
-    same afternoon. *(Resolved same day: that bump landed as `c660130` —
-    alert #4 "fixed", zero open alerts on the repo; detail in R.5b's
-    sweep note.)*
-  - *(An interim 2026-07-25 evening rebuild — postcss-only delta, verified
-    cold-install — was superseded by the session-end rebuild below; note →
-    PLAN-ARCHIVE.md.)*
-  - **npm-audit noise on install — investigated and settled
-    (2026-07-25):** installing the tarball into a *local project
-    directory* reports 4 moderate advisories, all one chain
-    (`@hono/node-server` <2.0.5 — Windows-only path traversal in
-    `serve-static` — reached transitively via `@modelcontextprotocol/sdk`,
-    which `@anthropic-ai/claude-agent-sdk` also requires as a peer).
-    **Testers never see it: npm skips audit on global installs**, so the
-    documented `npm i -g ./mirafold-0.2.0.tgz` prints no advisory at all
-    (verified against a clean prefix). And it cannot be fixed from our
-    side anyway: the MCP SDK still declares `^1.19.9` at its latest
-    (1.29.0), hono 1.x has no patched release (1.19.15 is the last), a
-    published package's own `overrides` field is ignored by npm (verified
-    by packing one and installing it), and **npm v12 no longer reads an
-    `npm-shrinkwrap.json` shipped inside a tarball** — the one mechanism
-    that used to pin a consumer's transitive tree. `bundleDependencies`,
-    npm's suggested replacement, is a non-starter here: `@lydell/node-pty`
-    and the agent SDK ship per-platform optional binaries. What DID land:
-    `package.json` gains an `overrides` block mirroring the existing yarn
-    `resolutions`, so an `npm install` from source resolves the same tree
-    yarn does (`npm install --package-lock-only` → 0 vulnerabilities);
-    it has no effect on the tarball. Our own testing keeps running the
-    forced 2.0.11, as R.5b's sweep note records.
-  - **Tarball rebuilt once more at session end (2026-07-25), shell
-    `b97f85d`** — still **0.2.0**, Kyle's call ("don't bother updating the
-    version number"). Staged at `../beta/mirafold-0.2.0.tgz` (335,280 bytes,
-    sha256 `69c84f6d…`). Carries everything from that evening: the
-    flat-outline gear, the readable pairing card with copy as its one action,
-    the phone Explorer fixes, the browser bundle no longer shipping
-    package.json, and the discarded-tab pairing fix. Verified by cold
-    `npm i -g` into a throwaway prefix — `--version` 0.2.0, boots, serves
-    HTTP 200 — and by grepping the packed bundle to confirm it actually
-    carries that work rather than trusting the pack. ⬜ **Kyle still owes the
-    replace-in-place upload to Drive.**
-  - **Where the version lives, for whenever it IS bumped (swept
-    2026-07-25):** `mirafold/package.json` is the single source of truth —
-    `bin/mirafold.js` reads it at runtime for `--version` and the boot banner,
-    `web/src/version.ts` imports it at build time for the version the browser
-    announces, and `npm pack` names the tarball from it. Since 2026-07-29
-    NO hand-written copy of the version remains anywhere: the Drive
-    artifact is the version-free `../beta/mirafold.tgz` (adopted in
-    practice 2026-07-28, confirmed by Kyle 2026-07-29 — Drive
-    replace-in-place keeps the link AND the documented filename stable),
-    and `beta/WELCOME.md` + `mirafold-site/public/beta.html` both
-    instruct `npm i -g ./mirafold.tgz` (updated 2026-07-29). The
-    marketing site's own install line is `npm i -g mirafold` and the
-    README uses a `mirafold-*.tgz` wildcard, both already version-free.
-    So a version bump touches package.json and nothing else — `npm pack`
-    emits `mirafold-<v>.tgz`, rename it to `mirafold.tgz` when staging.
+  - **Tester-002 thread CLOSED 2026-07-30** — every concern resolved by
+    standard practice, not bespoke exceptions: SECURITY.md ships in the
+    package with a "Running it safely" section; the sole real blocker
+    (supply-chain provenance) dissolved at the public flip. →
+    PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - Finding #5 (2026-07-30, the live-Gemini check — LAUNCH BLOCKER, FIXED
+    same day): Gemini CLI 0.53.0 stopped loading project settings in
+    untrusted folders, so the adapter's auth selection was ignored. Fixed
+    by the shell-owned once-per-workspace trust ask (P.6b,
+    `server/sessions/workspace-trust.ts`), mutation-checked. **Standing
+    caveat: Gemini is the most volatile of the three engines — re-run
+    R.6's live-Gemini check after Google releases.** Full diagnosis, incl.
+    the two measured negatives that each cost a round of wrong belief →
+    PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - Finding #4 (2026-07-30, LAUNCH BLOCKER, fixed same day): `sendFile`
+    with an absolute path 404'd the SPA fallback for every
+    version-manager install (dot-segment policy); fixed with
+    `{ root: DIST }` + a Tier-3 install-shaped pin. **The lesson that
+    spawned R.6b: only exercising the packaged artifact from a realistic
+    install path proves the packaged artifact.** → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - Finding #3 (2026-07-24, real phone — SERIOUS, fixed): a noopener new
+    tab inherits neither fragment nor sessionStorage, so "new" on the
+    relay path had no pairing code; `newSessionHref()` re-encodes the
+    relay target (PR #6, deployed). → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - Finding #2 + sweep (2026-07-23): overlay cards had `max-width` but no
+    `max-height` and overflowed short windows; fixed on the shared card
+    idiom (onboarding's fix later refined into the fluid `--onb-squeeze`
+    ramp, e2e-pinned). Settings/pair got the same two-line cap; internal
+    scroll is the accepted behavior for the settings card at short heights
+    (the theme picker's layout is Kyle-locked). → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+  - **Beta-tarball era mechanics + status (2026-07-23 → 07-25)** —
+    hand-sent tarball distribution, the testers-subscribe-FOR-REAL rule,
+    the first finding (an untrue stand-in model label; Kyle's standing
+    call: show NOTHING until the real model is known), 0.2.0 rebuilds, the
+    npm-audit-noise investigation (testers never see it — npm skips audit
+    on global installs; unfixable from our side and measured so), and the
+    where-the-version-lives sweep (`package.json` is the single source —
+    a bump touches nothing else). The channel itself is superseded by the
+    public npm path (R.5b). Full history → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
   - **Do not run `npm install` in this repo** (learned 2026-07-25):
     `npm install --package-lock-only` silently rewrote `yarn.lock` —
@@ -1720,23 +898,14 @@ with it. Both sequence BEFORE R.5.**
     yarn for every package operation, as CLAUDE.md already says; npm is
     for `npm pack` only.
 
-- [x] **Step R.5d — Relay staging (nonprod) environment** — **DONE
-  2026-07-23** (the day the private release went live, per the sequencing).
-  `genui-relay-staging` on Fly from the same Dockerfile via
-  `fly.staging.toml` (auto-stop, idles at zero, ungated); the Deploy
-  workflow gained the environment dropdown (default staging) with
-  per-environment app-scoped FLY_API_TOKENs (staging's token cannot touch
-  production); first staging deploy dispatched through the new path and
-  the full smoke PASSED against `wss://genui-relay-staging.fly.dev`
-  (pairing + byte-identical round-trip + refusals). Runbook: DEPLOY.md §6.
-  Why it exists: the relay is the only component that needs a nonprod — the
-  shell's "production" is the user's own machine and the site already has
-  Pages previews. Staging exercises what local runs can't: real TLS, the
-  `fly-client-ip` header the rate limiter trusts, real network behavior, Fly
-  machine lifecycle. The flow it buys: deploy a ref to staging → point a local
-  shell at it (`MIRAFOLD_RELAY_URL=wss://genui-relay-staging.fly.dev`) → smoke
-  + phone pairing check → dispatch the same ref to production. Original step
-  spec → PLAN-ARCHIVE.md.
+- [x] **Step R.5d — Relay staging (nonprod) environment** — DONE
+  2026-07-23; `genui-relay-staging` on Fly (auto-stop, idles at zero,
+  ungated), deploy-workflow environment dropdown with per-environment
+  app-scoped tokens, first staging deploy + full smoke passed. The relay
+  is the only component needing a nonprod (real TLS, `fly-client-ip`,
+  machine lifecycle); the flow: deploy a ref to staging → point a local
+  shell at it → smoke + phone check → dispatch the same ref to
+  production. Runbook: DEPLOY.md §6. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 - [ ] **Step R.6 — Launch prep (the week before; everything verifiable
   without publishing)** *(split out of the old launch-day mega-step
   2026-07-08 — same items, grouped so nothing hides mid-paragraph; nothing
@@ -2053,118 +1222,6 @@ with it. Both sequence BEFORE R.5.**
   postMessage, and parse-error paths. Focused repetition and two complete
   78-test browser runs passed unchanged; protected proof remains N3.4.
 
-- [x] **Step R.6b — The packaged-artifact pass (opened + done 2026-07-30,
-  after the day's two blockers)** — `scripts/packaged-pass.mjs`: `npm pack`,
-  `npm i -g`, then drive the INSTALLED global through onboarding, session
-  creation, a hard reload of the session URL, generative-UI paint, the pin
-  dock, the `!` PTY, the Explorer, and a standalone start of
-  `dist-server/render-mcp.js` — nine checks, mock-forced, discovery off, no
-  model reached. **9/9 on 0.3.0.**
-  - Why it exists: both 2026-07-30 blockers (Finding #4's dot-path 404,
-    Finding #5's Gemini folder gate) were invisible to all three tiers by
-    construction — the checkout has no dot-segment, `yarn dev` serves the
-    front end from Vite so the daemon's own routes never execute, and the
-    cold-install check only read `--version`. Only an install shows them.
-  - NOT wired into `yarn test:e2e` on purpose: it drives a global install CI
-    doesn't have. It is a pre-release ritual — run it against the artifact
-    about to ship, i.e. immediately before the R.7 publish.
-
-- [x] **A turn that ends by `error` wedged the activity indicator forever —
-  found and FIXED 2026-07-30** (chasing the Tier-3 flake below; the two are
-  related in symptom, NOT in cause).
-  - **The defect:** `server/sessions/registry.ts` treats `turn_end` OR
-    `error` as terminal — that is what flips the session to idle and clears
-    the burst gate. The shell's counter (`web/src/turn-busy.ts`) decremented
-    only on `turn_end`. So any turn dying by error — an adapter crash, an
-    engine killed mid-stream, a dropped frame — left the count permanently
-    high: the indicator read "working…" for the LIFE of the session, on
-    every viewport, while the daemon knew it was idle. **A reload did not
-    heal it**, because replay rebuilds the same imbalance out of history.
-  - **The fix:** the client mirrors the daemon's terminal set, and
-    `Shell.tsx`'s error branch drops the indicator the way `turn_end` does.
-    Tradeoff, stated in the code: with two turns genuinely in flight an
-    error may read idle a beat early — which self-heals on the next activity
-    frame, where the wedge it replaces never healed at all.
-  - **Pinned:** four Tier-1 cases in `turn-busy.test.ts` (mutation-checked —
-    reverting the terminal set fails three), plus a Tier-3 test driving a
-    new deterministic mock scenario (`playTurnError`: `status` then `error`,
-    no `turn_end`) through the live path AND a reload, in its own session.
-    That converts a 1-in-4 heisenbug class into a test that always runs.
-
-- [ ] **Flake watch — one unterminated turn in the artifact chain (Tier-3
-  test `update-in-place artifacts survive the liveness tripwire`).** STILL
-  OPEN, and NOT the bug above: the captured trace shows **21 `user_prompt`
-  against 20 `turn_end`, with ZERO `error` and ZERO `bang_end` frames** —
-  a turn with no terminal frame of any kind. FIFO attribution points at
-  `burst-alpha`, the prompt the artifact iframe's bridge issues, though
-  interleaving makes that name the weakest part of the finding.
-  - **Ruled out by probe, not by reading:** the replay floor on an idle
-    reload (three rounds, clean); the burst gate inflating the count (it
-    refuses BEFORE broadcasting `user_prompt`); mid-turn queueing in general
-    (a socket probe sending a prompt 300ms into a running turn returns
-    `{ups: 2, ends: 2}`); and every mock artifact scenario — `playArtifact`,
-    `playBridgeArtifact`, `playUpdatingArtifact` all call `endTurn`.
-  - **The tool for next time already exists:** `web/src/turn-trace.ts` is
-    armed by the e2e harness and `waitTurnIdle` dumps it on any wedge —
-    frame types, replay flags, counts, and the prompt prefix. Reproduce with
-    `node --import tsx --test server/testing/app.e2e.ts` after a `yarn
-    build` (~64% per run in isolation, far higher than in a full Tier-3).
-  - **Cost note (Kyle, 2026-07-30):** this consumed a large share of a
-    session. If it recurs, read the dumped trace — do not re-derive it.
-
-- [x] **Step R.6b — The packaged-artifact pass (opened + done 2026-07-30,
-  after the day's two blockers)** — `scripts/packaged-pass.mjs`: `npm pack`,
-  `npm i -g`, then drive the INSTALLED global through onboarding, session
-  creation, a hard reload of the session URL, generative-UI paint, the pin
-  dock, the `!` PTY, the Explorer, and a standalone start of
-  `dist-server/render-mcp.js` — nine checks, mock-forced, discovery off, no
-  model reached. **9/9 on 0.3.0.**
-  - Why it exists: both 2026-07-30 blockers (Finding #4's dot-path 404,
-    Finding #5's Gemini folder gate) were invisible to all three tiers by
-    construction — the checkout has no dot-segment, `yarn dev` serves the
-    front end from Vite so the daemon's own routes never execute, and the
-    cold-install check only read `--version`. Only an install shows them.
-  - NOT wired into `yarn test:e2e` on purpose: it drives a global install CI
-    doesn't have. It is a pre-release ritual — run it against the artifact
-    about to ship, i.e. immediately before the R.7 publish.
-
-- [ ] **Flake watch — Tier-3 test 36 wedges on a stuck activity indicator
-  (2026-07-30; IDENTIFIED, cause not yet proven — do not chase blind).**
-  - **The test:** `2026-07-29 update-in-place artifacts survive the liveness
-    tripwire` (`server/testing/app.e2e.ts`). It fails in its PRECONDITION,
-    not its subject: the wait for the previous turn's activity indicator to
-    clear. Rate ~1 in 4–7 full runs.
-  - **What the instrumentation caught** (`waitTurnIdle`, added same day —
-    diagnostic only, changes no assertion): `activity: "✢working…(30s)"`,
-    i.e. the indicator polled visible for the entire 30s, WHILE the polite
-    live region already held the finished response — and that region only
-    speaks at `turn_end`. So the turn ended and the indicator did not clear.
-    That rules out "a turn never ended" and puts it on the shell's
-    open-turn counter. Prompt box was enabled; last five transcript entries
-    were the artifact tests' turns (`show me a navigating artifact`, then
-    the iframe-issued `burst-alpha`).
-  - **Falsified:** the obvious reading of `web/src/turn-busy.ts`'s replay
-    floor (`replayed && ACTIVITY_TYPES → max(current, 1)`) — that a plain
-    attach-with-replay of an IDLE session forces the count to 1 with no
-    `turn_end` to follow. Probed directly against the built daemon: turn,
-    idle, reload, ×3 — indicator clear every time. Not it, at least not on
-    the straight-line path.
-  - **Still open, and where to look next:** the failing sequence involves
-    artifact turns plus an iframe-issued prompt (`burst-alpha`) whose
-    sibling (`burst-beta`) is deliberately dropped by the 400ms bridge rate
-    limit. `turn-busy.ts`'s own comment names this exact hazard — "a LIVE
-    straggler after a final turn_end … must not re-open a closed turn, or
-    busy wedges on with no turn_end ever coming". The next diagnostic is
-    the frame sequence itself: record every `(type, replayed)` the client
-    applies plus the running count, and read it back at the wedge. Do NOT
-    "fix" the floor rule without that — it was written to close a real gap
-    (a queued follow-up losing the indicator across an engine roll-in), and
-    an unproven change would trade one wedge for that one.
-  - **Not caused by 2026-07-30's work:** the extended axe sweep runs later
-    in the file with its own daemon and page, and the `FilesPanel`
-    tabIndex/role change touches the Explorer's scroll container. The
-    failure predates both.
-
 - [ ] **Step R.7 — Launch day (the M1+M2+M3 splash, one event)**
   - Goal: everything fires together and the signals start reading.
   - **Launch-week provider-terms re-check (K.3's standing item):** within
@@ -2318,21 +1375,13 @@ Full bodies + dated status in PLAN-ARCHIVE.md ("Moved 2026-07-19").
 
 ## Phase A — Accessibility (opened 2026-07-20; ✅ COMPLETE 2026-07-21)
 
-> **Correction 2026-07-30 — A.4's page was NOT live, for nine days.** The
-> public accessibility statement was written and committed 2026-07-21 into the
-> site repo's `staged/` (site `b42c286`), and never made it into `public/`
-> when the blackout lifted on 07-23. `mirafold.com/accessibility` 404'd, no
-> footer linked it, the sitemap didn't list it — while this plan recorded the
-> step as done and live. Restored, linked from every page's footer, and added
-> to the sitemap 2026-07-30 (site `c4426df`); **measured live: 200.** The
-> lesson is the umbrella's own: a page's existence is a fact about the world,
-> not about a plan, and the plan is exactly as current as the last time
-> someone typed. *Also refreshed on restore*: a new known limitation states
-> plainly that the last hands-on keyboard/screen-reader audit was 2026-07-21,
-> that the automated axe gate covers newer surfaces where they appear in it
-> (onboarding, transcript, Explorer, settings, connect-device, fleet, cockpit
-> desktop + phone — `assertAxeClean` call sites), and that the `!` input bar,
-> the pin dock and the ⤢ enlarged file view have not yet had the same pass.
+> **Correction 2026-07-30 — A.4's page was NOT live for nine days**: the
+> statement was committed to the site repo's `staged/` and never copied to
+> `public/` at the blackout lift, while this plan recorded it done.
+> Restored, footer-linked on every page, sitemapped 2026-07-30 — measured
+> live: 200. The lesson is the umbrella's own: a page's existence is a fact
+> about the world, not about a plan. Full note (incl. the refreshed
+> known-limitations wording) → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 Kyle's directive, verbatim: *"i want mirafold to be friendly to all people
 capable of using it and to be ada compliant."* The ADA names no technical
@@ -2726,18 +1775,10 @@ anywhere; each is independent.
 - [x] **Step Q.5 — Pin the `.env` guard's edges** — done 2026-07-12; traversal + cross-cwd denials pinned across all four guarded readers, non-vacuous by weakening the guard. (Symlink bypass stays the documented accepted residual.) → PLAN-ARCHIVE.md.
 
 - [x] **WATCH ITEM (2026-07-24): the follow-tail re-arm race — closed
-  2026-08-08 by N3.3.** Seen once on the
-  CI runner (app.e2e.ts "re-follows once back at the bottom", sat 188px above
-  the tail), green on rerun and on every local run; root-caused same day.
-  Mechanism: re-arming depended on `use-follow-tail.ts`'s `onScroll`
-  measuring within `BOTTOM_SLACK_PX` (24) of the bottom, but scroll events
-  fire a frame after the scroll — under load the stream can paint >24px in
-  that gap, so a reader (or the test's single programmatic jump) landing at
-  the bottom mid-stream measures as "not at bottom" and follow never re-arms.
-  A real product race, not only test fragility. Downward wheel/touch intent
-  that reaches the current bottom now re-arms synchronously against pre-input
-  geometry; the existing instant-follow and input-detach decisions remain.
-  Pure boundary tests and a controlled real-wheel browser scenario pin it.
+  2026-08-08 by N3.3.** A real product race (scroll events lag the scroll a
+  frame, so landing at the bottom mid-stream could measure "not at
+  bottom"); downward intent that reaches the bottom now re-arms
+  synchronously against pre-input geometry. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ---
 
@@ -3682,137 +2723,53 @@ concatenation each broken → exact pinning tests failed → restored).
 
 ## Guidance tuning — the prose exit ramp (✅ 2026-07-27)
 
-One bullet in `RENDER_GUIDANCE` (`server/render-tools.ts`, commit `9330ded`),
-from a live report: a recipe ask rendered as plain markdown. Probed against
-the real engine with the adapter's exact setup first — pipeline healthy (a
-table-shaped prompt tool-searches and paints; render tools ARE deferred
-behind the SDK's tool search, noted, deliberately left alone), so the cause
-was the old "plain markdown remains right for long-form prose" bullet
-filing whole prose-shaped answers under markdown. New bullet: markdown is
-connective tissue; find and render the answer's structured core (recipe and
-prose-buried comparison as worked examples). Measured on the recipe prompt:
-0/2 renders → 2/3, ingredients + steps as components; diagnostic-prose
-control stays 0/2 (no over-rendering). Confirmed in the real UI end-to-end.
-Ported to mirafold-chat the same day (its `090d29f`) with its own probe.
+One `RENDER_GUIDANCE` bullet (`server/render-tools.ts`, `9330ded`):
+markdown is connective tissue — find and render the answer's structured
+core. Measured 0/2 → 2/3 renders on the recipe probe with no
+over-rendering; ported to mirafold-chat the same day. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-## Open from the 2026-07-27 security audit (three repos, checked against a
-## "pre-launch checklist" post Kyle brought in)
+## Closed from the 2026-07-27 security audit (three repos, checked against
+## a "pre-launch checklist" post Kyle brought in)
 
-**Shipped that day** (each landed with a test whose guard was broken and
-watched to fail before restoring): relay `new URL` crash guard · daemon
-exact-origin WebSocket check · credential scrubber on both log sinks ·
-site cross-site guard on the waitlist form POST · site `no-store` on
-credential responses · site `HEAD /api/health` · daemon `connect-src`
-narrowed off the `ws:`/`wss:` wildcards · daemon refuses a malformed
-`MIRAFOLD_RELAY_URL` instead of crashing at boot.
-
-**Deploy state (2026-07-28).** The relay crash guard is **LIVE in
-production** — Fly `v9`, ref `f01a765`, staging `v2` first per the
-documented flow. Verified on both by firing the real payload at the live
-host and reading the logs: `{"event":"bad_request_target"}` with no restart
-between it and the preceding `listening` event, health `ok` on four probes
-after. That deploy also shipped the relay's `HEAD /health` (confirmed `200`
-live), which had been sitting undeployed since 07-23. The site fixes went
-live with the push (Cloudflare Pages builds on push to main). **The daemon
-fixes ship with the next release** — they only reach users when the package
-does. Note the relay does NOT auto-deploy: `deploy.yml` is
-`workflow_dispatch` only, so relay code sitting on `main` is NOT live until
-someone dispatches it.
+**Shipped that day** (each landed with a break-the-guard-watch-it-fail
+test): relay `new URL` crash guard · daemon exact-origin WebSocket check ·
+credential scrubber on both log sinks · site cross-site guard, `no-store`
+and `HEAD /api/health` · daemon `connect-src` narrowed · malformed
+`MIRAFOLD_RELAY_URL` refused at boot. Deploy state 2026-07-28: the relay
+guards went LIVE (Fly v9, verified against the live host); site fixes ship
+on push; daemon fixes ride the next package release. **Standing gotcha:
+the relay does NOT auto-deploy — `deploy.yml` is `workflow_dispatch`
+only, so relay code sitting on `main` is not live until someone
+dispatches it.** Full record → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ### ✅ RESOLVED 2026-07-28 — the `relay.e2e.ts` test 3 flake
 
-`assert.ok(tapped.length > 50)` (`server/relay/relay.e2e.ts:91`) was a
-hardcoded frame-count threshold and it was **load-sensitive**. Sampled
-2026-07-27 in isolation: **1 pass / 3 fail**, failing at exactly `saw 50`.
-The comment directly above it already documented the same failure a week
-earlier — *"the 'saw 40' flake, reproduced 2/20 under saturation
-2026-07-19"* — so the earlier fix (keying the wait on turn completion)
-did not remove the underlying brittleness, only moved the number.
-
-Mechanism: `DELTA_COALESCE_MS` (33ms) merges streamed deltas, so the number
-of frames the tap sees depends on machine load — under saturation more
-deltas merge, fewer frames cross, and the count drops under the threshold.
-
-**The owed isolation run was run 2026-07-28 and CLEARED the 07-27
-`server/index.ts` change**: 6 samples on HEAD (0 pass / 6 fail, `saw`
-43–50) vs. 6 samples with `server/index.ts` reverted to `5e0abe4^`
-(0 pass / 6 fail, `saw` 44–49) — identical distributions, so the flake is
-fully explained by the threshold, no second problem. (Note the fail rate
-on this machine had drifted to 6/6 — the tally sat permanently just under
-50, i.e. the threshold was not merely flaky but effectively broken.)
-
-**Fix (same day):** the count was only ever a guard against the ciphertext
-loop below it passing vacuously over zero frames. Replaced the total-frame
-tally with growth-during-the-turn: capture `tapped.length` before the
-remote prompt, assert it grew by ≥2 after both viewports saw `turn_end` —
-the prompt itself must cross the tap upstream (c2d) and the `turn_end`
-that detaches the stop buttons must cross downstream (d2c), and delta
-coalescing can never merge either away. Deterministic under any load.
-Mutation-tested (both tap `frame` calls dropped from `relay-stub.ts` →
-fails `saw 0 new frames over 0` → restored); verified 6/6 passing
-unpinned and 3/3 passing under single-core CPU pinning (`taskset -c 0`),
-the condition that originally reproduced the flake.
+A hardcoded frame-count threshold was load-sensitive under delta
+coalescing (more merging under load → fewer frames → spurious fail);
+replaced with growth-during-the-turn — ≥2 frames across the tap, which
+coalescing can never merge away. Deterministic under single-core CPU
+pinning; mutation-tested. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ### ✅ REDONE 2026-07-28 — per-session prompt gate, keyed on the turn grammar
 
-History: a 400ms per-session gate on `prompt` / `prompt_session` /
-component `action{kind:prompt}` was written 2026-07-27 and **reverted the
-same day** — it measured time since the last *accepted* prompt, which
-punishes legitimate back-to-back turns and broke four e2e tests (`shell
-picker`, `notice badging`, `navigating artifact`, `chart stretch`). The
-threat is real: nothing bounded a client that bursts prompts, each of which
-costs a model turn, and the artifact bridge reaches `action{kind:prompt}`
-with no user gesture (its 400ms gate is client-side — a hostile client
-simply wouldn't run it).
+All three model-driving paths enter one seam, `registry.dispatchPrompt`;
+the gate clears on the same terminal events that flip status idle — no
+timer. One mid-turn queued follow-up is allowed (terminal parity; the
+agents queue typed-mid-turn input); anything past it is refused to the
+offending viewport only, never broadcast. Pinned + mutation-tested in
+`hostile-client.itest.ts`. History incl. the reverted first attempt →
+PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-The redo implements the corrected design with one parity-driven refinement.
-All three model-driving paths now enter through ONE seam,
-`registry.dispatchPrompt` (echo + push behind the gate); the gate is
-cleared in `broadcast()` by the same terminal events that flip status back
-to idle (`turn_end` / `error` / `bang_end`) — no timer anywhere. The
-refinement: a prompt while idle starts the turn, and **one more** may
-arrive while it runs, because the terminal agents queue typed-mid-turn
-input (the Claude Code adapter literally `queue.push`es it) and the desktop
-prompt box still sends on Enter while busy — a strict refuse-while-busy
-gate would have refused a legitimate human flow. Anything past that one
-queued follow-up is refused with the shared `PROMPT_GATE_REFUSAL` line
-(sent only to the offending viewport — never broadcast, so it can't touch
-session status or other viewports' busy state). Burn is capped near one
-turn per completed turn; no human pace, and none of the four e2e tests,
-can trip it.
+### ✅ The three ranked items — ALL RESOLVED 2026-07-28
 
-Pinned in `hostile-client.itest.ts` (burst of 5 → exactly 2 echoes + 3
-refusals → gate clears at turn_end and a fresh prompt completes);
-mutation-tested (gate forced open → the pin fails on 5 echoes / 0
-refusals → restored). Tier-1 443/443, Tier-2 137/137 with the gate in.
-
-### ✅ The three ranked items — ALL RESOLVED 2026-07-28 (relay changes await a deploy)
-
-1. **Relay caps vs. machine memory + missing backpressure — FIXED.**
-   Defaults lowered to launch scale (`maxConnections` 2000→256, `maxSockets`
-   2400→320, `maxPairs` 1000→128 — env-raisable per-deploy). **Send-side
-   backpressure added** on both forwarding paths: a receiver whose socket
-   buffers past `RELAY_MAX_BUFFERED_BYTES` (64 MB — sized so a maxed-ring
-   attach-replay, ~43 MB sealed, survives) is closed `CLOSE_OVERLOADED`;
-   closing rather than dropping keeps the stream gapless (a re-attach
-   replays). **Byte-rate cap added** to the per-connection window
-   (`RELAY_RATE_MAX_BYTES`, 64 MB/s — the frame cap alone left ~3.8 GB/s
-   legal). No contract change: existing close codes only, so the mirror and
-   the contract-guard itest are untouched. Both pinned in the relay's
-   standalone suite (a stalled-socket test and a big-frame test), both
-   mutation-tested (each guard neutered → its pin fails/hangs → restored).
-2. **Pairing id in the URL query — wording fixed, exposure MEASURED.**
-   `SECURITY.md`, `README.md`, and `log.ts` no longer call it "a bearer
-   secret" — it is `b64url(SHA-256(code)[0..16))`, a rendezvous id that
-   decrypts nothing (verified against `relay-crypto.ts`); its exposure
-   enables slot squatting/DoS, not disclosure. The Fly question was
-   **verified live 2026-07-28** instead of assumed: a marker-id probe
-   dialed at the production relay produced NO proxy log line at all —
-   Fly's edge logs `request.url` **only on proxy-error lines**, so the
-   pairing id does not reach platform logs on the happy path. Conclusion:
-   moving the id to a header/`Sec-WebSocket-Protocol` (a both-repo
-   contract change) stays unjustified; SECURITY.md now states the
-   deployment-layer caveat honestly.
+Relay caps lowered to launch scale + send-side backpressure
+(`RELAY_MAX_BUFFERED_BYTES`) + a byte-rate cap, pinned + mutation-tested
+and deployed as Fly v10 the same day; the pairing id's exposure measured
+honestly (a rendezvous id, not a bearer secret — decrypts nothing, and no
+proxy logging on the happy path, verified live against Fly); stale
+`mirafold-relay/dist/` deleted with a `prestart` build so a local run
+can't execute months-old code. Full record → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
+The pairing-id standing policy survives here verbatim:
 
    **Standing policy (Kyle, 2026-07-28): opportunistic, never dedicated.**
    A from-scratch design would carry the id in `Sec-WebSocket-Protocol`
@@ -3835,96 +2792,24 @@ refusals → restored). Tier-1 443/443, Tier-2 137/137 with the gate in.
    exposure is harmless by construction (E2E keys derive from the code
    the relay never sees; ids die on daemon restart) — hiding the id
    better is defense-in-depth on a denial-only vector.
-3. **Stale `mirafold-relay/dist/` — deleted**, and `npm start` now runs a
-   `prestart` build, so a local run can never again execute months-old
-   code (verified: `npm start` rebuilt dist with the new limits in it).
-
-**Deploy note — RESOLVED same day:** Kyle dispatched production directly
-from `main` (~13:12 UTC, no staging run this time; v9 did staging first) —
-Fly **`v10`**, ref `6b83ded`, the exact audit commit. Verified live:
-workflow run green, health `200`, and his entitled daemon re-paired
-through the new build 6s after `listening`. The new guards themselves
-aren't safely probe-able against production (they'd need a real flood or
-stall); their proof is the pinned + mutation-tested suite behind the ref.
 
 ### ✅ 2026-07-28 — the refusal reason is VISIBLE on the phone (Kyle's call)
 
-A relay refusal's why (no daemon 4003 / at capacity 4004 / bad origin
-4006, mapped in `web/src/ws.ts` `viewportRefusalReason`) reached the
-StatusBar only as the dot's `title` — a hover tooltip no touch device can
-reveal, on the remote path built for phones. Kyle chose the middle option
-of the recorded three (tooltip-only / visible line / banner): a **visible
-line beside the dot**, shown only when the connection is down WITH a known
-reason — an ordinary blip keeps the quiet dot and plain "reconnecting…"
-tooltip. `.sb-conn-note`: warn-colored to match the off-dot it explains,
-ellipsis-bounded so it can't push the phone row's controls off. No live
-region on it — Shell's Announcer already speaks the transition (A.1); this
-is the visible copy of the same words. Wording kept from the provisional
-strings (they already said the right things: the no-daemon line points at
-the desktop as the fix; "at capacity" stays true for the new mid-session
-backpressure shed, which uses the same close code). Pinned end-to-end in
-`relay.e2e.ts` test 4 — the daemon is killed mid-pairing and headless
-Chrome must show the exact 4003 string beside the dot — and
-mutation-tested (render neutered → the pin fails → restored). **LIVE on
-the remote path same day**: the git-integrated Pages project rebuilt on
-the push; verified by fetching the served assets (`.sb-conn-note` in both
-the live JS and CSS at app.mirafold.com). Local users get it with the
-next package release, like every daemon-side change.
-
-Also noted, not acted on: `mirafold-site/PLAN.md`'s "Remote viewport app
-origin" item still reads as though the bundle hasn't shipped (it is live at
-`app.mirafold.com`); the site repo's `CLAUDE.md` had the same staleness and
-was corrected 2026-07-27.
+A relay refusal's why reached the phone only as a hover tooltip;
+`.sb-conn-note` is now a visible warn-colored line beside the dot, shown
+only when down WITH a known reason. E2e-pinned, mutation-tested, live on
+the remote path same day. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ### ✅ 2026-07-28 — permission answers sync across viewports (Kyle's phone bug)
 
-Kyle's report: allow/deny tapped on the phone looked like it worked (its own
-bar cleared) but "nothing actually happens" — the desktop's copy of the same
-ask stayed up and the phone hung; and an answer given ON the desktop didn't
-reliably clear the phone's bar either. Root cause (reproduced with a local +
-relay-stub two-viewport harness before touching anything): **nothing on the
-wire ever announced a permission's resolution.** Each viewport dropped an ask
-only when it was itself clicked, or at `turn_end`; the fleet mirror was kept
-honest (`answerPermission` + clock-aging) but attached session viewports were
-not. So the second device kept showing an ask that had already been answered
-elsewhere — or auto-denied by the adapter's 60s `PERMISSION_TIMEOUT_MS` — and
-a tap on that stale bar is, by design, a silent no-op at the adapter. Exactly
-"the phone just hangs there." The relay was innocent: a fresh
-`permission_response` from the remote path resolves fine (proven in the
-repro); it was the stale-bar window that made phone answers look dead.
-
-The fix (additive wire message, no relay/contract change — the relay never
-parses frames): **`permission_resolved { id, allow }`** is broadcast on the
-session stream for EVERY resolution path. Emitted from the one place all
-paths funnel through — the adapter's ask `finish` (answer from any viewport,
-timeout auto-deny, interrupt/close deny-all) in `claude-code.ts`, mirrored in
-`mock.ts`; adapters that emit `permission_request` MUST emit this
-(protocol.ts). Registry: `captureCockpit` drops exactly that id from the
-fleet mirror (the timeout path only this catches — `answerPermission` never
-ran) and releases the `permission` status hold only when nothing is still
-pending; `deliver`'s blanket working-flip skips the new type so a second
-pending ask keeps the hold. Client (`Shell.tsx`): drops the ask by id the
-moment the broadcast lands — with a polite announcement when the ask was
-still showing here (it resolved elsewhere), silent when this viewport's own
-click already removed it. Replay benefits for free: the buffer now carries
-request→resolved, so a reloaded viewport can't repaint a stale bar mid-turn.
-
-Pinned in all three tiers and each pin mutation-tested (guard broken → exact
-pin fails → restored): Tier-1 — adapter emits on answer AND on the
-interrupt deny-all (`claude-code.test.ts`), registry drop + hold-until-none-
-pend (`registry.test.ts`), protocol fixture. Tier-2 — the second viewport's
-very NEXT frame after the answer is the resolution, before the allowed
-tool's frames (`session.itest.ts`); the timeout announces `allow:false`
-before `turn_end` (ibid.); and Kyle's exact scenario, answered FROM the
-phone through the encrypted relay path with the local viewport hearing it
-(`relay.itest.ts`). Tier-3 — desktop answers, the PHONE's bar must drop
-while the turn is still streaming, not at `turn_end` (`phone.e2e.ts`, the
-count-pinned "restarted cleanly" discriminator). Tier-1 454/454, Tier-2
-139/139, Tier-3 67/67. No relay deploy involved (the relay never parses
-frames). **Client half LIVE on the remote path same day** — the Pages
-project rebuilt on the push; verified by fetching the served bundle
-(`permission_resolved` in app.mirafold.com's JS). Local daemons get the
-daemon half with the next package release, like every daemon-side change.
+Nothing on the wire announced a permission's resolution, so a second
+device kept showing a stale bar (and taps on it were silent no-ops). Fix:
+additive **`permission_resolved { id, allow }`** broadcast from every
+resolution path — adapters that emit `permission_request` MUST emit it
+(protocol.ts) — with the registry holding `permission` status until
+nothing is pending. Pinned in all three tiers, mutation-tested; replay
+carries request→resolved so a reload can't repaint a stale bar. Full
+diagnosis → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ## Stretch goals (unscheduled — polish, no milestone gates on these)
 
@@ -3952,114 +2837,38 @@ Wire-contract check (all additive, nothing reshapes): new *optional props*
 schemas' ideal degradation; a new *`kind` enum value* fails an old client's
 parse into the Step 1.4 raw-props fallback — legible, and the designed path.
 
-- [x] **Step S.1 — `chart` kind: pie (donut)** ✅ 2026-07-27 (Kyle-directed,
-  branch `claude/next-registry-components-lyrbrq`, with S.2 same sitting).
-  Built to spec: `pie` on the kind enum; slices = `x` names ×
-  `series[0].values`; size-ordered, past 6 the tail folds into ONE "other"
-  (top 5 + other — the fixed-slot palette always suffices, never cycled);
-  donut with the total in the hole, a per-slice direct-label list
-  (chip + name + value + share, no around-the-donut collisions by
-  construction) and hover tooltip. The one-series rule is enforced in the
-  RENDERER by throw → RenderBlock's error boundary → the raw-props fallback
-  (the schema's raw shapes can't carry cross-field refinements through the
-  generic strict/tolerant derivation; the describe strings state the rule for
-  the agent). Done-when observed in headless Chrome: 8-category mock pie →
-  6 slices incl. "other"; 2-series pie → legible fallback with the good
-  charts unharmed; verified at desktop and phone widths, both fine (0px
-  side-scroll).
-  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+- [x] **Step S.1 — `chart` kind: pie (donut)** ✅ 2026-07-27 —
+  size-ordered slices, past 6 the tail folds into ONE "other", donut total
+  + per-slice direct labels; the one-series rule enforced in the renderer
+  → raw-props fallback. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 - [x] **Step S.2 — chart ergonomics: `stacked`, `horizontal`, histogram
-  hint** ✅ 2026-07-27 (with S.1, same sitting). Optional `stacked` +
-  `horizontal` booleans, bar-only, quiet no-ops on line/pie (and on a
-  single-series stack), composable with each other; the kind `.describe()`
-  now tells the agent to pre-bin distributions into labeled bar buckets.
-  Stacked: cumulative columns in palette-slot order, surface-stroke gaps
-  between segments, only the data end rounded, y-scale spans column TOTALS,
-  negatives dropped (no stacking geometry). Horizontal: bars rightward,
-  category labels whole down the left (the vertical axis clips at 12 chars —
-  the point), height grows with category count; the value-unit label moved
-  top-right after the screenshot pass caught it overlapping the last tick.
-  Old-client degradation pinned by test: a rebuilt "yesterday" tolerant
-  schema strips both flags to a plain grouped/vertical bar, and yesterday's
-  kind enum rejects `pie` whole into the fallback. Verified at desktop and
-  phone widths in headless Chrome.
-  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+  hint** ✅ 2026-07-27 — bar-only, quiet no-ops elsewhere, composable;
+  old-client degradation pinned by a rebuilt "yesterday" tolerant schema.
+  → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-- [x] **Security audit of the 2026-07-27 component work** ✅ same day, all
-  three approved fixes landed with pinned, mutation-tested regressions:
-  1. **Session replay buffer capped by BYTES** (`SESSION_BUFFER_MAX_BYTES`,
-     32 MB) beside the existing 4000-message count cap. The count cap
-     assumed text-only messages; `image` made one message worth megabytes
-     from a short path, with no permission prompt. Measured open: 40 renders
-     retained 96 MB, ~10 GB at the count ceiling. Re-probed closed: 200
-     renders now plateau at 32.9 MB. Full note in SECURITY.md.
-  2. **Workspace dir is a REQUIRED argument** on `makeRenderServer` and
-     `generativeUIMsg` — it jails the image read, and optional meant a
-     future adapter could skip containment by forgetting it.
-  3. **`mermaid` moved to devDependencies** — the runtime is inlined into
-     `dist/` at build time and nothing shipped loads it from `node_modules`
-     (verified), so it was costing every user 84 MB and 62 transitive
-     packages of install + supply-chain surface for zero runtime use.
-     Kyle's zero-passengers rule, applied.
-  Clean on everything else probed: image containment (symlink/traversal/
-  `.env`/wrong-bytes/oversize all refused, mutation-tested), every new
-  parser against pathological input (worst case 56 ms, no hangs, clamps
-  hold), the diagram sandbox, supply chain (0 advisories/248 pkgs, no
-  install scripts), and repo hygiene (no secrets in the session's commits).
+- [x] **Security audit of the 2026-07-27 component work** ✅ same day —
+  session replay buffer capped by BYTES (`SESSION_BUFFER_MAX_BYTES`,
+  32 MB) beside the count cap; workspace dir a REQUIRED argument on the
+  render seam (it jails the image read); `mermaid` moved to
+  devDependencies (inlined at build — the zero-passengers rule applied).
+  All pinned + mutation-tested; everything else probed clean. →
+  PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-- [x] **Workflow-gap batch (Kyle-directed 2026-07-27, same branch): `console`,
-  `image`, `diagram`** ✅ — the three glaring terminal-agent workflow gaps
-  from the 2026-07-27 survey, each through the full seam, one commit apiece:
-  - **`console`** — quoted terminal output (build logs, failing tests, stack
-    traces): command header, exit badge, copy; a self-written SGR-subset
-    parser turns ANSI colors into class spans (16 fg colors on a pinned
-    palette, other escapes stripped; text rides React as text nodes).
-  - **`image`** — the visual-verification gap. Agent authors a WORKSPACE
-    PATH; the daemon inlines the bytes at the WireMsg synthesis point (all
-    three adapters; the stdio stub stays file-access-free). Explorer-grade
-    posture: `inside()` realpath containment (mutation-tested), secret
-    denial, 2 MB raw cap (sealed relay frame ≈1.8×, relay ceiling 8 MB;
-    replay ring is count-capped so per-image bytes are the bound), raster
-    magic-byte allowlist, NO svg. Client accepts `src` only as a
-    strict-shaped data:image/raster URI — anything else → raw-props
-    fallback. Refusals render their reason.
-  - **`diagram`** — mermaid (flowchart/sequence/state/class/ER), rendered in
-    the ARTIFACT-grade sandbox, never the shell origin: shell-supplied
-    runtime (securityLevel strict) inlined in an opaque-origin no-network
-    iframe; agent source arrives by postMessage only (no interpolation slot
-    — pinned by test); nonce-stamped ready/height/error channel. New dep
-    `mermaid` (^11, deep-spec verdict): ~3.6 MB lazy chunk, first diagram
-    only. Broken source shows the error beside the source.
-  **Deliberately NOT built: structured input beyond `question`** (multi-value
-  forms, editable commit messages). Free-text input inside agent-authored UI
-  collides with the trusted-shell rule that input surfaces are shell-owned —
-  it needs a design conversation with Kyle first, not a batch add.
+- [x] **Workflow-gap batch (Kyle-directed 2026-07-27): `console`,
+  `image`, `diagram`** ✅ — each through the full seam: ANSI-parsed
+  console output; daemon-inlined images (jailed, raster-only, 2 MB cap, NO
+  svg); mermaid in the ARTIFACT-grade sandbox, postMessage-only.
+  **Deliberately NOT built: structured input beyond `question`** —
+  free-text input inside agent-authored UI collides with the trusted-shell
+  rule that input surfaces are shell-owned; it needs a design conversation
+  with Kyle first, never a batch add. → PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
-- [x] **Step S.3 — `stat` registry component (KPI tile)** ✅ 2026-07-27
-  (Kyle-directed, on branch `claude/next-registry-components-lyrbrq`; built to
-  this spec exactly — `label`/`value`/optional `delta {value, direction,
-  good}`/optional `footer`, delta tone follows `good` never the raw direction,
-  the arrow glyph carries direction so state never rides on color alone,
-  proportional figures per the dataviz stat-tile contract). Done-when observed
-  in headless Chrome: the mock `kpi` turn renders the tile, an update-in-place
-  re-send on the same wire id moves the number (one tile, never a stack), and
-  it pins to the dock and back. **Same sitting, same seam, Kyle-directed —
-  two MORE registry components** (all three across both transports via
-  `RENDER_TOOL_COMPONENT`, display-only, no ACTION_TOOLS changes):
-  - **`code`** — display code that is NOT a change (the tool description
-    steers code-vs-diff explicitly): filename/lang header, copy button,
-    client-side tokenizing of plain text through the same
-    react-markdown + rehype-highlight pipeline as turn fences (hast → React,
-    never raw HTML; the fence always outruns any backtick run inside), and
-    optional 1-based highlight ranges clamped to the code's own length. Line
-    emphasis is PINNED-surface styling (neutral lift + code-fg bar) because
-    per-theme tints go pale under the pinned-dark code surface's light text —
-    caught by the both-themes screenshot pass.
-  - **`status-list`** — labeled rows with a pass/fail/warn/pending/skip
-    verdict pill (glyph + word, existing semantic tokens; a Tier-1 test pins
-    glyph↔enum so vocabulary drift fails loudly).
-  - *(Original spec bullets → PLAN-ARCHIVE.md.)*
+- [x] **Step S.3 — `stat` registry component (KPI tile)** ✅ 2026-07-27 —
+  plus `code` (display-only, copy button, clamped highlight ranges on the
+  pinned-dark code surface) and `status-list` (verdict pills, glyph↔enum
+  Tier-1-pinned) the same sitting, same seam, display-only. →
+  PLAN-ARCHIVE.md, "Moved 2026-08-12 (prune — completed bodies)."
 
 ---
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -3381,6 +3381,101 @@ both acceptance requirements, not a later responsive cleanup.
   a separately-verified decision for later. → **PLAN-ARCHIVE.md, "Moved
   2026-08-12 (Changes polish + branch closure)."**
 
+## Needs-you notifications (opened 2026-08-12; Kyle-directed)
+
+**Product call.** The remote/away story is the product's spine — fleet view,
+relay viewport, desktop app all assume the user steps away — yet every surface
+so far answers "what's happening when I look?" and nothing answers "tell me
+when I need to look." The next feature is OS-level notifications when a
+session needs the user: a permission prompt appears, or a turn finishes. Scope
+is the local tiers only (any open Mirafold page: local tab, desktop app, relay
+viewport open on a phone — all the same Notification API code path). True
+closed-browser Web Push (service worker + push service + E2E payload story) is
+deliberately parked in Post-release ideas until the habit loop proves out.
+
+**Triggers — exactly two, by design.** (1) A session enters `permission`;
+(2) a session's turn ends (`busy`/`working` → `idle`). NOT per-tool chatter,
+and NOT socket disconnects: a phone backgrounding its tab drops the socket
+routinely, so a "disconnected" toast would train users to disable the feature.
+Session-death notification waits until the wire carries a distinct exit signal.
+
+**The suppression rule (most of the design).** A notification fires only for
+state the user cannot already see: nothing fires while the firing tab is
+visible (`document.visibilityState`), and gaining visibility closes every
+toast that tab created. One notification per session (`tag` = session id), a
+newer event replacing the older; a toast whose cause resolves elsewhere
+(answered on another device, agent prompted from the terminal) closes itself
+the moment the state moves on. Accepted v1 sharp edge: a hidden fleet tab can
+toast about a session visible in another tab — same tag keeps it to one toast,
+and cross-tab suppression is noted in Post-release ideas, not built.
+
+**Trust boundary.** Notifications are shell-owned chrome: titles/bodies are
+composed by the shell, and every engine-derived string (tool name, permission
+detail) is carried as inert plain text into an OS surface that never
+interprets markup. The preference is off by default; flipping it on is the
+only thing that triggers the browser's permission prompt (never page load).
+No secret ever enters a notification body — tool + detail are already
+user-visible PermBar strings.
+
+### Phase NF.1 — The notify engine + both surfaces wired
+
+- [x] **Step NF.1 — Pure decision core, DOM binder, Shell + fleet wiring** —
+  completed 2026-08-12: `web/src/notify.ts` (reducer + binder + DOM wiring)
+  landed with 23 Tier-1 tests covering the full matrix below; both routes
+  wired exactly as specified, `yarn test` 695 green, typecheck clean. —
+  **Goal:** notifications actually fire from both routes, correctly
+  suppressed, coalesced, and self-closing, behind a preference that defaults
+  off. **Build:** `web/src/notify.ts`: (a) a pure transition reducer — given
+  the previous per-session state map, fresh session snapshots
+  (`{id, state: idle|busy|permission, title, agent?, detail?}`), and flags
+  `{enabled, granted, visible}`, return show/close actions plus the next map —
+  every rule above lives here; (b) `createNotifier(deps)` binding the reducer
+  to injected `{isVisible, permission, spawn, onVisibilityChange}` with a
+  `reset()` that reseeds state without emitting (used across socket
+  drop/reconnect so a forced `busy→idle` never fakes a turn-end). Wire Shell
+  (its `asks`/`busy` tri-state, title from the cwd basename, detail from
+  `asks[0]`) and FleetView (per-session from the `sessions` snapshot,
+  `wantsAnswer` for the permission side, close toasts for sessions that leave
+  the list). Clicking focuses the firing tab. **Files:** `web/src/notify.ts`,
+  `web/src/notify.test.ts`, `web/src/components/Shell.tsx`,
+  `web/src/components/FleetView.tsx`. **Done when:** Tier-1 tests prove the
+  reducer's full matrix (permission shown once; answered-elsewhere closes;
+  turn-end shown on `busy→idle` and `permission→idle`; visible suppresses
+  shows but still advances state; disabled/ungranted emit nothing; per-session
+  independence; vanished session closes; reset never emits) and the binder's
+  lifecycle against fakes; `yarn typecheck` passes.
+
+### Phase NF.2 — The settings affordance + end-to-end proof
+
+- [x] **Step NF.2 — Toggle in the settings card, e2e, docs** — completed
+  2026-08-12: Notifications section shipped in the settings card (switch row
+  + blocked hint), Shell owns preference/permission logic, e2e proves the
+  full hidden-tab loop (toggle → permission toast → answered → turn-end
+  toast → visibility closes all). One diagnosed trap recorded for future e2e
+  work: tsx's esbuild keepNames injects a module-scope `__name` helper into
+  compiled classes/accessor properties, which Playwright then serializes
+  WITHOUT the helper — init scripts and evaluates containing them die on a
+  ReferenceError, so the Notification stub and the visibility override are
+  plain-JS strings. — **Goal:** a
+  user can find and flip the feature, and headless Chrome proves the visible
+  behavior. **Build:** a Notifications section in the settings card
+  (`ThemePicker.tsx`, prop-driven — the card stays Vite-only and dumb): one
+  toggle row ("Notify me when a session needs me"), `aria-pressed`, a plain
+  hint line when the browser has the permission hard-denied ("blocked in
+  browser settings") or the API is absent. Shell owns the logic: preference in
+  `localStorage["mirafold-notify"]`, enabling requests browser permission when
+  still undecided. Fleet honors the same stored preference with no UI of its
+  own. Settings-card CSS additions in `web/src/styles/12-dialogs.css`.
+  **Files:** `web/src/components/ThemePicker.tsx`,
+  `web/src/components/Shell.tsx`, `web/src/notify.ts` (preference helpers),
+  `web/src/styles/12-dialogs.css`, `server/testing/app.e2e.ts`, README.
+  **Done when:** the e2e opens settings, sees the section, flips the toggle
+  (Notification API stubbed via init script), asserts the stored preference
+  and `aria-pressed`, and a stubbed-notification assertion proves a hidden-tab
+  permission event spawns exactly one tagged toast; axe stays clean;
+  `yarn test` + `yarn test:e2e` + `yarn typecheck` pass; README's shell-UI
+  section gains the tab-status-adjacent paragraph.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -123,6 +123,23 @@ has a home in this plan, the entry points there instead of duplicating it.
     (which context owns the key) must be settled once and reused by both. Decide
     it with whichever of the two ships first.
 
+- [ ] **Needs-you notifications, the closed-browser tier** (parked from Phase
+  NF, 2026-08-12) — true Web Push so a phone with the browser closed still
+  hears "a session needs you": a service worker + Push API subscription, the
+  daemon (or relay) sending through the browser vendors' push services, and
+  on iOS only inside an installed PWA (which makes the PWA idea above its
+  prerequisite). E2E wrinkle to solve honestly: the relay is deliberately
+  blind, so either the daemon encrypts push payloads end-to-end or the push
+  is content-free ("a session needs you") with detail loading on tap. Ship
+  only after the local tiers (Phase NF) prove the habit loop.
+
+- [ ] **Needs-you notifications, cross-tab suppression** (parked from Phase
+  NF, 2026-08-12) — v1 accepts one sharp edge: a hidden fleet tab can toast
+  about a session that's visible in another tab (same `tag` keeps it to a
+  single toast). If it turns out to annoy in practice, a BroadcastChannel
+  "session X visible here" heartbeat lets hidden tabs suppress toasts for
+  sessions the user is already looking at.
+
 - [ ] **Multiuser chat** — multiple people in one session's conversation;
   rides Phase 4's multi-user seam (Locked decisions: "architected so
   multi-user is additive later").

--- a/README.md
+++ b/README.md
@@ -752,6 +752,9 @@ web/               the browser app (React 19 + Vite)
                      shell and the fleet's new-session card
   src/tab-status.ts  the tab status light: brand-M favicon + corner badge
                      (busy / permission) and title, painted from wire state
+  src/notify.ts      needs-you notifications (Phase NF): OS toasts when a
+                     hidden tab's session hits a permission or finishes a
+                     turn — pure transition reducer + injectable binder
   src/use-escape.ts  useEscapeKey — the one Esc idiom behind every overlay
                      and the busy interrupt
   src/use-focus-trap.ts  useFocusTrap — focus in on open, Tab cycles inside,
@@ -1075,6 +1078,16 @@ colored corner badge when busy or awaiting permission, so a row of tabs reads as
 fleet view). Busy state is derived entirely from the wire — `user_prompt`
 sets it, `turn_end` clears it — so a replayed in-flight turn restores it
 correctly.
+
+The same idle/busy/permission tri-state feeds **needs-you notifications**
+(`notify.ts`, Phase NF): with the settings-card toggle on (off by default —
+enabling is the only thing that asks the browser for permission), a *hidden*
+tab raises an OS notification when a session hits a permission prompt or
+finishes a turn, one per session (`tag` = session id), self-closing when the
+cause resolves elsewhere or the tab becomes visible again. Both routes wire
+it — the session viewport from its own `asks`/`busy`, the fleet from every
+`sessions` snapshot — and titles/bodies are shell-composed with engine
+strings carried as inert plain text (the trusted-shell rule, §3).
 
 ### 6.2 `ws.ts` — `SocketClient`
 

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -140,11 +140,15 @@ async function withFreshMockSession(
   token: string,
   run: (isolatedPage: Page) => Promise<void>,
   agent = "Claude Code",
+  // Runs before the first navigation — the slot for addInitScript stubs that
+  // must exist before the app boots (the NF Notification recorder).
+  prepare?: (isolatedPage: Page) => Promise<void>,
 ): Promise<void> {
   const daemon = await startDaemon({ MIRAFOLD_TOKEN: token });
   let isolatedPage: Page | undefined;
   try {
     isolatedPage = await browser.newPage();
+    if (prepare) await prepare(isolatedPage);
     await isolatedPage.goto(`http://127.0.0.1:${daemon.port}/?token=${token}`);
     await isolatedPage.locator(".onb-agent", { hasText: agent }).click();
     await isolatedPage.waitForURL(/\/s\/[\w-]+/);
@@ -1226,6 +1230,113 @@ test("settings card: gear opens it, picking applies live and writes the slot (S.
   await page.locator(".settings-backdrop").click({ position: { x: 8, y: 8 } });
   assert.equal(await page.locator(".settings-card").count(), 0);
   assert.equal(await dataTheme(), "dark"); // ends where the suite expects
+});
+
+test("NF: hidden viewport toasts a permission then the turn end; visibility closes both", async () => {
+  const token = "e2e-notify-7b31";
+  type ToastRec = { title: string; body?: string; tag?: string; closed: boolean };
+  const toasts = (p: Page) =>
+    p.evaluate(() => (window as unknown as { __TOASTS__: ToastRec[] }).__TOASTS__);
+  // A JS string, not a function — the accessor property would otherwise
+  // compile with the module-scope __name wrapper (same keepNames trap as the
+  // stub below) and die serialized.
+  const setVisibility = (p: Page, state: "hidden" | "visible") =>
+    p.evaluate(
+      `Object.defineProperty(document, "visibilityState", {
+         configurable: true, get: function () { return "${state}"; },
+       });
+       document.dispatchEvent(new Event("visibilitychange"));`,
+    );
+  await withFreshMockSession(
+    token,
+    async (page2) => {
+      // The toggle lives in the settings card and defaults off; flipping it
+      // writes the preference (the stub's grant is already "granted", so no
+      // permission dance here — that branch is Tier-1 logic).
+      await page2.locator(".sb-settings").click();
+      await page2.waitForSelector(".settings-card");
+      const row = page2.locator(".notify-row");
+      assert.equal(await row.getAttribute("aria-checked"), "false");
+      await row.click();
+      assert.equal(await row.getAttribute("aria-checked"), "true");
+      assert.equal(
+        await page2.evaluate(() => localStorage.getItem("mirafold-notify")),
+        "1",
+      );
+      await assertAxeClean(page2, "settings notifications section");
+      await page2.keyboard.press("Escape");
+      await page2.waitForSelector(".settings-card", { state: "detached" });
+
+      // Background the tab — the notifier reads visibilityState live, and
+      // only a hidden tab may toast.
+      await setVisibility(page2, "hidden");
+
+      // A permission lands while hidden → exactly one toast, session-tagged,
+      // shell-composed title with the engine's ask as inert text.
+      await page2.locator("textarea").click();
+      await page2.keyboard.type("run something dangerous");
+      await page2.keyboard.press("Enter");
+      await page2.waitForSelector(".perm-bar");
+      await page2.waitForFunction(
+        () => (window as unknown as { __TOASTS__?: unknown[] }).__TOASTS__?.length === 1,
+        undefined,
+        { timeout: 15_000 },
+      );
+      const [first] = await toasts(page2);
+      assert.match(first.title, /^⚠ permission — /);
+      assert.match(first.body ?? "", /Claude Code wants Bash: rm -rf/);
+      assert.ok(first.tag?.startsWith("mirafold-"), `tag was ${first.tag}`);
+
+      // Answering retires the permission toast (the state moved on); the
+      // finishing turn then toasts once more under the same tag.
+      await page2.locator(".perm-allow").click();
+      await page2.waitForFunction(
+        () => {
+          const t = (window as unknown as { __TOASTS__: { closed: boolean }[] }).__TOASTS__;
+          return t.length === 2 && t[0].closed;
+        },
+        undefined,
+        { timeout: 15_000 },
+      );
+      const [, second] = await toasts(page2);
+      assert.match(second.title, /^✓ turn finished — /);
+      assert.equal(second.tag, first.tag);
+
+      // Coming back closes everything this tab created — the page itself is
+      // now the notification.
+      await setVisibility(page2, "visible");
+      await page2.waitForFunction(() =>
+        (window as unknown as { __TOASTS__: { closed: boolean }[] }).__TOASTS__.every(
+          (t) => t.closed,
+        ),
+      );
+    },
+    "Claude Code",
+    async (p) => {
+      // Notification stubbed before boot: headless Chrome auto-denies the
+      // real API and an OS toast is invisible to the DOM anyway — the
+      // recorder IS the observable surface. A plain-JS STRING, not a
+      // function: tsx compiles this file with esbuild keepNames, which
+      // injects a module-scope `__name` helper into compiled classes —
+      // Playwright then serializes the function without the helper and the
+      // init script dies on a ReferenceError before installing the stub
+      // (diagnosed 2026-08-12 via pageerror probe).
+      await p.addInitScript(`
+        const spawned = [];
+        window.__TOASTS__ = spawned;
+        window.Notification = class {
+          constructor(title, opts) {
+            this.rec = { title, body: opts && opts.body, tag: opts && opts.tag, closed: false };
+            this.onclick = null;
+            spawned.push(this.rec);
+          }
+          close() { this.rec.closed = true; }
+          static get permission() { return "granted"; }
+          static requestPermission() { return Promise.resolve("granted"); }
+        };
+      `);
+    },
+  );
 });
 
 test("Esc on an open card is exclusive — it dismisses without interrupting the turn", async () => {

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -8,6 +8,8 @@ import { SocketClient } from "../ws";
 import { tildify } from "../tildify";
 import { useArmedConfirm } from "../use-armed-confirm";
 import { paintTabStatus } from "../tab-status";
+import { agentLabel } from "../agents-meta";
+import { createDomNotifier, folderTitle } from "../notify";
 import { createFolderPickerRequests } from "../folder-picker-requests";
 
 // 4.6 Mission control, grown into the Phase M cockpit: every live session in
@@ -199,6 +201,36 @@ export function FleetView() {
         ? `⚠ ${needsYou} need${needsYou === 1 ? "s" : ""} you — Mirafold`
         : "Mirafold — sessions";
   }, [needsYou, fleetBusy]);
+
+  // Needs-you notifications (NF.1): a hidden cockpit toasts per session. No
+  // toggle UI here — the preference set in any session's settings card is
+  // read live from storage by the notifier. reset() on disconnect: stale
+  // snapshots must not diff against a world the socket no longer sees.
+  const [notifier] = useState(createDomNotifier);
+  useEffect(() => {
+    if (!notifier) return;
+    if (!connected || sessions === null) {
+      notifier.reset();
+      return;
+    }
+    notifier.update(
+      sessions.map((s) => {
+        const ask = s.permissions?.[0];
+        return {
+          id: s.sessionId,
+          state: wantsAnswer(s)
+            ? ("permission" as const)
+            : s.status === "working"
+              ? ("busy" as const)
+              : ("idle" as const),
+          title: s.name || folderTitle(s.cwd) || agentLabel(s.agent),
+          agent: agentLabel(s.agent),
+          tool: ask?.tool,
+          detail: ask?.detail,
+        };
+      }),
+    );
+  }, [notifier, connected, sessions]);
 
   // Stable identity: Onboarding keys its poll interval on this prop, so a
   // fresh arrow each render would restart the 3s timer instead of letting

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -24,6 +24,7 @@ import { ThemePicker } from "./ThemePicker";
 import { tildify } from "../tildify";
 import { agentLabel, connectHint } from "../agents-meta";
 import { paintTabStatus } from "../tab-status";
+import { createDomNotifier, folderTitle, notifyPrefEnabled, setNotifyPref } from "../notify";
 import { useEscapeKey } from "../use-escape";
 import { Announcer, turnResponse, useAnnouncer } from "./Announcer";
 import { PermBar, type PermAsk } from "./PermBar";
@@ -190,6 +191,40 @@ export function Shell() {
     setMode(entry.appearance);
   };
 
+  // ── Needs-you notifications (Phase NF) ──────────────────────────────────
+  // Preference + the browser's own grant, both shell-owned. Off by default;
+  // flipping it on is the ONLY thing that asks the browser for notification
+  // permission (never page load). "unsupported" (iOS Safari outside an
+  // installed PWA) hides the settings section entirely.
+  const [notifyOn, setNotifyOn] = useState(
+    () => typeof Notification !== "undefined" && notifyPrefEnabled(),
+  );
+  const [notifyPerm, setNotifyPerm] = useState<NotificationPermission | "unsupported">(() =>
+    typeof Notification === "undefined" ? "unsupported" : Notification.permission,
+  );
+  const toggleNotify = () => {
+    if (notifyOn) {
+      setNotifyPref(false);
+      setNotifyOn(false);
+      return;
+    }
+    if (notifyPerm === "default") {
+      // Enable only once granted — an "on" toggle that can never fire is a lie.
+      void Notification.requestPermission().then((p) => {
+        setNotifyPerm(p);
+        if (p === "granted") {
+          setNotifyPref(true);
+          setNotifyOn(true);
+        }
+      });
+      return;
+    }
+    // "denied" still flips the preference on — the card's hint line says why
+    // it stays silent, and un-blocking in the browser then just works.
+    setNotifyPref(true);
+    setNotifyOn(true);
+  };
+
   // The socket + pub/sub live in session-bus.ts (H.9); one bus per mount.
   // useState's lazy initializer, NOT useMemo: Fast Refresh re-runs useMemo on
   // every hot edit (dependency lists are deliberately ignored), and each
@@ -197,6 +232,9 @@ export function Shell() {
   // inflating the fleet's viewport count during dev (2026-07-25, Kyle).
   // State survives a hot update, so the one bus lives as long as the page.
   const [bus] = useState(createSessionBus);
+  // Same lazy-useState idiom: one notifier (and one visibilitychange
+  // listener) for the page's life. Null where the API doesn't exist.
+  const [notifier] = useState(createDomNotifier);
 
   // Screen-reader announcements (A.1) — see Announcer.tsx for why the
   // transcript itself stays silent and these speak at turn boundaries.
@@ -395,6 +433,29 @@ export function Shell() {
     paintTabStatus(asks.length > 0 ? "permission" : busy ? "busy" : "idle");
   }, [busy, asks.length]);
 
+  // Needs-you notifications (NF.1): the same tri-state the tab light paints,
+  // pushed through the notifier so a hidden viewport can toast. reset() on
+  // any disconnect: the drop forces busy→false above, and that forced edge
+  // must never read as a finished turn.
+  useEffect(() => {
+    if (!notifier) return;
+    if (!connected || !meta.sessionId) {
+      notifier.reset();
+      return;
+    }
+    const ask = asks[0];
+    notifier.update([
+      {
+        id: meta.sessionId,
+        state: asks.length > 0 ? "permission" : busy ? "busy" : "idle",
+        title: folderTitle(meta.cwd) ?? (meta.agent ? agentLabel(meta.agent) : "session"),
+        agent: meta.agent ? agentLabel(meta.agent) : undefined,
+        tool: ask?.tool,
+        detail: ask?.detail,
+      },
+    ]);
+  }, [notifier, connected, busy, asks, meta]);
+
   const answer = (id: string, allow: boolean) => {
     bus.answerPermission(id, allow);
     setAsks((a) => a.filter((x) => x.id !== id));
@@ -566,6 +627,15 @@ export function Shell() {
             slots={slots}
             onPick={pickTheme}
             onClose={() => setSettingsOpen(false)}
+            notify={
+              notifyPerm === "unsupported"
+                ? undefined
+                : {
+                    enabled: notifyOn,
+                    blocked: notifyPerm === "denied",
+                    onToggle: toggleNotify,
+                  }
+            }
             // The card's Session section (R.4l) — on phone this is THE place
             // these facts live (the bar carries only the agent name; the
             // prompt crumb is desktop-only), so it gets everything.

--- a/web/src/components/ThemePicker.tsx
+++ b/web/src/components/ThemePicker.tsx
@@ -4,10 +4,11 @@ import { cost, tokens } from "./StatusBar";
 
 // The settings card (S.4) — SHELL-OWNED UI, the one new chrome affordance of
 // Phase S (the pill is locked unchanged). Centered modal over the scrim,
-// same idiom as the pairing card. Two sections: Session (R.4l — the facts
+// same idiom as the pairing card. Three sections: Session (R.4l — the facts
 // the phone status bar no longer carries inline: folder, model, usage…;
 // details-on-demand is the phone's one path to them, so this section is
-// load-bearing there and merely redundant on desktop) and Theme.
+// load-bearing there and merely redundant on desktop), Theme, and
+// Notifications (Phase NF — prop-driven, Shell owns the logic).
 //
 // Vite-only module: the swatch chips read each theme's real colors by
 // importing the theme CSS as raw text (import.meta.glob), so a new theme's
@@ -71,11 +72,23 @@ function sessionRows(session?: SessionFacts): [label: string, value: string][] {
   return rows.filter((r): r is [string, string] => Boolean(r[1]));
 }
 
+/** Needs-you notifications (NF.2), prop-driven — Shell owns the preference,
+ *  the browser-permission dance, and the notifier; the card only shows the
+ *  switch. Absent = the Notification API doesn't exist here (iOS Safari
+ *  outside an installed PWA) and the section stays out entirely. */
+export type NotifyFacts = {
+  enabled: boolean;
+  /** The browser has notifications hard-denied for this site. */
+  blocked: boolean;
+  onToggle: () => void;
+};
+
 export function ThemePicker({
   slots,
   onPick,
   onClose,
   session,
+  notify,
 }: {
   /** The current slot choices — the checked row per group. */
   slots: Record<ThemeAppearance, string>;
@@ -83,6 +96,7 @@ export function ThemePicker({
   onPick: (id: string) => void;
   onClose: () => void;
   session?: SessionFacts;
+  notify?: NotifyFacts;
 }) {
   const rows = sessionRows(session);
 
@@ -149,6 +163,27 @@ export function ThemePicker({
           })}
         </div>
       ))}
+      {notify && (
+        <>
+          <div className="settings-section-title">Notifications</div>
+          <button
+            className="notify-row"
+            role="switch"
+            aria-checked={notify.enabled}
+            onClick={notify.onToggle}
+          >
+            <span className="notify-row-name">Notify me when a session needs me</span>
+            <span className="notify-row-state" aria-hidden="true">
+              {notify.enabled ? "on" : "off"}
+            </span>
+          </button>
+          {notify.blocked && (
+            <div className="notify-blocked">
+              Blocked in the browser — allow notifications for this site to use this.
+            </div>
+          )}
+        </>
+      )}
     </ModalCard>
   );
 }

--- a/web/src/notify.test.ts
+++ b/web/src/notify.test.ts
@@ -1,0 +1,273 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createNotifier,
+  decide,
+  folderTitle,
+  type NotificationHandle,
+  type NotifyAction,
+  type NotifyFlags,
+  type NotifyState,
+  type SessionSnapshot,
+} from "./notify";
+
+const HIDDEN: NotifyFlags = { enabled: true, granted: true, visible: false };
+const VISIBLE: NotifyFlags = { enabled: true, granted: true, visible: true };
+
+const snap = (over: Partial<SessionSnapshot> = {}): SessionSnapshot => ({
+  id: "s1",
+  state: "idle",
+  title: "mirafold",
+  agent: "claude",
+  ...over,
+});
+
+const prev = (entries: [string, NotifyState][]) => new Map(entries);
+
+test("a permission appearing in a hidden tab toasts once, shell-composed", () => {
+  const { actions, states } = decide(
+    prev([["s1", "busy"]]),
+    [snap({ state: "permission", tool: "Bash", detail: "git push origin main" })],
+    HIDDEN,
+  );
+  assert.equal(actions.length, 1);
+  const a = actions[0];
+  assert.equal(a.kind, "show");
+  assert.equal(a.kind === "show" && a.event, "permission");
+  assert.equal(a.kind === "show" && a.title, "⚠ permission — mirafold");
+  assert.equal(a.kind === "show" && a.body, "claude wants Bash: git push origin main");
+  assert.equal(states.get("s1"), "permission");
+});
+
+test("a session first seen already blocked on permission toasts — a background tab discovering a stalled session is the point", () => {
+  const { actions } = decide(new Map(), [snap({ state: "permission", tool: "Bash" })], HIDDEN);
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].kind, "show");
+  assert.equal(actions[0].kind === "show" && actions[0].body, "claude wants Bash.");
+});
+
+test("first sight of busy or idle stays silent — no evidence a turn just ended", () => {
+  assert.equal(decide(new Map(), [snap({ state: "busy" })], HIDDEN).actions.length, 0);
+  assert.equal(decide(new Map(), [snap({ state: "idle" })], HIDDEN).actions.length, 0);
+});
+
+test("busy→idle toasts a turn end", () => {
+  const { actions } = decide(prev([["s1", "busy"]]), [snap()], HIDDEN);
+  assert.equal(actions.length, 1);
+  const a = actions[0];
+  assert.equal(a.kind === "show" && a.event, "turn-end");
+  assert.equal(a.kind === "show" && a.title, "✓ turn finished — mirafold");
+  assert.equal(a.kind === "show" && a.body, "claude is waiting for your next prompt.");
+});
+
+test("permission→idle toasts the turn end (answered + finished while away)", () => {
+  const { actions } = decide(prev([["s1", "permission"]]), [snap()], HIDDEN);
+  assert.equal(actions.length, 1);
+  assert.equal(actions[0].kind === "show" && actions[0].event, "turn-end");
+});
+
+test("permission→busy closes — the ask was answered elsewhere", () => {
+  const { actions } = decide(
+    prev([["s1", "permission"]]),
+    [snap({ state: "busy" })],
+    HIDDEN,
+  );
+  assert.deepEqual(actions, [{ kind: "close", id: "s1" }]);
+});
+
+test("a visible tab suppresses shows but still consumes the transition", () => {
+  const first = decide(prev([["s1", "busy"]]), [snap({ state: "permission" })], VISIBLE);
+  assert.equal(first.actions.length, 0);
+  // Backgrounding later must not replay the already-seen edge through decide
+  // (the binder's visibility hook owns the still-pending re-toast).
+  const second = decide(first.states, [snap({ state: "permission" })], HIDDEN);
+  assert.equal(second.actions.length, 0);
+});
+
+test("a visible tab still emits the close when a turn ends", () => {
+  const { actions } = decide(prev([["s1", "permission"]]), [snap()], VISIBLE);
+  assert.deepEqual(actions, [{ kind: "close", id: "s1" }]);
+});
+
+test("disabled or ungranted emit nothing but keep tracking state", () => {
+  for (const flags of [
+    { ...HIDDEN, enabled: false },
+    { ...HIDDEN, granted: false },
+  ]) {
+    const { actions, states } = decide(
+      prev([["s1", "busy"]]),
+      [snap({ state: "permission" })],
+      flags,
+    );
+    assert.equal(actions.length, 0);
+    assert.equal(states.get("s1"), "permission");
+  }
+});
+
+test("a vanished session closes its toast", () => {
+  const { actions, states } = decide(prev([["s1", "permission"]]), [], HIDDEN);
+  assert.deepEqual(actions, [{ kind: "close", id: "s1" }]);
+  assert.equal(states.size, 0);
+});
+
+test("sessions transition independently", () => {
+  const { actions } = decide(
+    prev([
+      ["a", "busy"],
+      ["b", "permission"],
+      ["c", "idle"],
+    ]),
+    [
+      snap({ id: "a", state: "permission", title: "api", tool: "Bash" }),
+      snap({ id: "b", state: "busy", title: "web" }),
+      snap({ id: "c", state: "idle", title: "docs" }),
+    ],
+    HIDDEN,
+  );
+  const kinds = actions.map((a: NotifyAction) => `${a.kind}:${a.id}`);
+  assert.deepEqual(kinds, ["show:a", "close:b"]);
+});
+
+test("an unchanged state emits nothing", () => {
+  const { actions } = decide(
+    prev([["s1", "permission"]]),
+    [snap({ state: "permission" })],
+    HIDDEN,
+  );
+  assert.equal(actions.length, 0);
+});
+
+test("a runaway permission detail is capped for the OS surface", () => {
+  const { actions } = decide(
+    new Map(),
+    [snap({ state: "permission", tool: "Bash", detail: "x".repeat(500) })],
+    HIDDEN,
+  );
+  const body = actions[0].kind === "show" ? actions[0].body : "";
+  assert.equal(body.length, 160);
+  assert.ok(body.endsWith("…"));
+});
+
+test("folderTitle takes the last path segment and survives absence", () => {
+  assert.equal(folderTitle("/home/kyle/Projects/mirafold"), "mirafold");
+  assert.equal(folderTitle("/"), undefined);
+  assert.equal(folderTitle(undefined), undefined);
+});
+
+// ---- binder ----
+
+class FakeToast implements NotificationHandle {
+  closed = false;
+  onclick: (() => void) | null = null;
+  constructor(public opts: { tag: string; title: string; body: string }) {}
+  close() {
+    this.closed = true;
+  }
+}
+
+function harness(over: { visible?: boolean; enabled?: boolean; granted?: boolean } = {}) {
+  const spawned: FakeToast[] = [];
+  const state = { visible: over.visible ?? false, enabled: over.enabled ?? true, granted: over.granted ?? true, focused: 0 };
+  const notifier = createNotifier({
+    enabled: () => state.enabled,
+    granted: () => state.granted,
+    visible: () => state.visible,
+    spawn: (o) => {
+      const t = new FakeToast(o);
+      spawned.push(t);
+      return t;
+    },
+    focus: () => state.focused++,
+  });
+  return { notifier, spawned, state };
+}
+
+test("binder: a toast carries the session tag; the next event retires the old handle", () => {
+  const { notifier, spawned } = harness();
+  notifier.update([snap({ state: "permission", tool: "Bash" })]);
+  assert.equal(spawned.length, 1);
+  assert.equal(spawned[0].opts.tag, "mirafold-s1");
+  notifier.update([snap({ state: "idle" })]);
+  assert.equal(spawned.length, 2, "turn-end toast replaces the permission one");
+  assert.equal(spawned[0].closed, true);
+  assert.equal(spawned[1].closed, false);
+});
+
+test("binder: resolution elsewhere closes the live toast", () => {
+  const { notifier, spawned } = harness();
+  notifier.update([snap({ state: "permission" })]);
+  notifier.update([snap({ state: "busy" })]);
+  assert.equal(spawned[0].closed, true);
+});
+
+test("binder: reset closes everything and reseeds silently", () => {
+  const { notifier, spawned } = harness();
+  notifier.update([snap({ state: "permission" })]);
+  notifier.reset([snap({ state: "busy" })]);
+  assert.equal(spawned[0].closed, true);
+  notifier.update([snap({ state: "busy" })]);
+  assert.equal(spawned.length, 1, "reseeded state is not a transition");
+  notifier.update([snap({ state: "idle" })]);
+  assert.equal(spawned.length, 2, "a genuine edge after the reseed still toasts");
+});
+
+test("binder: gaining visibility closes every toast this tab created", () => {
+  const { notifier, spawned, state } = harness();
+  notifier.update([
+    snap({ id: "a", state: "permission" }),
+    snap({ id: "b", state: "permission", title: "web" }),
+  ]);
+  assert.equal(spawned.length, 2);
+  state.visible = true;
+  notifier.visibilityChanged();
+  assert.ok(spawned.every((t) => t.closed));
+});
+
+test("binder: losing visibility re-toasts a still-pending permission (the switch-away race)", () => {
+  const { notifier, spawned, state } = harness({ visible: true });
+  notifier.update([snap({ state: "permission", tool: "Bash" })]); // seen, suppressed
+  assert.equal(spawned.length, 0);
+  state.visible = false;
+  notifier.visibilityChanged();
+  assert.equal(spawned.length, 1);
+  assert.equal(spawned[0].opts.title, "⚠ permission — mirafold");
+});
+
+test("binder: losing visibility never re-toasts idle sessions", () => {
+  const { notifier, spawned, state } = harness({ visible: true });
+  notifier.update([snap({ state: "idle" })]);
+  state.visible = false;
+  notifier.visibilityChanged();
+  assert.equal(spawned.length, 0);
+});
+
+test("binder: losing visibility respects the preference and the OS grant", () => {
+  const { notifier, spawned, state } = harness({ visible: true });
+  notifier.update([snap({ state: "permission" })]);
+  state.visible = false;
+  state.enabled = false;
+  notifier.visibilityChanged();
+  assert.equal(spawned.length, 0);
+});
+
+test("binder: click focuses the firing tab and dismisses", () => {
+  const { notifier, spawned, state } = harness();
+  notifier.update([snap({ state: "permission" })]);
+  spawned[0].onclick!();
+  assert.equal(state.focused, 1);
+  assert.equal(spawned[0].closed, true);
+});
+
+test("binder: an unsupported spawn (null) is survivable", () => {
+  const state = { visible: false };
+  const notifier = createNotifier({
+    enabled: () => true,
+    granted: () => true,
+    visible: () => state.visible,
+    spawn: () => null,
+    focus: () => {},
+  });
+  notifier.update([snap({ state: "permission" })]);
+  notifier.update([snap({ state: "idle" })]);
+  notifier.visibilityChanged();
+});

--- a/web/src/notify.ts
+++ b/web/src/notify.ts
@@ -1,0 +1,242 @@
+// Needs-you notifications (Phase NF): OS toasts when a session needs the
+// user — a permission prompt appeared, or a turn finished — fired only from
+// a tab the user can't see. The design rules live in the pure reducer here
+// so Tier-1 can prove them without a DOM:
+//   - fire only while hidden; gaining visibility closes everything this tab
+//     created (the page itself is now the notification);
+//   - one toast per session (`tag` = session id), newer events replace older;
+//   - a toast whose cause resolves elsewhere (answered on another device,
+//     prompted from the terminal) closes the moment the state moves on;
+//   - losing visibility re-toasts any still-pending permission — the race
+//     where the ask lands just as the user switches away is exactly the
+//     failure this feature exists to close.
+// Titles and bodies are shell-composed; engine-derived strings (tool,
+// permission detail) ride along as inert plain text into an OS surface that
+// never interprets markup (the trusted-shell rule).
+
+export type NotifyState = "idle" | "busy" | "permission";
+
+export type SessionSnapshot = {
+  id: string;
+  state: NotifyState;
+  /** Shell-composed display name (session name / folder basename). */
+  title: string;
+  agent?: string;
+  /** The blocking ask, when state is "permission" — inert engine text. */
+  tool?: string;
+  detail?: string;
+};
+
+export type NotifyFlags = {
+  enabled: boolean;
+  granted: boolean;
+  visible: boolean;
+};
+
+export type ShowAction = {
+  kind: "show";
+  id: string;
+  event: "permission" | "turn-end";
+  title: string;
+  body: string;
+};
+export type CloseAction = { kind: "close"; id: string };
+export type NotifyAction = ShowAction | CloseAction;
+
+// OS toast bodies clip anyway; capping here keeps a multi-line heredoc from
+// turning the notification center into a scrollback.
+const DETAIL_CAP = 160;
+const cap = (s: string) =>
+  s.length > DETAIL_CAP ? s.slice(0, DETAIL_CAP - 1) + "…" : s;
+
+/** Last path segment — the session word a toast title leads with. */
+export function folderTitle(cwd?: string): string | undefined {
+  return cwd?.split(/[/\\]/).filter(Boolean).pop();
+}
+
+export function permissionToast(s: SessionSnapshot): ShowAction {
+  const who = s.agent ?? "The agent";
+  const body = s.tool
+    ? s.detail
+      ? cap(`${who} wants ${s.tool}: ${s.detail}`)
+      : `${who} wants ${s.tool}.`
+    : `${who} is waiting on a permission.`;
+  return {
+    kind: "show",
+    id: s.id,
+    event: "permission",
+    title: `⚠ permission — ${s.title}`,
+    body,
+  };
+}
+
+export function turnEndToast(s: SessionSnapshot): ShowAction {
+  return {
+    kind: "show",
+    id: s.id,
+    event: "turn-end",
+    title: `✓ turn finished — ${s.title}`,
+    body: `${s.agent ?? "The agent"} is waiting for your next prompt.`,
+  };
+}
+
+/**
+ * The transition reducer. A session first seen mid-flight counts as coming
+ * from "idle": first sight of a pending permission toasts (a background tab
+ * discovering a stalled session is the feature working), while first sight
+ * of "busy" or "idle" stays silent — there's no evidence a turn just ended.
+ */
+export function decide(
+  prev: ReadonlyMap<string, NotifyState>,
+  next: SessionSnapshot[],
+  flags: NotifyFlags,
+): { actions: NotifyAction[]; states: Map<string, NotifyState> } {
+  const states = new Map(next.map((s) => [s.id, s.state] as const));
+  const actions: NotifyAction[] = [];
+  if (!flags.enabled || !flags.granted) return { actions, states };
+
+  for (const id of prev.keys())
+    if (!states.has(id)) actions.push({ kind: "close", id });
+
+  for (const s of next) {
+    const was = prev.get(s.id);
+    if (was === s.state) continue;
+    if (s.state === "permission") {
+      if (!flags.visible) actions.push(permissionToast(s));
+    } else if (was === undefined) {
+      continue; // first sight of busy/idle: no evidence a turn just ended
+    } else if (s.state === "idle") {
+      // busy→idle AND permission→idle both end a turn the user isn't
+      // watching; the turn-end toast replaces any permission toast (same tag).
+      if (!flags.visible) actions.push(turnEndToast(s));
+      else actions.push({ kind: "close", id: s.id });
+    } else {
+      // →busy: the cause resolved elsewhere (ask answered, new prompt sent).
+      actions.push({ kind: "close", id: s.id });
+    }
+  }
+  return { actions, states };
+}
+
+/** The subset of a Notification the binder drives — injectable for Tier-1. */
+export type NotificationHandle = {
+  close(): void;
+  onclick: (() => void) | null;
+};
+
+export type NotifierDeps = {
+  enabled(): boolean;
+  granted(): boolean;
+  visible(): boolean;
+  spawn(opts: {
+    tag: string;
+    title: string;
+    body: string;
+  }): NotificationHandle | null;
+  focus(): void;
+};
+
+export type Notifier = {
+  /** Fresh session snapshots — diffs against the last call and acts. */
+  update(next: SessionSnapshot[]): void;
+  /**
+   * Reseed without emitting, closing any open toast. Used across socket
+   * drop/reconnect: a dropped socket forces busy→false in the viewport, and
+   * without the reseed that forced edge would toast a turn-end no turn earned.
+   */
+  reset(next?: SessionSnapshot[]): void;
+  /** Call on every document visibilitychange. */
+  visibilityChanged(): void;
+};
+
+export function createNotifier(deps: NotifierDeps): Notifier {
+  let states = new Map<string, NotifyState>();
+  let last: SessionSnapshot[] = [];
+  const open = new Map<string, NotificationHandle>();
+
+  const close = (id: string) => {
+    open.get(id)?.close();
+    open.delete(id);
+  };
+  const show = (a: ShowAction) => {
+    // The OS replaces same-tag toasts, but only our own handle can be
+    // close()d later — so retire the old handle explicitly.
+    close(a.id);
+    const h = deps.spawn({ tag: `mirafold-${a.id}`, title: a.title, body: a.body });
+    if (!h) return;
+    h.onclick = () => {
+      deps.focus();
+      close(a.id);
+    };
+    open.set(a.id, h);
+  };
+
+  return {
+    update(next) {
+      last = next;
+      const { actions, states: s } = decide(states, next, {
+        enabled: deps.enabled(),
+        granted: deps.granted(),
+        visible: deps.visible(),
+      });
+      states = s;
+      for (const a of actions) a.kind === "show" ? show(a) : close(a.id);
+    },
+    reset(next = []) {
+      last = next;
+      states = new Map(next.map((s) => [s.id, s.state] as const));
+      for (const id of [...open.keys()]) close(id);
+    },
+    visibilityChanged() {
+      if (deps.visible()) {
+        for (const id of [...open.keys()]) close(id);
+        return;
+      }
+      if (!deps.enabled() || !deps.granted()) return;
+      for (const s of last) if (s.state === "permission") show(permissionToast(s));
+    },
+  };
+}
+
+// ---- browser wiring ----
+
+export const NOTIFY_STORAGE_KEY = "mirafold-notify";
+
+export const notifyPrefEnabled = (): boolean =>
+  localStorage.getItem(NOTIFY_STORAGE_KEY) === "1";
+
+export const setNotifyPref = (on: boolean): void => {
+  if (on) localStorage.setItem(NOTIFY_STORAGE_KEY, "1");
+  else localStorage.removeItem(NOTIFY_STORAGE_KEY);
+};
+
+/**
+ * The real-DOM notifier: preference read live from localStorage (so a fleet
+ * tab honors a toggle flipped in a session tab), OS grant read live (it can
+ * be revoked any time). Returns null where the Notification API doesn't
+ * exist (iOS Safari outside an installed PWA) — callers skip wiring.
+ */
+export function createDomNotifier(): Notifier | null {
+  if (typeof Notification === "undefined") return null;
+  const notifier = createNotifier({
+    enabled: notifyPrefEnabled,
+    granted: () => Notification.permission === "granted",
+    visible: () => document.visibilityState === "visible",
+    spawn: (o) => {
+      // `new Notification` throws on platforms that only allow
+      // ServiceWorkerRegistration.showNotification (Android Chrome) — treat
+      // as unsupported rather than crashing the update path.
+      try {
+        const n = new Notification(o.title, { body: o.body, tag: o.tag, icon: "/favicon-32x32.png" });
+        const h: NotificationHandle = { close: () => n.close(), onclick: null };
+        n.onclick = () => h.onclick?.();
+        return h;
+      } catch {
+        return null;
+      }
+    },
+    focus: () => window.focus(),
+  });
+  document.addEventListener("visibilitychange", () => notifier.visibilityChanged());
+  return notifier;
+}

--- a/web/src/styles/12-dialogs.css
+++ b/web/src/styles/12-dialogs.css
@@ -634,3 +634,60 @@
   flex-shrink: 0;
 }
 
+/* ---- Needs-you notifications (Phase NF) — the card's third section. ------
+   Same row idiom as .theme-row; the switch state reads in the trailing
+   on/off word (aria-checked carries it for screen readers). */
+
+.theme-group + .settings-section-title {
+  margin-top: 18px;
+}
+
+.notify-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  width: 100%;
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 0.9em;
+  color: var(--fg-body);
+  text-align: left;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  cursor: pointer;
+}
+
+.notify-row:hover {
+  background: var(--surface-hover);
+  border-color: var(--border-faint);
+}
+
+.notify-row[aria-checked="true"] {
+  border-color: var(--border-mid);
+  background: var(--surface-2);
+}
+
+.notify-row-name {
+  flex: 1;
+  min-width: 0;
+}
+
+.notify-row-state {
+  flex-shrink: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.85em;
+  color: var(--fg-dimmer);
+}
+
+.notify-row[aria-checked="true"] .notify-row-state {
+  color: var(--accent);
+}
+
+.notify-blocked {
+  margin-top: 8px;
+  font-size: 0.8em;
+  line-height: 1.45;
+  color: var(--warn-fg);
+}
+


### PR DESCRIPTION
## What

OS-level notifications when a session needs the user — the away-story gap: fleet view, relay viewport, and the desktop app all assume the user steps away, but nothing told them *when to look back*.

- **Two triggers, by design**: a session enters `permission`, or a turn ends (`busy → idle`). No per-tool chatter, no disconnect toasts (a phone backgrounding its tab drops the socket routinely — that would train users to disable the feature).
- **The suppression rule**: toasts fire only from hidden tabs; gaining visibility closes everything the tab created; losing visibility re-toasts still-pending permissions (the switch-away race is exactly the failure this feature closes).
- **Coalescing/self-closing**: one toast per session (`tag` = session id), newer replaces older, and a toast whose cause resolves elsewhere (answered on another device, prompted from the terminal) closes itself.
- **Trust boundary**: titles/bodies are shell-composed; engine strings (tool, permission detail) ride as inert plain text. Off by default; flipping the settings-card toggle on is the only thing that ever asks the browser for permission.
- Both routes wired: Shell from its own `asks`/`busy` tri-state, FleetView from every `sessions` snapshot. Closed-browser Web Push and cross-tab suppression are deliberately parked in POST-RELEASE.md.

## How

`web/src/notify.ts` — a pure transition reducer (all rules above live there) plus an injectable binder; `createDomNotifier()` binds to the real DOM. `reset()` reseeds across socket drop/reconnect so the forced `busy→false` never fakes a turn-end.

## Verification

- Tier-1: 23 new tests on the reducer + binder matrix; full `yarn test` 695/695.
- Tier-3: new e2e proves the whole hidden-tab loop (toggle → permission toast → allow retires it → turn-end toast, same tag → visibility closes both); full suite 96/96. One diagnosed trap recorded in PLAN.md: tsx's esbuild keepNames injects a `__name` helper that Playwright serializes away, so the e2e's Notification stub and visibility override are plain-JS strings.
- Tier-2: 150/150 (no server code touched; cross-check).
- `yarn typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)