### PR TITLE
File drag-and-drop: dropped files stage on the daemon, their paths land in the prompt

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2517,6 +2517,89 @@ user-visible PermBar strings.
   `yarn test` + `yarn test:e2e` + `yarn typecheck` pass; README's shell-UI
   section gains the tab-status-adjacent paragraph.
 
+## File drag-and-drop input (opened 2026-08-12; Kyle-directed)
+
+**Product call.** Kyle: take files in by drag and drop, like the terminal.
+In a terminal that feature is mostly the TERMINAL EMULATOR's: dropping a
+file inserts its shell-quoted path at the cursor, and the agent reads the
+path with its own tools. A browser cannot do that — a drop hands over the
+file's NAME and BYTES, never its real filesystem path — so Mirafold's
+faithful equivalent is: catch the drop on shell-owned chrome, ship the
+bytes to the daemon over the existing WebSocket in bounded chunks, stage
+them in a per-session directory OUTSIDE the working tree (no tree
+pollution — the terminal never copies into the repo either), and insert
+the staged file's absolute path into the prompt. The agent then reads it
+exactly as a terminal drop's path — zero adapter changes, agent-neutral by
+construction, and the same mechanism makes drops work from a phone through
+the relay, which a terminal cannot do at all. (Promoted from
+POST-RELEASE.md's "Input augment" entry; clipboard PASTE of files/images
+stays parked there.)
+
+**Bounds.** Staging is `os.tmpdir()/mirafold-uploads/<sessionId>/` (0700);
+v1 cleanup relies on the OS's tmp reaping (recorded decision — per-session
+delete-on-end can ride later). Caps: `FILE_UPLOAD_MAX_BYTES` (10 MB
+default, env), 2 concurrent uploads per connection, chunks bounded well
+under `MAX_WS_PAYLOAD`, a 30s no-chunk stall reaper, sanitized basenames
+(never a path), collision-suffixed. Uploads follow the prompt's relay
+gate: refused on a remote viewport when the session's backend kind is not
+`allowedOverRelay` — an upload is model input staging. Replies are
+correlated per-viewport (echoed client-minted id, `CLIENT_ID_RE` grammar),
+never broadcast, never replay-buffered. The drop overlay, progress strip,
+and path insertion are shell-owned end to end; a staged path enters the
+prompt via the existing draft-merge path, which never discards composed
+text.
+
+### Phase FD.1 — Wire + daemon staging
+
+- [x] **Step FD.1 — Chunked upload messages + the staging writer** —
+  completed 2026-08-12: five additive message types + Q.2 fixtures,
+  `upload-handlers.ts` with 12 Tier-1 tests covering the full refusal
+  matrix, and 2 Tier-2 itests proving byte-exact staging + typed refusals
+  over a real socket. — **Goal:** a client can stream a bounded file to the daemon and get back
+  a staged absolute path, with every abuse path refused loudly. **Build:**
+  additive protocol types (`file_upload_begin {id,name,size}` /
+  `file_upload_chunk {id,data}` / `file_upload_abort {id}` client-side;
+  `file_upload_done {id,path,name}` / `file_upload_error {id,message}`
+  replies) + Q.2 fixtures; `server/sessions/upload-handlers.ts` on the
+  fs-handlers template (per-connection state, never throws, every
+  well-formed request gets exactly one reply); connection.ts delegation +
+  dispose on close. **Files:** `server/protocol.ts`,
+  `server/protocol.test.ts`, `server/sessions/upload-handlers.ts` (+
+  `.test.ts`), `server/sessions/connection.ts`,
+  `server/sessions/file-upload.itest.ts`. **Done when:** Tier-1 covers
+  sanitization (path-stripped names, control chars, dot-names, length
+  cap, collision suffixing), size/concurrency/stall caps, chunk-overflow
+  and chunk-before-begin refusals, and the remote relay gate; a Tier-2
+  itest streams real bytes over a real socket and reads back the exact
+  file from staging; `yarn typecheck` green.
+
+### Phase FD.2 — The drop experience in the shell
+
+- [x] **Step FD.2 — Dropzone, progress, path insertion, e2e, docs** —
+  completed 2026-08-12: window-level drop targets + overlay + upload strip
+  shipped, staged paths quoted into the prompt via the draft merge with a
+  polite announcement, 10 Tier-1 tests on the client core, and the e2e
+  proves the whole loop (synthesized `DataTransfer` drop → overlay →
+  staged-path in textarea → byte-exact file on disk → announcement). One
+  diagnosed trap recorded: the drag listeners attach only after the
+  session attaches, so a dispatch racing the mount fires into the void —
+  the e2e waits for the session UI first. — **Goal:** dragging files onto a session viewport uploads them and puts
+  their staged paths in the prompt, visibly and accessibly. **Build:**
+  `web/src/file-drop.ts` — pure chunking/state core + a
+  folder-picker-style reply router, Tier-1-tested; session-bus gains the
+  three send methods; Shell wires window-level drag listeners (gated off
+  onboarding), a shell-owned drop overlay + a compact upload strip above
+  the prompt (name + progress + dismissible error), quoted-path insertion
+  through the PromptDraft merge, and a polite announcement per attached
+  file; CSS in the prompt-area stylesheet. **Files:**
+  `web/src/file-drop.ts` (+ `.test.ts`), `web/src/session-bus.ts`,
+  `web/src/components/Shell.tsx`, styles, `server/testing/app.e2e.ts`,
+  README, POST-RELEASE.md (annotate the Input augment entry). **Done
+  when:** the e2e drops a real `File` via `DataTransfer` on the live page,
+  watches the strip, reads the staged path out of the textarea, verifies
+  the staged file's exact bytes on disk, and axe stays clean; all three
+  tiers green.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -144,9 +144,11 @@ has a home in this plan, the entry points there instead of duplicating it.
   rides Phase 4's multi-user seam (Locked decisions: "architected so
   multi-user is additive later").
 
-- [ ] **Input augment** — drag & drop and paste (files, images) into the
-  prompt box; eventually voice input. All shell-owned — the trusted-shell
-  boundary is untouched.
+- [ ] **Input augment** — the drag & drop half SHIPPED 2026-08-12 as the
+  plan's "File drag-and-drop input" phase (chunked upload to a per-session
+  staging dir, staged path into the prompt). Remaining here: clipboard
+  PASTE of files/images into the prompt box, and eventually voice input.
+  All shell-owned — the trusted-shell boundary is untouched.
 
 - [ ] **Skills as buttons** — surface the agent's skills / slash commands as
   clickable shell affordances instead of typed invocations.

--- a/README.md
+++ b/README.md
@@ -755,6 +755,9 @@ web/               the browser app (React 19 + Vite)
   src/notify.ts      needs-you notifications (Phase NF): OS toasts when a
                      hidden tab's session hits a permission or finishes a
                      turn — pure transition reducer + injectable binder
+  src/file-drop.ts   file drag-and-drop (Phase FD): chunked upload of a
+                     dropped file's bytes + the staged-path prompt insert
+                     — pure chunk/state core, Shell owns the listeners
   src/use-escape.ts  useEscapeKey — the one Esc idiom behind every overlay
                      and the busy interrupt
   src/use-focus-trap.ts  useFocusTrap — focus in on open, Tab cycles inside,
@@ -1088,6 +1091,19 @@ cause resolves elsewhere or the tab becomes visible again. Both routes wire
 it — the session viewport from its own `asks`/`busy`, the fleet from every
 `sessions` snapshot — and titles/bodies are shell-composed with engine
 strings carried as inert plain text (the trusted-shell rule, §3).
+
+The shell also owns **file drag-and-drop** (`file-drop.ts`, Phase FD). In a
+terminal, dropping a file inserts its path and the agent reads the path
+itself; a browser never exposes a dropped file's real path, so the shell
+streams the bytes over the socket (`file_upload_begin/chunk/abort`, base64
+chunks bounded under the socket payload cap), the daemon stages them in a
+per-session directory under the OS temp dir — never the working tree — and
+the reply's absolute path lands in the prompt, quoted the way a terminal
+quotes it. Zero adapter involvement: the agent reads the staged path with
+its own tools, so all three agents get the feature at once, and the same
+path works from a phone through the relay. Uploads follow the prompt's
+relay gate; caps (10 MB/file, 2 concurrent, stall reaping) and name
+sanitization live in `server/sessions/upload-handlers.ts`.
 
 ### 6.2 `ws.ts` — `SocketClient`
 

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -145,6 +145,14 @@ const WIRE: WireByType = {
     version: "0.0.1",
   },
   folder_picked: { type: "folder_picked", id: "fp1", path: "/home/u/other-project" },
+  // Phase FD: staged-upload replies (correlated, per-viewport).
+  file_upload_done: {
+    type: "file_upload_done",
+    id: "u1",
+    path: "/tmp/mirafold-uploads/s1/notes.txt",
+    name: "notes.txt",
+  },
+  file_upload_error: { type: "file_upload_error", id: "u1", message: "file too large" },
   refused: {
     type: "refused",
     reason: "subscription_over_relay",
@@ -264,6 +272,10 @@ const CLIENT: ClientByType = {
   fs_listdir: { type: "fs_listdir", id: "f4", path: "src" },
   fs_read: { type: "fs_read", id: "f2", path: "src/app.ts" },
   fs_diff: { type: "fs_diff", id: "f3", path: "src/app.ts" },
+  // Phase FD: a dropped file's bytes, chunked (base64), declared size first.
+  file_upload_begin: { type: "file_upload_begin", id: "u1", name: "notes.txt", size: 11 },
+  file_upload_chunk: { type: "file_upload_chunk", id: "u1", data: "aGVsbG8gd29ybGQ=" },
+  file_upload_abort: { type: "file_upload_abort", id: "u1" },
   client_error: { type: "client_error", message: "TypeError: x is undefined", clientVersion: "0.0.1" },
 };
 

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -370,6 +370,17 @@ type WireMsgBody =
       // so older clients still perform their existing safe refresh.
       reason?: "status";
     }
+  // File drag-and-drop input (Phase FD): the staged-upload replies. A drop
+  // ships the file's BYTES (browsers never expose a dropped file's real
+  // path) in bounded chunks; `done` answers with the absolute path the
+  // daemon staged them at — OUTSIDE the working tree — which the shell
+  // inserts into the prompt for the agent to read with its own tools,
+  // exactly like a terminal drop's inserted path. Correlated per-viewport
+  // request/reply (echoed client-minted id) — never broadcast, never
+  // replay-buffered. `name` rides `done` so the strip can label the result
+  // without holding client state hostage to it.
+  | { type: "file_upload_done"; id: string; path: string; name: string }
+  | { type: "file_upload_error"; id: string; message: string }
   // Reply to a client ping — connection liveness only, never
   // buffered or sequenced (4.4).
   | { type: "pong" }
@@ -617,6 +628,15 @@ export type ClientMsg =
   // user's daemon can be version-skewed, so the whole-tree pair is the
   // compatibility floor, never removed here.
   | { type: "fs_listdir"; id: string; path: string }
+  // File drag-and-drop input (Phase FD): a dropped file's bytes, chunked.
+  // `begin` declares a sanitized display name and the exact total size (the
+  // cap check runs before any byte arrives); `chunk.data` is base64, each
+  // decoded chunk bounded well under MAX_WS_PAYLOAD; `abort` discards a
+  // partial upload (a navigating page, a cancelled drop). Same id grammar
+  // as fs correlation ids; per-connection state only.
+  | { type: "file_upload_begin"; id: string; name: string; size: number }
+  | { type: "file_upload_chunk"; id: string; data: string }
+  | { type: "file_upload_abort"; id: string }
   // The browser half's uncaught errors (window "error"/"unhandledrejection"),
   // forwarded so the daemon's flight-recorder log hears about a front-end
   // crash — otherwise a "it went blank" bug report arrives with an empty log

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -6,6 +6,7 @@ import { runActionTool } from "./actions";
 import { createBangHandlers } from "./bang-handlers";
 import { createFsHandlers } from "./fs-handlers";
 import { createFolderPickerHandler } from "./folder-picker-handler";
+import { createUploadHandlers } from "./upload-handlers";
 import {
   ADAPTER_AGENTS,
   availableAgents,
@@ -111,6 +112,13 @@ export function openConnection(
     viewport,
     remote,
     isClosed: () => closed,
+  });
+  // File drag-and-drop staging (Phase FD) — per-connection chunked uploads,
+  // the fs-handlers pattern (upload-handlers.ts).
+  const uploads = createUploadHandlers({
+    viewport,
+    getEntry: () => entry,
+    remote,
   });
 
   // Identity first, then the replayed history, then the live stream. 4.4:
@@ -480,6 +488,17 @@ export function openConnection(
       case "fs_changes":
         fs.changes(msg);
         break;
+      case "file_upload_begin":
+        // File drag-and-drop staging (Phase FD) — chunked, capped, gated;
+        // handled in upload-handlers.ts (one delegation per case, like fs_*).
+        uploads.begin(msg);
+        break;
+      case "file_upload_chunk":
+        uploads.chunk(msg);
+        break;
+      case "file_upload_abort":
+        uploads.abort(msg);
+        break;
       case "client_error":
         // The browser half's uncaught errors, landing in the flight-recorder
         // log so a front-end crash leaves a trace a bug report can attach.
@@ -499,6 +518,7 @@ export function openConnection(
   const close = () => {
     closed = true;
     folderPicker.close();
+    uploads.dispose();
     if (entry) {
       registry.detach(entry, viewport);
       log.info(`viewport detached ← session ${entry.id}`);

--- a/server/sessions/file-upload.itest.ts
+++ b/server/sessions/file-upload.itest.ts
@@ -1,0 +1,77 @@
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import { startDaemon, createSession, type Daemon } from "../testing/itest-harness";
+import { stagingDir, FILE_UPLOAD_MAX_BYTES } from "./upload-handlers";
+
+// Phase FD over a REAL socket: a chunked upload lands byte-exact in the
+// session's staging dir and the reply path is where the bytes actually are —
+// the whole point of the feature is that path's honesty, so the proof reads
+// the disk, not the handler. Abuse paths (oversize, overflow) get typed
+// error replies on the same live connection, and the connection keeps
+// working afterward.
+
+let d: Daemon;
+
+before(async () => {
+  d = await startDaemon();
+});
+after(async () => {
+  await d.stop();
+});
+
+const b64 = (s: string | Buffer) => Buffer.from(s).toString("base64");
+
+test("FD.1: chunked upload over a real socket stages exact bytes at the replied path", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  try {
+    // Three chunks incl. multibyte content — byte math, not string math.
+    const body = "line one\n☃ snowman\n" + "x".repeat(1000);
+    const bytes = Buffer.from(body);
+    client.send({ type: "file_upload_begin", id: "up1", name: "notes.txt", size: bytes.length } as never);
+    for (let at = 0; at < bytes.length; at += 500) {
+      client.send({ type: "file_upload_chunk", id: "up1", data: b64(bytes.subarray(at, at + 500)) } as never);
+    }
+    const done = (await client.type("file_upload_done")) as { id: string; path: string; name: string };
+    assert.equal(done.id, "up1");
+    assert.equal(done.name, "notes.txt");
+    assert.ok(done.path.startsWith(stagingDir(sessionId)), `staged outside staging: ${done.path}`);
+    assert.equal(fs.readFileSync(done.path, "utf8"), body);
+
+    // The same connection refuses an over-cap declaration with a typed
+    // reply and stays healthy for a follow-up upload.
+    client.send({
+      type: "file_upload_begin",
+      id: "up2",
+      name: "huge.bin",
+      size: FILE_UPLOAD_MAX_BYTES + 1,
+    } as never);
+    const refused = (await client.type("file_upload_error")) as { id: string };
+    assert.equal(refused.id, "up2");
+
+    client.send({ type: "file_upload_begin", id: "up3", name: "second.txt", size: 2 } as never);
+    client.send({ type: "file_upload_chunk", id: "up3", data: b64("ok") } as never);
+    const done3 = (await client.type("file_upload_done")) as { id: string; path: string };
+    assert.equal(done3.id, "up3");
+    assert.equal(fs.readFileSync(done3.path, "utf8"), "ok");
+  } finally {
+    fs.rmSync(stagingDir(sessionId), { recursive: true, force: true });
+    client.close();
+  }
+});
+
+test("FD.1: overflow past the declared size dies with a typed error, file never staged", async () => {
+  const { client, sessionId } = await createSession(d.port);
+  try {
+    client.send({ type: "file_upload_begin", id: "ov", name: "small.txt", size: 3 } as never);
+    client.send({ type: "file_upload_chunk", id: "ov", data: b64("way too many bytes") } as never);
+    const err = (await client.type("file_upload_error")) as { id: string };
+    assert.equal(err.id, "ov");
+    const dir = stagingDir(sessionId);
+    const staged = fs.existsSync(dir) ? fs.readdirSync(dir) : [];
+    assert.deepEqual(staged, [], "nothing may be staged from a dead upload");
+  } finally {
+    fs.rmSync(stagingDir(sessionId), { recursive: true, force: true });
+    client.close();
+  }
+});

--- a/server/sessions/upload-handlers.test.ts
+++ b/server/sessions/upload-handlers.test.ts
@@ -1,0 +1,226 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WireMsg } from "../protocol";
+import type { SessionEntry } from "./registry";
+import {
+  FILE_UPLOAD_MAX_BYTES,
+  FILE_UPLOAD_MAX_CHUNK_BYTES,
+  FILE_UPLOAD_MAX_CONCURRENT,
+  collisionFreePath,
+  createUploadHandlers,
+  safeUploadName,
+  stagingDir,
+} from "./upload-handlers";
+
+const b64 = (s: string) => Buffer.from(s).toString("base64");
+
+// A throwaway session identity per test: staging lands under the real
+// os.tmpdir()/mirafold-uploads/<id>, so unique ids keep tests isolated and
+// deletable.
+let n = 0;
+function harness(over: { remote?: boolean; kind?: string; entry?: boolean } = {}) {
+  const sessionId = `uh-test-${process.pid}-${++n}`;
+  const sent: WireMsg[] = [];
+  const entry =
+    over.entry === false
+      ? null
+      : ({ id: sessionId, kind: over.kind ?? "api-key" } as unknown as SessionEntry);
+  const handlers = createUploadHandlers({
+    viewport: (m) => sent.push(m),
+    getEntry: () => entry,
+    remote: over.remote ?? false,
+  });
+  const cleanup = () => fs.rmSync(stagingDir(sessionId), { recursive: true, force: true });
+  return { handlers, sent, sessionId, cleanup };
+}
+
+test("a chunked upload stages the exact bytes and answers with the path", () => {
+  const { handlers, sent, sessionId, cleanup } = harness();
+  try {
+    handlers.begin({ type: "file_upload_begin", id: "u1", name: "notes.txt", size: 11 });
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("hello ") });
+    assert.equal(sent.length, 0, "mid-upload is silent");
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("world") });
+    assert.equal(sent.length, 1);
+    const done = sent[0];
+    assert.equal(done.type, "file_upload_done");
+    if (done.type !== "file_upload_done") return;
+    assert.equal(done.name, "notes.txt");
+    assert.ok(done.path.startsWith(stagingDir(sessionId)));
+    assert.equal(fs.readFileSync(done.path, "utf8"), "hello world");
+  } finally {
+    cleanup();
+  }
+});
+
+test("a zero-byte file is complete at begin", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    handlers.begin({ type: "file_upload_begin", id: "u0", name: "empty.txt", size: 0 });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_done");
+    if (sent[0].type === "file_upload_done") {
+      assert.equal(fs.readFileSync(sent[0].path, "utf8"), "");
+    }
+  } finally {
+    cleanup();
+  }
+});
+
+test("same-name drops get collision suffixes, not overwrites", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    for (const [id, body] of [
+      ["a1", "first"],
+      ["a2", "second"],
+    ] as const) {
+      handlers.begin({ type: "file_upload_begin", id, name: "dup.txt", size: body.length });
+      handlers.chunk({ type: "file_upload_chunk", id, data: b64(body) });
+    }
+    const paths = sent.map((m) => (m.type === "file_upload_done" ? m.path : ""));
+    assert.match(paths[0], /dup\.txt$/);
+    assert.match(paths[1], /dup-2\.txt$/);
+    assert.equal(fs.readFileSync(paths[0], "utf8"), "first");
+    assert.equal(fs.readFileSync(paths[1], "utf8"), "second");
+  } finally {
+    cleanup();
+  }
+});
+
+test("declared size over the cap refuses before any byte arrives", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    handlers.begin({
+      type: "file_upload_begin",
+      id: "big",
+      name: "big.bin",
+      size: FILE_UPLOAD_MAX_BYTES + 1,
+    });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_error");
+  } finally {
+    cleanup();
+  }
+});
+
+test("more bytes than declared kills the upload", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.txt", size: 3 });
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("toolong") });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_error");
+    // The dead id answers "unknown upload" rather than resurrecting.
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("x") });
+    assert.equal(sent[1].type, "file_upload_error");
+  } finally {
+    cleanup();
+  }
+});
+
+test("an oversized single chunk is refused even under the total cap", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    const size = FILE_UPLOAD_MAX_CHUNK_BYTES + 1;
+    handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.bin", size });
+    handlers.chunk({
+      type: "file_upload_chunk",
+      id: "u1",
+      data: Buffer.alloc(size).toString("base64"),
+    });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_error");
+  } finally {
+    cleanup();
+  }
+});
+
+test("a chunk with no begin answers unknown-upload, never hangs correlation", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    handlers.chunk({ type: "file_upload_chunk", id: "ghost", data: b64("x") });
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_error");
+  } finally {
+    cleanup();
+  }
+});
+
+test("concurrency past the cap refuses the extra upload only", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    for (let i = 0; i <= FILE_UPLOAD_MAX_CONCURRENT; i++) {
+      handlers.begin({ type: "file_upload_begin", id: `c${i}`, name: "f.txt", size: 5 });
+    }
+    assert.equal(sent.length, 1);
+    assert.equal(sent[0].type, "file_upload_error");
+    if (sent[0].type === "file_upload_error") assert.equal(sent[0].id, `c${FILE_UPLOAD_MAX_CONCURRENT}`);
+  } finally {
+    cleanup();
+  }
+});
+
+test("no attached session refuses; a remote subscription viewport is gated", () => {
+  const a = harness({ entry: false });
+  a.handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.txt", size: 1 });
+  assert.equal(a.sent[0]?.type, "file_upload_error");
+
+  const b = harness({ remote: true, kind: "subscription" });
+  b.handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.txt", size: 1 });
+  assert.equal(b.sent[0]?.type, "file_upload_error");
+  if (b.sent[0]?.type === "file_upload_error") assert.match(b.sent[0].message, /relay/);
+
+  // The same remote viewport on an api-key session uploads fine.
+  const c = harness({ remote: true, kind: "api-key" });
+  try {
+    c.handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.txt", size: 2 });
+    c.handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("ok") });
+    assert.equal(c.sent[0]?.type, "file_upload_done");
+  } finally {
+    c.cleanup();
+  }
+});
+
+test("abort discards a partial silently; a hostile id is dropped whole", () => {
+  const { handlers, sent, cleanup } = harness();
+  try {
+    handlers.begin({ type: "file_upload_begin", id: "u1", name: "n.txt", size: 10 });
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("part") });
+    handlers.abort({ type: "file_upload_abort", id: "u1" });
+    assert.equal(sent.length, 0);
+    // Post-abort chunks are unknown.
+    handlers.chunk({ type: "file_upload_chunk", id: "u1", data: b64("more") });
+    assert.equal(sent[0]?.type, "file_upload_error");
+    // Bad id grammar: dropped with no reply at all.
+    handlers.begin({ type: "file_upload_begin", id: "../evil", name: "n", size: 1 });
+    assert.equal(sent.length, 1);
+  } finally {
+    cleanup();
+  }
+});
+
+test("safeUploadName strips paths and control chars, never returns empty", () => {
+  assert.equal(safeUploadName("/etc/passwd"), "passwd");
+  assert.equal(safeUploadName("..\\..\\boot.ini"), "boot.ini");
+  assert.equal(safeUploadName("a\x00b\x1fc.txt"), "abc.txt");
+  assert.equal(safeUploadName(".."), "dropped-file");
+  assert.equal(safeUploadName("   "), "dropped-file");
+  assert.equal(safeUploadName(undefined), "dropped-file");
+  assert.equal(safeUploadName("x".repeat(300)).length, 120);
+});
+
+test("collisionFreePath suffixes before the extension", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "uh-collide-"));
+  try {
+    assert.equal(collisionFreePath(dir, "a.txt"), path.join(dir, "a.txt"));
+    fs.writeFileSync(path.join(dir, "a.txt"), "");
+    assert.equal(collisionFreePath(dir, "a.txt"), path.join(dir, "a-2.txt"));
+    fs.writeFileSync(path.join(dir, "a-2.txt"), "");
+    assert.equal(collisionFreePath(dir, "a.txt"), path.join(dir, "a-3.txt"));
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/server/sessions/upload-handlers.ts
+++ b/server/sessions/upload-handlers.ts
@@ -1,0 +1,233 @@
+// File drag-and-drop input (Phase FD) — the file_upload_begin/chunk/abort
+// message handlers, on the fs-handlers template: per-connection state,
+// handlers never throw (the local WS path has no try/catch above this, so
+// an escaped throw would exit the daemon), and every well-formed request
+// gets exactly one reply — errors ride a typed reply, never silence.
+//
+// A drop ships bytes because a browser never exposes a dropped file's real
+// filesystem path; the daemon stages them OUTSIDE the working tree (no
+// working-tree writes — that surface belongs to the user and the agent) and
+// answers with the staged absolute path for the prompt. Cleanup rides the
+// OS's tmp reaping — a recorded v1 decision, not an accident.
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ClientMsg, WireMsg } from "../protocol";
+import type { SessionEntry } from "./registry";
+import { allowedOverRelay } from "../provider-policy";
+import { envInt } from "../env";
+import { CLIENT_ID_RE } from "./fs-handlers";
+import { createLogger } from "../log";
+
+const log = createLogger("uploads");
+
+// Total-size ceiling per upload. Sized for the realistic drop (an image, a
+// PDF, a log) — big enough to be useful, small enough that the in-memory
+// accumulation below stays trivially bounded.
+export const FILE_UPLOAD_MAX_BYTES = envInt("FILE_UPLOAD_MAX_BYTES", 10_000_000);
+// A drop of several files uploads them in parallel; past this the client
+// queues. Bounds per-connection memory at CONCURRENT × MAX_BYTES.
+export const FILE_UPLOAD_MAX_CONCURRENT = envInt("FILE_UPLOAD_MAX_CONCURRENT", 2);
+// One decoded chunk's ceiling. The client sends smaller; the bound here is
+// what keeps a hostile client from smuggling MAX_BYTES in one frame (the
+// socket's own MAX_WS_PAYLOAD would kill the whole connection at ~1 MB —
+// this refuses the upload instead).
+export const FILE_UPLOAD_MAX_CHUNK_BYTES = envInt("FILE_UPLOAD_MAX_CHUNK_BYTES", 300_000);
+// An upload nothing feeds is abandoned (a navigated-away page never sends
+// abort) — reap it so its memory isn't held for the connection's life.
+export const FILE_UPLOAD_STALL_MS = envInt("FILE_UPLOAD_STALL_MS", 30_000);
+
+// Same wording as the prompt/cockpit relay gate (R.4i): an upload is model
+// input staging, so it follows the same rule.
+const UPLOAD_RELAY_REFUSAL =
+  "This session runs on a subscription login, which can't be used over the relay. " +
+  "Use an API key to drive an agent remotely.";
+
+/** Path-free, control-free, bounded display name; never empty. */
+export function safeUploadName(raw: unknown): string {
+  const base = typeof raw === "string" ? (raw.split(/[/\\]/).pop() ?? "") : "";
+  // eslint-disable-next-line no-control-regex
+  const cleaned = base.replace(/[\x00-\x1f\x7f]/g, "").trim();
+  if (!cleaned || cleaned === "." || cleaned === "..") return "dropped-file";
+  return cleaned.slice(0, 120);
+}
+
+/** name.ext → name-2.ext, name-3.ext … until the name is free in dir. */
+export function collisionFreePath(dir: string, name: string): string {
+  const ext = path.extname(name);
+  const stem = name.slice(0, name.length - ext.length);
+  let candidate = path.join(dir, name);
+  for (let n = 2; fs.existsSync(candidate); n++) {
+    candidate = path.join(dir, `${stem}-${n}${ext}`);
+  }
+  return candidate;
+}
+
+/** The per-session staging dir, created private on first use. */
+export function stagingDir(sessionId: string): string {
+  return path.join(os.tmpdir(), "mirafold-uploads", sessionId);
+}
+
+type ActiveUpload = {
+  name: string;
+  size: number;
+  received: number;
+  chunks: Buffer[];
+  stall: NodeJS.Timeout;
+};
+
+type UploadDeps = {
+  viewport: (msg: WireMsg) => void;
+  getEntry: () => SessionEntry | null;
+  remote: boolean;
+};
+
+export type UploadHandlers = {
+  begin(msg: ClientMsg & { type: "file_upload_begin" }): void;
+  chunk(msg: ClientMsg & { type: "file_upload_chunk" }): void;
+  abort(msg: ClientMsg & { type: "file_upload_abort" }): void;
+  /** Connection closed — drop partials, clear timers. */
+  dispose(): void;
+};
+
+export function createUploadHandlers({ viewport, getEntry, remote }: UploadDeps): UploadHandlers {
+  const active = new Map<string, ActiveUpload>();
+
+  const fail = (id: string, message: string) => {
+    const up = active.get(id);
+    if (up) {
+      clearTimeout(up.stall);
+      active.delete(id);
+    }
+    viewport({ type: "file_upload_error", id, message });
+  };
+
+  const armStall = (id: string, up: ActiveUpload) => {
+    clearTimeout(up.stall);
+    up.stall = setTimeout(() => fail(id, "upload stalled — dropped"), FILE_UPLOAD_STALL_MS);
+  };
+
+  // Completion path, shared by an ordinary final chunk and the zero-byte
+  // file (complete at begin): stage the bytes, answer with the path.
+  const complete = (id: string, up: ActiveUpload) => {
+    clearTimeout(up.stall);
+    active.delete(id);
+    const entry = getEntry();
+    if (!entry) {
+      viewport({ type: "file_upload_error", id, message: "no session attached" });
+      return;
+    }
+    try {
+      const dir = stagingDir(entry.id);
+      fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+      const dest = collisionFreePath(dir, up.name);
+      fs.writeFileSync(dest, Buffer.concat(up.chunks), { mode: 0o600 });
+      log.info(`staged upload ${up.name} (${up.size} bytes) → session ${entry.id}`);
+      viewport({ type: "file_upload_done", id, path: dest, name: up.name });
+    } catch (err) {
+      viewport({
+        type: "file_upload_error",
+        id,
+        message: `could not stage the file: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  };
+
+  return {
+    begin(msg) {
+      // A bad correlation id drops the message whole (nothing to answer) —
+      // the fs-handlers rule, same grammar.
+      if (typeof msg.id !== "string" || !CLIENT_ID_RE.test(msg.id)) return;
+      const entry = getEntry();
+      if (!entry) {
+        fail(msg.id, "no session attached");
+        return;
+      }
+      if (remote && !allowedOverRelay(entry.kind)) {
+        fail(msg.id, UPLOAD_RELAY_REFUSAL);
+        return;
+      }
+      if (active.has(msg.id)) {
+        fail(msg.id, "duplicate upload id");
+        return;
+      }
+      if (active.size >= FILE_UPLOAD_MAX_CONCURRENT) {
+        fail(msg.id, "too many uploads at once — retry when one finishes");
+        return;
+      }
+      if (typeof msg.size !== "number" || !Number.isInteger(msg.size) || msg.size < 0) {
+        fail(msg.id, "malformed upload size");
+        return;
+      }
+      if (msg.size > FILE_UPLOAD_MAX_BYTES) {
+        fail(
+          msg.id,
+          `file too large (${msg.size} bytes; the limit is ${FILE_UPLOAD_MAX_BYTES})`,
+        );
+        return;
+      }
+      const up: ActiveUpload = {
+        name: safeUploadName(msg.name),
+        size: msg.size,
+        received: 0,
+        chunks: [],
+        stall: setTimeout(() => {}, 0),
+      };
+      active.set(msg.id, up);
+      // The empty file is legal and complete at begin.
+      if (up.size === 0) complete(msg.id, up);
+      else armStall(msg.id, up);
+    },
+
+    chunk(msg) {
+      if (typeof msg.id !== "string" || !CLIENT_ID_RE.test(msg.id)) return;
+      const up = active.get(msg.id);
+      if (!up) {
+        // Answer, don't hang the client's correlation: a chunk with no
+        // begin (or after a failure) tells the sender its upload is dead.
+        viewport({ type: "file_upload_error", id: msg.id, message: "unknown upload" });
+        return;
+      }
+      if (typeof msg.data !== "string") {
+        fail(msg.id, "malformed chunk");
+        return;
+      }
+      let bytes: Buffer;
+      try {
+        bytes = Buffer.from(msg.data, "base64");
+      } catch {
+        fail(msg.id, "malformed chunk");
+        return;
+      }
+      if (bytes.length > FILE_UPLOAD_MAX_CHUNK_BYTES) {
+        fail(msg.id, "chunk too large");
+        return;
+      }
+      up.received += bytes.length;
+      if (up.received > up.size) {
+        fail(msg.id, "more bytes than declared — dropped");
+        return;
+      }
+      up.chunks.push(bytes);
+      if (up.received < up.size) {
+        armStall(msg.id, up);
+        return;
+      }
+      complete(msg.id, up);
+    },
+
+    abort(msg) {
+      if (typeof msg.id !== "string" || !CLIENT_ID_RE.test(msg.id)) return;
+      const up = active.get(msg.id);
+      if (!up) return; // an abort needs no reply — the client already moved on
+      clearTimeout(up.stall);
+      active.delete(msg.id);
+    },
+
+    dispose() {
+      for (const up of active.values()) clearTimeout(up.stall);
+      active.clear();
+    },
+  };
+}

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1,6 +1,6 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { type Browser, type Page } from "playwright-core";
@@ -1337,6 +1337,53 @@ test("NF: hidden viewport toasts a permission then the turn end; visibility clos
       `);
     },
   );
+});
+
+test("FD: a dropped file uploads, stages on disk, and its quoted path lands in the prompt", async () => {
+  const token = "e2e-filedrop-4a19";
+  await withFreshMockSession(token, async (page2) => {
+    // The drag listeners attach only once the session is attached
+    // (meta.sessionId) — a dispatch racing the mount fires into the void,
+    // so wait for the session UI first (diagnosed 2026-08-12 by probe).
+    await page2.waitForSelector(".prompt-box textarea");
+    // Synthesize a real file drag: DataTransfer + File are native in
+    // Chromium. A JS string, not a function — the keepNames __name trap
+    // (see the NF test above) breaks serialized closures.
+    await page2.evaluate(`
+      window.__DT__ = (() => {
+        const dt = new DataTransfer();
+        dt.items.add(new File(["drag and drop payload snowman"], "dropped notes.txt", { type: "text/plain" }));
+        return dt;
+      })();
+      document.body.dispatchEvent(new DragEvent("dragenter", { bubbles: true, cancelable: true, dataTransfer: window.__DT__ }));
+    `);
+    // Mid-drag, the shell-owned overlay invites the drop.
+    await page2.waitForSelector(".drop-overlay");
+    await page2.evaluate(`
+      document.body.dispatchEvent(new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer: window.__DT__ }));
+    `);
+    // The staged path lands in the prompt, quoted (the name carries a space).
+    await page2.waitForFunction(
+      () => {
+        const el = document.querySelector(".prompt-box textarea") as HTMLTextAreaElement | null;
+        return el?.value.includes("mirafold-uploads") ?? false;
+      },
+      undefined,
+      { timeout: 15_000 },
+    );
+    assert.equal(await page2.locator(".drop-overlay").count(), 0, "overlay clears on drop");
+    const value = await page2.locator(".prompt-box textarea").inputValue();
+    const m = value.match(/'([^']*mirafold-uploads[^']*)'/);
+    assert.ok(m, `expected a quoted staged path in the prompt, got: ${value}`);
+    const staged = m![1];
+    assert.match(staged, /dropped notes\.txt$/);
+    // The path is honest: the exact dropped bytes sit at it on disk.
+    assert.equal(readFileSync(staged, "utf8"), "drag and drop payload snowman");
+    // The attach announced politely (the screen-reader path).
+    const status = await page2.locator('[role="status"]').innerText();
+    assert.match(status, /Attached dropped notes\.txt/);
+    rmSync(path.dirname(staged), { recursive: true, force: true });
+  });
 });
 
 test("Esc on an open card is exclusive — it dismisses without interrupting the turn", async () => {

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -25,6 +25,8 @@ import { tildify } from "../tildify";
 import { agentLabel, connectHint } from "../agents-meta";
 import { paintTabStatus } from "../tab-status";
 import { createDomNotifier, folderTitle, notifyPrefEnabled, setNotifyPref } from "../notify";
+import { createFileDrop, quoteForPrompt, type UploadEntry } from "../file-drop";
+import type { WireMsg } from "@protocol";
 import { useEscapeKey } from "../use-escape";
 import { Announcer, turnResponse, useAnnouncer } from "./Announcer";
 import { PermBar, type PermAsk } from "./PermBar";
@@ -236,9 +238,35 @@ export function Shell() {
   // listener) for the page's life. Null where the API doesn't exist.
   const [notifier] = useState(createDomNotifier);
 
+  // ── File drag-and-drop (Phase FD) ───────────────────────────────────────
+  // Shell chrome end to end: the drop overlay, the upload strip, and the
+  // staged-path insertion are shell-owned; agent output can't reach any of
+  // them. The pure core lives in file-drop.ts; the ref indirection lets the
+  // once-created instance call the latest announce/draft closures.
+  const [uploads, setUploads] = useState<UploadEntry[]>([]);
+  const [dragActive, setDragActive] = useState(false);
+  const attachDroppedPath = useRef<(path: string, name: string) => void>(() => {});
+  const [fileDrop] = useState(() =>
+    createFileDrop({
+      uploadBegin: (name, size) => bus.uploadBegin(name, size),
+      uploadChunk: (id, data) => bus.uploadChunk(id, data),
+      uploadAbort: (id) => bus.uploadAbort(id),
+      onChange: setUploads,
+      onAttached: (path, name) => attachDroppedPath.current(path, name),
+    }),
+  );
+
   // Screen-reader announcements (A.1) — see Announcer.tsx for why the
   // transcript itself stays silent and these speak at turn boundaries.
   const { message: announcement, announce } = useAnnouncer();
+  // Phase FD: a staged path lands in the prompt through the draft merge —
+  // which never discards composed text — quoted the way a terminal drop
+  // quotes, with a polite announcement naming what happened.
+  attachDroppedPath.current = (path, name) => {
+    promptDraftId.current += 1;
+    setPromptDraft({ id: promptDraftId.current, text: quoteForPrompt(path) });
+    announce(`Attached ${name} — its path was added to the prompt.`);
+  };
   // The turn's prose, accumulated from text_delta so turn_end can announce
   // the response once, whole. A ref (not state): nothing renders from it, and
   // it must not re-run the subscription on every token.
@@ -250,6 +278,9 @@ export function Shell() {
   useEffect(
     () =>
       bus.subscribe((m) => {
+        // Upload replies are per-viewport correlation traffic, not session
+        // history — route them before the turn accounting ever sees them.
+        if (fileDrop.handle(m as WireMsg)) return;
         // Replayed history must repaint state but never re-fire live-only
         // side effects: on every reload/reconnect the full-buffer replay
         // re-spoke each historical turn to screen readers, ending with an
@@ -456,6 +487,49 @@ export function Shell() {
     ]);
   }, [notifier, connected, busy, asks, meta]);
 
+  // Phase FD: window-level drag targets — anywhere on the page is the drop
+  // zone (small targets punish drags), gated off onboarding (no session to
+  // stage into). Depth-counted because dragenter/dragleave fire per element
+  // crossed; only file drags participate (text selections drag too).
+  useEffect(() => {
+    if (!meta.sessionId) return;
+    let depth = 0;
+    const hasFiles = (e: DragEvent) =>
+      Array.from(e.dataTransfer?.types ?? []).includes("Files");
+    const enter = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depth += 1;
+      setDragActive(true);
+    };
+    const over = (e: DragEvent) => {
+      if (hasFiles(e)) e.preventDefault();
+    };
+    const leave = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      depth = Math.max(0, depth - 1);
+      if (depth === 0) setDragActive(false);
+    };
+    const drop = (e: DragEvent) => {
+      if (!hasFiles(e)) return;
+      e.preventDefault();
+      depth = 0;
+      setDragActive(false);
+      const files = Array.from(e.dataTransfer?.files ?? []);
+      if (files.length) fileDrop.start(files);
+    };
+    window.addEventListener("dragenter", enter);
+    window.addEventListener("dragover", over);
+    window.addEventListener("dragleave", leave);
+    window.addEventListener("drop", drop);
+    return () => {
+      window.removeEventListener("dragenter", enter);
+      window.removeEventListener("dragover", over);
+      window.removeEventListener("dragleave", leave);
+      window.removeEventListener("drop", drop);
+    };
+  }, [meta.sessionId, fileDrop]);
+
   const answer = (id: string, allow: boolean) => {
     bus.answerPermission(id, allow);
     setAsks((a) => a.filter((x) => x.id !== id));
@@ -586,6 +660,27 @@ export function Shell() {
                 onKill={() => bus.killBang(bang.my!.id)}
               />
             )}
+            {uploads.length > 0 && (
+              <div className="drop-strip">
+                {uploads.map((u) => (
+                  <span
+                    key={u.id}
+                    className={"drop-chip" + (u.status === "error" ? " is-error" : "")}
+                  >
+                    {u.status === "uploading" ? `⇪ ${u.name}…` : `${u.name}: ${u.message}`}
+                    {u.status === "error" && (
+                      <button
+                        className="drop-chip-dismiss"
+                        onClick={() => fileDrop.dismiss(u.id)}
+                        aria-label={`Dismiss the ${u.name} upload error`}
+                      >
+                        ✕
+                      </button>
+                    )}
+                  </span>
+                ))}
+              </div>
+            )}
             <PromptBox
               onSend={send}
               busy={busy}
@@ -622,6 +717,11 @@ export function Shell() {
             />
           </div>
         </div>
+        {dragActive && (
+          <div className="drop-overlay" aria-hidden="true">
+            <div className="drop-overlay-card">Drop files — their paths go to the prompt</div>
+          </div>
+        )}
         {settingsOpen && (
           <ThemePicker
             slots={slots}

--- a/web/src/file-drop.test.ts
+++ b/web/src/file-drop.test.ts
@@ -1,0 +1,151 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FILE_DROP_CHUNK_BYTES,
+  FILE_DROP_MAX_BYTES,
+  FILE_DROP_MAX_FILES,
+  createFileDrop,
+  quoteForPrompt,
+  toBase64,
+  type DroppedFile,
+  type UploadEntry,
+} from "./file-drop";
+
+const file = (name: string, body: Uint8Array | string): DroppedFile => {
+  const bytes = typeof body === "string" ? new TextEncoder().encode(body) : body;
+  return {
+    name,
+    size: bytes.length,
+    arrayBuffer: async () => {
+      const copy = new Uint8Array(bytes.length);
+      copy.set(bytes);
+      return copy.buffer;
+    },
+  };
+};
+
+function harness() {
+  const sent: { begin: [string, number][]; chunks: [string, string][]; aborts: string[] } = {
+    begin: [],
+    chunks: [],
+    aborts: [],
+  };
+  const attached: [string, string][] = [];
+  let states: UploadEntry[] = [];
+  let mint = 0;
+  const drop = createFileDrop({
+    uploadBegin: (name, size) => {
+      sent.begin.push([name, size]);
+      return `u${++mint}`;
+    },
+    uploadChunk: (id, data) => sent.chunks.push([id, data]),
+    uploadAbort: (id) => sent.aborts.push(id),
+    onChange: (u) => (states = u),
+    onAttached: (p, n) => attached.push([p, n]),
+  });
+  return { drop, sent, attached, states: () => states };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+test("toBase64 matches Buffer for sizes past the block boundary", () => {
+  for (const n of [0, 1, 0x8000 - 1, 0x8000, 0x8000 + 1, 200_000]) {
+    const bytes = new Uint8Array(n).map((_, i) => i % 251);
+    assert.equal(toBase64(bytes), Buffer.from(bytes).toString("base64"), `n=${n}`);
+  }
+});
+
+test("quoteForPrompt quotes only when needed, escaping embedded quotes", () => {
+  assert.equal(quoteForPrompt("/tmp/plain.txt"), "/tmp/plain.txt");
+  assert.equal(quoteForPrompt("/tmp/my file.txt"), "'/tmp/my file.txt'");
+  assert.equal(quoteForPrompt("/tmp/it's.txt"), "'/tmp/it'\\''s.txt'");
+  assert.equal(quoteForPrompt("/tmp/$HOME.txt"), "'/tmp/$HOME.txt'");
+});
+
+test("a dropped file begins, chunks in bounded slices, and attaches on the reply", async () => {
+  const { drop, sent, attached, states } = harness();
+  const body = new Uint8Array(FILE_DROP_CHUNK_BYTES + 5).fill(7);
+  drop.start([file("data.bin", body)]);
+  await flush();
+  assert.deepEqual(sent.begin, [["data.bin", body.length]]);
+  assert.equal(sent.chunks.length, 2, "one full slice + the remainder");
+  assert.equal(states()[0]?.status, "uploading");
+
+  const consumed = drop.handle({
+    type: "file_upload_done",
+    id: "u1",
+    path: "/tmp/mirafold-uploads/s/data.bin",
+    name: "data.bin",
+  });
+  assert.equal(consumed, true);
+  assert.deepEqual(attached, [["/tmp/mirafold-uploads/s/data.bin", "data.bin"]]);
+  assert.equal(states().length, 0, "the chip clears on done");
+});
+
+test("a zero-byte file sends begin and no chunks", async () => {
+  const { drop, sent } = harness();
+  drop.start([file("empty.txt", "")]);
+  await flush();
+  assert.deepEqual(sent.begin, [["empty.txt", 0]]);
+  assert.equal(sent.chunks.length, 0);
+});
+
+test("an oversize file is refused locally — bytes never read, nothing sent", () => {
+  const { drop, sent, states } = harness();
+  drop.start([
+    { name: "huge.iso", size: FILE_DROP_MAX_BYTES + 1, arrayBuffer: async () => {
+      throw new Error("must not be read");
+    } },
+  ]);
+  assert.equal(sent.begin.length, 0);
+  assert.equal(states()[0]?.status, "error");
+  assert.match(states()[0]?.message ?? "", /too large/);
+});
+
+test("a drop past the file cap takes the first N and says so", async () => {
+  const { drop, sent, states } = harness();
+  drop.start(Array.from({ length: FILE_DROP_MAX_FILES + 3 }, (_, i) => file(`f${i}.txt`, "x")));
+  await flush();
+  assert.equal(sent.begin.length, FILE_DROP_MAX_FILES);
+  const overflow = states().find((u) => u.status === "error");
+  assert.match(overflow?.message ?? "", /first 8/);
+});
+
+test("a server error marks the chip; dismiss clears it", async () => {
+  const { drop, states } = harness();
+  drop.start([file("n.txt", "hello")]);
+  await flush();
+  drop.handle({ type: "file_upload_error", id: "u1", message: "file too large" });
+  assert.equal(states()[0]?.status, "error");
+  assert.equal(states()[0]?.message, "file too large");
+  drop.dismiss(states()[0].id);
+  assert.equal(states().length, 0);
+});
+
+test("a read failure aborts the upload and reports locally", async () => {
+  const { drop, sent, states } = harness();
+  drop.start([
+    { name: "gone.txt", size: 5, arrayBuffer: async () => {
+      throw new Error("NotReadableError");
+    } },
+  ]);
+  await flush();
+  assert.deepEqual(sent.aborts, ["u1"]);
+  assert.equal(states()[0]?.status, "error");
+  assert.match(states()[0]?.message ?? "", /could not read/);
+});
+
+test("a size that changed between drop and read aborts instead of desyncing", async () => {
+  const { drop, sent } = harness();
+  drop.start([
+    { name: "shrunk.txt", size: 10, arrayBuffer: async () => new ArrayBuffer(4) },
+  ]);
+  await flush();
+  assert.deepEqual(sent.aborts, ["u1"]);
+  assert.equal(sent.chunks.length, 0);
+});
+
+test("unrelated messages are not consumed", () => {
+  const { drop } = harness();
+  assert.equal(drop.handle({ type: "pong" }), false);
+});

--- a/web/src/file-drop.ts
+++ b/web/src/file-drop.ts
@@ -1,0 +1,146 @@
+// File drag-and-drop input (Phase FD), client half. A browser drop hands
+// over a file's NAME and BYTES — never its real path — so the shell streams
+// the bytes to the daemon in bounded base64 chunks and, on the staged-path
+// reply, hands the path to the prompt. Pure state + chunk math live here so
+// Tier-1 can prove them without a DOM; Shell owns the listeners, the
+// overlay, and the strip.
+import type { WireMsg } from "@protocol";
+
+export const FILE_DROP_MAX_FILES = 8;
+// Decoded bytes per chunk: base64 inflates ×4/3, so the frame rides ~256 KB —
+// under the daemon's per-chunk bound (300 KB decoded) AND well under the
+// socket's MAX_WS_PAYLOAD (1 MB), which would kill the whole connection.
+export const FILE_DROP_CHUNK_BYTES = 192_000;
+// Mirror of the daemon's FILE_UPLOAD_MAX_BYTES default, for instant local
+// refusal with the bytes never read. The daemon's cap stays authoritative —
+// a daemon running a raised env limit just means this refuses earlier than
+// it strictly must (accepted: the mirror is a courtesy, not the gate).
+export const FILE_DROP_MAX_BYTES = 10_000_000;
+
+export type UploadEntry = {
+  id: string;
+  name: string;
+  status: "uploading" | "error";
+  message?: string;
+};
+
+/** The slice of a DOM File the core needs — injectable for Tier-1. */
+export type DroppedFile = {
+  name: string;
+  size: number;
+  arrayBuffer(): Promise<ArrayBuffer>;
+};
+
+type FileDropDeps = {
+  uploadBegin(name: string, size: number): string;
+  uploadChunk(id: string, data: string): void;
+  uploadAbort(id: string): void;
+  /** The strip's render input — called with a fresh array on every change. */
+  onChange(uploads: UploadEntry[]): void;
+  /** A staged path is ready for the prompt. */
+  onAttached(path: string, name: string): void;
+};
+
+export type FileDrop = {
+  start(files: DroppedFile[]): void;
+  /** Routes upload replies; true = consumed. */
+  handle(msg: WireMsg): boolean;
+  dismiss(id: string): void;
+};
+
+/** btoa needs a "binary string"; build it in bounded blocks — a spread of a
+ *  multi-MB array would blow the call stack. */
+export function toBase64(bytes: Uint8Array): string {
+  let bin = "";
+  for (let at = 0; at < bytes.length; at += 0x8000) {
+    bin += String.fromCharCode(...bytes.subarray(at, at + 0x8000));
+  }
+  return btoa(bin);
+}
+
+/** Path → prompt token, the terminal drop's shape: quoted only when it
+ *  needs it, single-quote-escaped the POSIX way. */
+export function quoteForPrompt(p: string): string {
+  return /[\s'"\\$`]/.test(p) ? `'${p.replaceAll("'", `'\\''`)}'` : p;
+}
+
+export function createFileDrop(deps: FileDropDeps): FileDrop {
+  const uploads: UploadEntry[] = [];
+  let localId = 0;
+  const emit = () => deps.onChange([...uploads]);
+  const remove = (id: string) => {
+    const at = uploads.findIndex((u) => u.id === id);
+    if (at >= 0) uploads.splice(at, 1);
+  };
+  const failLocal = (name: string, message: string) => {
+    uploads.push({ id: `local-${++localId}`, name, status: "error", message });
+  };
+
+  const uploadOne = async (f: DroppedFile) => {
+    const id = deps.uploadBegin(f.name, f.size);
+    uploads.push({ id, name: f.name, status: "uploading" });
+    emit();
+    try {
+      const bytes = new Uint8Array(await f.arrayBuffer());
+      // A file that changed size between drop and read would desync the
+      // declared total — the daemon refuses overflow, and a short read just
+      // stalls out server-side; abort the honest way instead.
+      if (bytes.length !== f.size) throw new Error("file changed while reading");
+      for (let at = 0; at < bytes.length; at += FILE_DROP_CHUNK_BYTES) {
+        deps.uploadChunk(id, toBase64(bytes.subarray(at, at + FILE_DROP_CHUNK_BYTES)));
+      }
+      // Zero-byte file: complete at begin — the reply is already on its way.
+    } catch {
+      deps.uploadAbort(id);
+      remove(id);
+      failLocal(f.name, "could not read the dropped file");
+      emit();
+    }
+  };
+
+  return {
+    start(files) {
+      for (const f of files.slice(0, FILE_DROP_MAX_FILES)) {
+        if (f.size > FILE_DROP_MAX_BYTES) {
+          failLocal(f.name, `too large (limit ${Math.floor(FILE_DROP_MAX_BYTES / 1_000_000)} MB)`);
+          continue;
+        }
+        void uploadOne(f);
+      }
+      if (files.length > FILE_DROP_MAX_FILES) {
+        failLocal(
+          `${files.length - FILE_DROP_MAX_FILES} more file(s)`,
+          `only the first ${FILE_DROP_MAX_FILES} of a drop are taken`,
+        );
+      }
+      emit();
+    },
+
+    handle(msg) {
+      if (msg.type === "file_upload_done") {
+        remove(msg.id);
+        emit();
+        deps.onAttached(msg.path, msg.name);
+        return true;
+      }
+      if (msg.type === "file_upload_error") {
+        const u = uploads.find((x) => x.id === msg.id);
+        if (u) {
+          u.status = "error";
+          u.message = msg.message;
+        } else {
+          // An error for an upload we no longer track (an abort's crossing
+          // reply) still belongs to this feature — consume it silently.
+        }
+        emit();
+        return true;
+      }
+      return false;
+    },
+
+    dismiss(id) {
+      remove(id);
+      emit();
+    },
+  };
+}

--- a/web/src/session-bus.ts
+++ b/web/src/session-bus.ts
@@ -46,6 +46,11 @@ export interface SessionBus {
   requestFsChanges(): string;
   requestFsRead(path: string): string;
   requestFsDiff(path: string): string;
+  /** Phase FD: stream a dropped file's bytes to the daemon's staging dir.
+   *  Mints and returns the correlation id; the done/error reply echoes it. */
+  uploadBegin(name: string, size: number): string;
+  uploadChunk(id: string, data: string): void;
+  uploadAbort(id: string): void;
 }
 
 export function createSessionBus(): SessionBus {
@@ -174,6 +179,18 @@ export function createSessionBus(): SessionBus {
       const id = `fsd-${Math.random().toString(36).slice(2, 10)}`;
       socket.send({ type: "fs_diff", id, path });
       return id;
+    },
+    // Phase FD — the sendBang mint shape; per-viewport correlation only.
+    uploadBegin(name: string, size: number): string {
+      const id = `up-${Math.random().toString(36).slice(2, 10)}`;
+      socket.send({ type: "file_upload_begin", id, name, size });
+      return id;
+    },
+    uploadChunk(id: string, data: string) {
+      socket.send({ type: "file_upload_chunk", id, data });
+    },
+    uploadAbort(id: string) {
+      socket.send({ type: "file_upload_abort", id });
     },
   };
 }

--- a/web/src/styles/10-prompt.css
+++ b/web/src/styles/10-prompt.css
@@ -457,3 +457,65 @@
   border-left: 1px solid var(--border-faint);
 }
 
+
+/* ---- File drag-and-drop (Phase FD) --------------------------------------
+   Shell-owned drop affordances: a full-window overlay while a file drag is
+   over the page, and a compact upload strip above the prompt box. */
+
+.drop-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--overlay);
+  /* The overlay must never steal the drop from the window handlers. */
+  pointer-events: none;
+}
+
+.drop-overlay-card {
+  padding: 14px 22px;
+  background: var(--surface);
+  border: 1px dashed var(--accent);
+  border-radius: 10px;
+  color: var(--fg-strong);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 14px;
+}
+
+.drop-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  padding: 4px 2px;
+}
+
+.drop-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border: 1px solid var(--border-mid);
+  border-radius: 6px;
+  background: var(--surface-2);
+  color: var(--fg-dim);
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.drop-chip.is-error {
+  border-color: var(--warn-border, var(--border-mid));
+  color: var(--warn-fg);
+}
+
+.drop-chip-dismiss {
+  background: transparent;
+  border: 0;
+  padding: 0 2px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}


### PR DESCRIPTION
## What

Drag a file onto a session and its path appears in the prompt — the terminal-drop experience, rebuilt for the browser.

In a terminal, dropping a file inserts its shell-quoted *path*; the agent reads the path itself. A browser never exposes a dropped file's real path, so the faithful equivalent is: the shell catches the drop (window-level, shell-owned overlay + upload strip), streams the **bytes** over the existing WebSocket in bounded base64 chunks, the daemon stages them in a per-session directory under the OS temp dir — **never the working tree** — and the staged absolute path lands in the prompt, quoted the way a terminal quotes it.

- **Zero adapter changes.** The agent reads the staged path with its own tools, so Claude Code, Codex, and Gemini CLI all get the feature at once — and the same mechanism works from a phone through the relay, which a terminal can't do at all.
- **Bounded and gated**: `FILE_UPLOAD_MAX_BYTES` (10 MB, env), 2 concurrent per connection, per-chunk bound under `MAX_WS_PAYLOAD`, a 30s stall reaper, sanitized collision-suffixed basenames, and the prompt's relay gate (an upload is model-input staging).
- **Additive wire only**: `file_upload_begin/chunk/abort` → `file_upload_done/error`, correlated per-viewport, never broadcast, never replay-buffered, with protocol-freeze fixtures.

## Verification

- Tier-1 717/717 (12 new handler tests — the full refusal matrix — and 10 client-core tests).
- Tier-2 152/152 (2 new real-socket itests: byte-exact staging at the replied path; typed refusals with the connection staying healthy).
- Tier-3 97/97 (new e2e: synthesized `DataTransfer` drop → overlay → quoted staged path in the textarea → exact dropped bytes on disk → polite announcement).
- `yarn typecheck` clean.

Recorded v1 decision: staging cleanup rides the OS's tmp reaping; per-session delete-on-end can come later. Clipboard paste stays parked in POST-RELEASE.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)