### PR TITLE
Paintings polish batch: audit fixes, theme-following diagrams, adoption logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,9 @@ Where things live: **README.md** — architecture, the two load-bearing
 contracts, conventions. **PLAN.md** — work steps in order, one per prompt;
 don't start a step until the previous "Done when" is satisfied; check steps
 off with a dated status note. **BUSINESS.md** — why and in what sequence
-(milestone gates).
+(milestone gates). **GLOSSARY.md** — the decided product vocabulary (paintings
+vs. decks, the surfaces, prompt box, …); use its terms in docs, copy, and
+conversation — the "(was)" column exists to recognize old terms, not reuse them.
 
 ## Environment
 

--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -1,0 +1,90 @@
+# Mirafold glossary — the shared vocabulary
+
+*Status:* decided. One word per thing, so we can talk about Mirafold
+precisely. The "(was)" column is transition history — the old term, for anyone
+who knew it.
+
+*Context for a fresh reader:* Mirafold is a faithful browser re-skin of
+terminal coding agents (Claude Code, Codex, Gemini CLI), with generative UI
+layered on top. This file names its parts.
+
+*Naming register:* plain, terminal-native compounds — mostly two words
+(folder tree, diff panel, prompt box, run surface), understated, no marketing
+gloss. A good one-word name is welcome when it earns its place (*shell,
+paintings, decks*).
+
+---
+
+## The core distinction: paintings vs. decks
+
+The most important pair, because it is the trusted-shell boundary
+(agent-owned vs. shell-owned) said out loud:
+
+- *Painting* — something the *agent* authored, via the render tools (a
+  chart, a table, a diff view). Agent content. Lives in the output zone,
+  pinnable.
+- *Deck* — something the *shell* paints: its own live chrome (a run deck, a
+  preview deck, a subagent deck). Not agent content — Mirafold's instruments.
+
+If the agent made it, it's a painting. If the shell made it, it's a deck. Never
+blur the two — that blur is exactly what the security model exists to prevent.
+
+---
+
+## The shell and what's in it
+
+| Term | What it is | (was) |
+|---|---|---|
+| *shell* | the whole product / app | — |
+| *output zone* | the main scroll where the agent's replies and paintings appear | — |
+| *painting* | an agent-authored generative-UI component | "widget" |
+| *deck* | a shell-owned live pane (run deck, preview deck, subagent deck) | "card" |
+| *prompt box* | the input box you type into | "input box" |
+| *pin dock* | where you pin live paintings to keep them in view | — |
+| *status bar* | the strip showing agent → model, session status, usage | — |
+| *permission bar* | the allow / deny prompt when the agent asks to act | PermBar |
+| *notice line* | the dim line where the shell speaks; engine words are badged to their source | notice |
+| *bang line* | inline ! shell commands run from the prompt box | — |
+
+---
+
+## The surfaces (the big views you switch to)
+
+Collectively the *surfaces*. The varied suffixes (*tree / panel / view /
+surface*) are deliberate — each suits the shape of its thing.
+
+| Term | What it is | (was) |
+|---|---|---|
+| *folder tree* | the file browser surface | "Explorer" |
+| *diff panel* | the change-review surface | "Changes" |
+| *fleet view* | mission control — every live session at a glance | "fleet" |
+| *run surface* | shows the real output of what the agent runs — tests, builds, running servers, web preview | (new) |
+
+### Inside the run surface
+
+| Term | What it is | Note |
+|---|---|---|
+| *run deck* | one live deck in the run surface — a test run, a build, a running server | a deck |
+| *preview* | the web-rendered member — a run deck that shows the actual page | labeled "Preview"; still a deck |
+
+---
+
+## Sessions & connectivity
+
+| Term | What it is | Note |
+|---|---|---|
+| *session* | one running agent instance | |
+| *viewport* | a screen attached to a session (your laptop, your phone) | matters for later multi-user work |
+| *relay* | the blind WebSocket forwarder that carries remote viewports | serves no HTML/JS, ever |
+| *daemon* | the local process on the user's machine that runs the agent | internal term |
+| *agent picker* | the first screen: choose an agent and a folder | (was: onboarding) |
+| *backend picker* | the second step: choose which backend (local model / endpoint) | |
+| *connect device* | pairing a phone or second device to the daemon via the relay | |
+| *adapter* | the per-agent driver behind the AgentSession seam | internal term |
+
+---
+
+## The one rule to hold
+
+*Paintings are the agent's. Decks are the shell's.* Everything else is just
+labels; that one is load-bearing.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2600,6 +2600,68 @@ text.
   the staged file's exact bytes on disk, and axe stays clean; all three
   tiers green.
 
+## Paintings polish batch (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
+
+**Origin.** A paintings audit (this session) asked three questions: are the
+existing paintings at the delightful bar, does the agent actually reach for
+them, and are there coverage gaps. Verdict: the registry is strong (fallback
+architecture, CVD-safe charts, never-color-alone) with a short list of
+concrete defects; adoption is UNMEASURABLE (no instrumentation anywhere);
+coverage needs nothing new now (the 2026-07-10 survey already filled the real
+gaps, POST-RELEASE.md's 2026-08-02 growth analysis still governs). So: polish
+first, measurement second, new paintings demand-gated.
+
+- [x] **Fix batch** — completed 2026-08-13, all three tiers green
+  (724/152/97):
+  - `.rc` gains `overflow-wrap: anywhere` — an unbroken token (URL, SHA,
+    long path) in any painting's prose no longer pushes the transcript
+    sideways; inert on the monospace bodies (`white-space: pre` has no wrap
+    points), so code/console/diff keep their horizontal scroll.
+  - Chart: line charts fit the y domain to the DATA (`chartDomain`) — a
+    200–210 ms latency trend is no longer a flat stripe under a forced zero
+    baseline (bars still anchor to zero: a bar's length IS its value);
+    ≤2-point line charts draw always-on dots (a 1-point polyline painted
+    nothing); the forced last x label suppresses a stride label it would
+    collide with (`showXLabel`); grouped bars can no longer bleed past
+    their band at high category×series counts (`groupedBarLayout`). All
+    four pure + Tier-1-pinned.
+  - Table: every row renders exactly `columns.length` cells (surplus
+    truncated, missing padded — misaligned rows used to escape the header
+    silently); number cells right-align with `tabular-nums`
+    (`.rc-table-num`); empty `rows` shows a muted "no rows" instead of a
+    bare header. Tier-1-pinned (`Table.test.ts`, new).
+  - Code + Console bodies: vertical clamp (`max-height: 360px`, scroll) —
+    the diff body's existing treatment; a dumped whole file / 200k-char log
+    scrolls in its panel instead of consuming the transcript.
+  - **Diagram follows the app theme now (decision).** Pinned-dark is the
+    CODE-surface convention (`--code-bg` + ANSI/hljs palettes, manifest
+    PINNED_TOKENS); a diagram is a picture, not a code surface, and on the
+    light themes it rendered as a jarring dark slab. The frame body is
+    transparent (the panel surface is the canvas), mermaid re-initializes
+    per message with the shell-computed dark flag + `--surface` color, and
+    a `data-theme` MutationObserver re-posts on theme switch so baked-in
+    SVG colors follow. Sandbox posture unchanged (strict, no-network CSP,
+    postMessage-only source) — Tier-1 pins the transparent body +
+    per-message init.
+- [x] **Paintings-adoption instrumentation** — completed 2026-08-13: one
+  LOCAL log line per paint (`paint <component> agent=<agent>`) at
+  `registry.deliver()`, the choke point every adapter's stream crosses.
+  Local daemon log only, nothing leaves the machine; cheap enough to keep,
+  one `if` to delete if treated as temporary. Purpose: make "does this
+  engine actually reach for the render tools" answerable from logs — the
+  audit found the Codex/Gemini guidance asymmetry (one-shot first-turn
+  prepend vs. Claude's every-request system-prompt append) impossible to
+  evaluate without it.
+- Audit findings deliberately NOT fixed here (recorded, not lost): the two
+  hand-kept `TOOL_DESCRIPTIONS` maps (render-tools.ts / render-mcp.ts) have
+  drifted in wording with no guard test; no test pins Claude's
+  `mcpServers`/`systemPrompt.append` registration; the stdio
+  `emit_artifact` description omits the `mirafold.prompt/tool` sandbox API
+  that the in-process description documents (Codex/Gemini can't author
+  interactive artifacts); registry CSS half-lives in `08-picker.css`
+  (housekeeping); HBar tooltip parks at `left: 40%`. Each is a candidate
+  for a follow-up surfacing-parity step.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -577,6 +577,16 @@ export class SessionRegistry {
     if (msg.type === "error") {
       createLogger(`session ${entry.id}`).error(msg.message);
     }
+    // Paintings-adoption instrumentation (2026-08-13 audit): one LOCAL log
+    // line per generative-UI paint, from the choke point every adapter's
+    // stream crosses — so "does this engine actually reach for the render
+    // tools" is answerable from the daemon log instead of guessed. Local
+    // only; nothing leaves the machine.
+    if (msg.type === "render" || msg.type === "artifact") {
+      createLogger(`session ${entry.id}`).info(
+        `paint ${msg.type === "render" ? msg.component : "artifact"} agent=${entry.agent}`,
+      );
+    }
     // MIRAFOLD_DEBUG=1 traces every normalized event on the session
     // stream (bang_input never crosses broadcast, so no secret can land
     // here). One line per WireMsg, payload truncated (R.4g).

--- a/web/src/registry/Chart.test.ts
+++ b/web/src/registry/Chart.test.ts
@@ -1,6 +1,59 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { niceTicks, fmt, pieSlices, arcPath, stackSegments } from "./Chart";
+import {
+  niceTicks,
+  fmt,
+  pieSlices,
+  arcPath,
+  stackSegments,
+  chartDomain,
+  showXLabel,
+  groupedBarLayout,
+} from "./Chart";
+
+test("chartDomain: bars anchor to zero, lines fit the data", () => {
+  // A latency band far from zero: the bar domain must include the honest
+  // baseline; the line domain must NOT flatten the trend against it.
+  assert.deepEqual(chartDomain([200, 210, 205], true), [0, 210]);
+  assert.deepEqual(chartDomain([200, 210, 205], false), [200, 210]);
+  // Negatives anchor symmetrically for bars, fit for lines.
+  assert.deepEqual(chartDomain([-5, -2], true), [-5, 0]);
+  assert.deepEqual(chartDomain([-5, -2], false), [-5, -2]);
+  // No finite values at all: a degenerate but usable domain, never ±Infinity.
+  assert.deepEqual(chartDomain([], false), [0, 0]);
+});
+
+test("showXLabel: the forced last label suppresses a stride label it would collide with", () => {
+  // 17 labels, stride 3: index 15 is a stride hit one band from the forced
+  // 16 — the old `i % stride === 0` clause drew both, overlapping.
+  assert.equal(showXLabel(16, 17, 3), true);
+  assert.equal(showXLabel(15, 17, 3), false);
+  assert.equal(showXLabel(12, 17, 3), true); // a full stride short — keeps
+  // Stride 1 (≤8 categories): every label still draws.
+  for (let i = 0; i < 5; i++) assert.equal(showXLabel(i, 5, 1), true, `i=${i}`);
+});
+
+test("groupedBarLayout: bars plus gaps never exceed the group band", () => {
+  // The old Math.max(2, …) floor with a fixed 2px gap overflowed: 6 series
+  // needed ≥22 units while a 40-category band offers ~11.5 of group width.
+  for (const [band, n] of [
+    [16, 6],
+    [8, 4],
+    [80, 6],
+    [640, 1],
+  ] as const) {
+    const { groupW, barW, gap } = groupedBarLayout(band, n);
+    assert.ok(barW > 0);
+    assert.ok(
+      n * barW + (n - 1) * gap <= groupW + 1e-9,
+      `band=${band} n=${n}: group overflows its band`,
+    );
+  }
+  // Roomy case keeps the classic look: 2px gaps, bars well above the floor.
+  const roomy = groupedBarLayout(200, 3);
+  assert.equal(roomy.gap, 2);
+  assert.ok(roomy.barW > 40);
+});
 
 test("niceTicks spans the range and the top tick clears the data max", () => {
   // 2026-08-11 test-audit: exact output is deterministic and knowable, so pin

--- a/web/src/registry/Chart.tsx
+++ b/web/src/registry/Chart.tsx
@@ -107,6 +107,39 @@ export function arcPath(
   );
 }
 
+/** Y domain over the DRAWN values. Bars anchor to zero — a bar's length IS
+ *  its value, so a cropped baseline would lie. Lines fit the data instead: a
+ *  latency series of 200–210 ms anchored to zero renders as a flat stripe at
+ *  the top of the plot, hiding the trend the chart exists to show. Pure, for
+ *  Tier-1. */
+export function chartDomain(values: number[], zeroAnchor: boolean): [number, number] {
+  if (values.length === 0) return [0, 0];
+  return zeroAnchor
+    ? [Math.min(0, ...values), Math.max(0, ...values)]
+    : [Math.min(...values), Math.max(...values)];
+}
+
+/** Which thinned x labels draw: every `stride`-th plus the forced last — but
+ *  a stride label lands only when it sits a full stride short of the last, so
+ *  the two never collide in adjacent bands. Pure, for Tier-1. */
+export function showXLabel(i: number, len: number, stride: number): boolean {
+  if (i === len - 1) return true;
+  return i % stride === 0 && len - 1 - i >= stride;
+}
+
+/** Grouped-bar geometry: bars plus gaps always fit the group's 72% band, so
+ *  a crowded chart thins its bars instead of bleeding into the neighboring
+ *  category (the old 2px bar floor with a fixed 2px gap overflowed the band
+ *  at high category×series counts). Pure, for Tier-1. */
+export function groupedBarLayout(
+  band: number,
+  seriesCount: number,
+): { groupW: number; barW: number; gap: number } {
+  const groupW = band * 0.72;
+  const gap = seriesCount > 1 ? Math.min(2, groupW / (4 * seriesCount)) : 0;
+  return { groupW, barW: Math.max(0.5, (groupW - gap * (seriesCount - 1)) / seriesCount), gap };
+}
+
 export type StackSeg = { si: number; v: number; lo: number; hi: number };
 
 /** Per-x cumulative spans for stacked bars, in series (palette-slot) order.
@@ -270,7 +303,8 @@ function HBarChart({ title, x, series, yLabel, stacked }: ComponentProps<"chart"
   const values = cols
     ? cols.flatMap((col) => (col.length ? [col[col.length - 1].hi] : []))
     : series.flatMap((s) => s.values.slice(0, x.length)).filter(Number.isFinite);
-  const tks = niceTicks(Math.min(0, ...values), Math.max(0, ...values));
+  const [dLo, dHi] = chartDomain(values, true);
+  const tks = niceTicks(dLo, dHi);
   const vMin = tks[0];
   const vMax = tks[tks.length - 1] === vMin ? vMin + 1 : tks[tks.length - 1];
 
@@ -422,8 +456,7 @@ function VChart({ title, kind, x, series, yLabel, stacked }: ComponentProps<"cha
   const values = cols
     ? cols.flatMap((col) => (col.length ? [col[col.length - 1].hi] : []))
     : series.flatMap((s) => s.values.slice(0, x.length)).filter(Number.isFinite);
-  const dataMin = Math.min(0, ...values);
-  const dataMax = Math.max(0, ...values);
+  const [dataMin, dataMax] = chartDomain(values, kind !== "line");
   const tks = niceTicks(dataMin, dataMax);
   const yMin = tks[0];
   const yMax = tks[tks.length - 1] === yMin ? yMin + 1 : tks[tks.length - 1];
@@ -459,8 +492,7 @@ function VChart({ title, kind, x, series, yLabel, stacked }: ComponentProps<"cha
       : [];
 
   const band = iw / x.length;
-  const groupW = band * 0.72;
-  const barW = Math.max(2, (groupW - 2 * (series.length - 1)) / series.length);
+  const { groupW, barW, gap: barGap } = groupedBarLayout(band, series.length);
 
   return (
     <div className="rc rc-chart">
@@ -484,7 +516,7 @@ function VChart({ title, kind, x, series, yLabel, stacked }: ComponentProps<"cha
           )}
           {/* x labels, thinned */}
           {x.map((label, i) =>
-            i % labelStride === 0 || i === x.length - 1 ? (
+            showXLabel(i, x.length, labelStride) ? (
               <text key={i} x={xPos(i)} y={H - 8} textAnchor="middle" fontSize="10.5" style={INK_MUTED}>
                 {elide(label, 12)}
               </text>
@@ -499,7 +531,7 @@ function VChart({ title, kind, x, series, yLabel, stacked }: ComponentProps<"cha
                   <path
                     key={`${si}-${i}`}
                     d={barPath(
-                      PAD.left + i * band + (band - groupW) / 2 + si * (barW + 2),
+                      PAD.left + i * band + (band - groupW) / 2 + si * (barW + barGap),
                       yPos(v),
                       barW,
                       yPos(Math.max(yMin, Math.min(0, yMax))),
@@ -566,6 +598,24 @@ function VChart({ title, kind, x, series, yLabel, stacked }: ComponentProps<"cha
                   strokeLinecap="round"
                 />
               ))}
+              {/* ≤2 points: a polyline is invisible (one point) or a bare
+                  segment — always-on dots make the data visible pre-hover */}
+              {x.length <= 2 &&
+                series.map((s, si) =>
+                  s.values.slice(0, x.length).map((v, i) =>
+                    Number.isFinite(v) ? (
+                      <circle
+                        key={`${si}-${i}`}
+                        cx={xPos(i)}
+                        cy={yPos(v)}
+                        r="3.5"
+                        fill={seriesColor(si)}
+                        style={SURFACE}
+                        strokeWidth="2"
+                      />
+                    ) : null,
+                  ),
+                )}
               {/* hover markers: ≥8px, ringed with the surface color */}
               {hover !== null &&
                 series.map((s, si) =>

--- a/web/src/registry/Diagram.test.ts
+++ b/web/src/registry/Diagram.test.ts
@@ -15,6 +15,17 @@ test("diagramDoc: the frame document carries the runtime and nonce — never age
   assert.equal(diagramDoc.length, 2);
 });
 
+test("diagramDoc: the frame follows the app theme — transparent body, per-message init", () => {
+  const doc = diagramDoc("r", "n");
+  // The panel surface is the canvas: a hardcoded dark body would paint a
+  // dark slab into light themes (2026-08-13 paintings audit).
+  assert.match(doc, /html,body\{margin:0;background:transparent\}/);
+  // mermaid.initialize runs INSIDE the message handler, so every render pass
+  // (including a theme-switch re-post) carries the current dark/background.
+  const handler = doc.slice(doc.indexOf("addEventListener('message'"));
+  assert.ok(handler.includes("mermaid.initialize"), "init must ride each message");
+});
+
 test("diagramDoc: a hostile nonce can't escape its JSON string", () => {
   const doc = diagramDoc("r", '</script><script>alert(1)</script>');
   // JSON.stringify escapes the closing tag's slash — the raw sequence must

--- a/web/src/registry/Diagram.tsx
+++ b/web/src/registry/Diagram.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ComponentProps } from "@registry-spec";
+import { THEMES } from "../themes/manifest";
 
 // Mermaid diagrams, rendered INSIDE the artifact-grade sandbox — never in the
 // shell origin. Mermaid is a large parser with a sanitization-CVE history;
@@ -17,19 +18,24 @@ import type { ComponentProps } from "@registry-spec";
 const DIAGRAM_CSP =
   "default-src 'none'; script-src 'unsafe-inline'; style-src 'unsafe-inline'; img-src data:; font-src data:";
 
-/** The frame document: runtime + a bootstrap that waits for THE one
- *  nonce-stamped source message. Pure; exported for the Tier-1 test, which
- *  pins that agent source is NOT in the document. */
+/** The frame document: runtime + a bootstrap that waits for nonce-stamped
+ *  source messages. Pure; exported for the Tier-1 test, which pins that agent
+ *  source is NOT in the document. Diagrams follow the APP theme, unlike the
+ *  pinned-dark code surfaces — a diagram is a picture, not a code surface, so
+ *  each message re-initializes mermaid with the shell-computed dark flag and
+ *  panel color; the body stays transparent so the panel surface is the canvas. */
 export function diagramDoc(runtime: string, nonce: string): string {
   // <-escape keeps any string safe inside the inline <script>, though
   // the caller only ever passes a crypto.randomUUID().
   const boot =
     `(function(){var N=${JSON.stringify(nonce).replace(/</g, "\\u003c")};` +
     "function post(m){m.mirafoldDiagram=1;m.nonce=N;try{parent.postMessage(m,'*')}catch(e){}}" +
-    "mermaid.initialize({startOnLoad:false,securityLevel:'strict',theme:'dark'," +
-    "themeVariables:{darkMode:true,background:'#141a26',fontFamily:\"system-ui,-apple-system,'Segoe UI',sans-serif\"}});" +
     "window.addEventListener('message',function(e){" +
     "var d=e.data;if(!d||d.mirafoldDiagram!==1||d.nonce!==N||typeof d.source!=='string')return;" +
+    "var dark=d.dark!==false;" +
+    "mermaid.initialize({startOnLoad:false,securityLevel:'strict',theme:dark?'dark':'default'," +
+    "themeVariables:{darkMode:dark,background:typeof d.background==='string'?d.background:'#141a26'," +
+    "fontFamily:\"system-ui,-apple-system,'Segoe UI',sans-serif\"}});" +
     "mermaid.render('mf-diagram',d.source).then(function(r){" +
     "document.getElementById('host').innerHTML=r.svg;" +
     "var s=document.querySelector('#host svg');if(s){s.style.maxWidth='100%'}" +
@@ -39,11 +45,21 @@ export function diagramDoc(runtime: string, nonce: string): string {
   return (
     '<!doctype html><html><head><meta charset="utf-8">' +
     `<meta http-equiv="Content-Security-Policy" content="${DIAGRAM_CSP}">` +
-    "<style>html,body{margin:0;background:#141a26}#host{padding:10px}</style>" +
+    "<style>html,body{margin:0;background:transparent}#host{padding:10px}</style>" +
     `<script>${runtime}</script>` +
     `<script>${boot}</script>` +
     '</head><body><div id="host"></div></body></html>'
   );
+}
+
+/** What the frame needs to draw on the current theme: the appearance side
+ *  from the manifest (absent/unknown data-theme = the dark default) and the
+ *  panel surface color mermaid derives its contrast colors against. */
+function themeInfo(): { dark: boolean; background: string } {
+  const id = document.documentElement.dataset["theme"];
+  const appearance = THEMES.find((t) => t.id === id)?.appearance ?? "dark";
+  const surface = getComputedStyle(document.documentElement).getPropertyValue("--surface").trim();
+  return { dark: appearance === "dark", background: surface || "#141a26" };
 }
 
 /** The lazily-loaded mermaid runtime source, shared by every diagram. */
@@ -94,16 +110,25 @@ export function Diagram({ title, source }: ComponentProps<"diagram">) {
     return () => window.removeEventListener("message", onMsg);
   }, [nonce]);
 
+  // A theme switch must re-render the diagram itself (mermaid bakes its
+  // colors into the SVG) — watch the root's data-theme stamp.
+  const [themeTick, setThemeTick] = useState(0);
+  useEffect(() => {
+    const mo = new MutationObserver(() => setThemeTick((t) => t + 1));
+    mo.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
+    return () => mo.disconnect();
+  }, []);
+
   const post = () => {
     frameRef.current?.contentWindow?.postMessage(
-      { mirafoldDiagram: 1, nonce, source },
+      { mirafoldDiagram: 1, nonce, source, ...themeInfo() },
       "*",
     );
   };
-  // Re-send when source changes after the frame already loaded.
+  // Re-send when the source or theme changes after the frame already loaded.
   useEffect(() => {
     if (runtime) post();
-  }, [source, runtime]);
+  }, [source, runtime, themeTick]);
 
   if (error) {
     return (

--- a/web/src/registry/Table.test.ts
+++ b/web/src/registry/Table.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Table } from "./Table";
+
+const render = (props: object) => renderToStaticMarkup(createElement(Table as never, props));
+
+test("rows render exactly one cell per column — surplus truncated, missing padded", () => {
+  const html = render({
+    columns: ["file", "lines"],
+    rows: [
+      ["a.ts", 10, "SURPLUS"], // a third cell would escape the two headers
+      ["b.ts"], // a short row must not ragged-shift later columns
+    ],
+  });
+  assert.ok(!html.includes("SURPLUS"), "surplus cell rendered past the header");
+  const cells = html.match(/<td/g) ?? [];
+  assert.equal(cells.length, 4, "every row renders columns.length cells");
+});
+
+test("number cells scan as a column: rc-table-num, string cells stay markdown", () => {
+  const html = render({ columns: ["k", "v"], rows: [["**bold**", 42]] });
+  assert.match(html, /class="rc-table-num"[^>]*>42/);
+  assert.ok(html.includes("<strong>bold</strong>"), "string cells render inline markdown");
+  assert.ok(!html.includes("rc-table-num\"><strong>"), "markdown cells never take the numeric class");
+});
+
+test("empty rows render a visible empty state, not a bare header", () => {
+  const html = render({ columns: ["a"], rows: [] });
+  assert.ok(html.includes("no rows"));
+});

--- a/web/src/registry/Table.tsx
+++ b/web/src/registry/Table.tsx
@@ -15,17 +15,27 @@ export function Table({ title, columns, rows }: ComponentProps<"table">) {
             </tr>
           </thead>
           <tbody>
+            {/* Cells align to `columns` by index (the schema's contract), so
+                every row renders exactly columns.length cells: surplus cells
+                would escape the header, missing ones would ragged-shift the
+                columns after them. */}
             {rows.map((row, r) => (
               <tr key={r}>
-                {row.map((cell, c) => (
-                  <td key={c}>
-                    {typeof cell === "number" ? cell : <Md text={cell} inline />}
-                  </td>
-                ))}
+                {columns.map((_, c) => {
+                  const cell = row[c];
+                  return typeof cell === "number" ? (
+                    <td key={c} className="rc-table-num">
+                      {cell}
+                    </td>
+                  ) : (
+                    <td key={c}>{cell !== undefined ? <Md text={cell} inline /> : null}</td>
+                  );
+                })}
               </tr>
             ))}
           </tbody>
         </table>
+        {rows.length === 0 && <div className="rc-table-empty">no rows</div>}
       </div>
     </div>
   );

--- a/web/src/styles/07-registry.css
+++ b/web/src/styles/07-registry.css
@@ -14,6 +14,11 @@
   padding: 14px 16px;
   max-width: 720px;
   animation: rc-mount 0.22s ease-out;
+  /* Agent-authored prose routinely carries unbroken tokens (URLs, SHAs, long
+     paths); without a break rule one of them pushes the whole transcript
+     sideways. Inert on the monospace bodies — white-space: pre allows no
+     wrap points — so code/console/diff keep their horizontal scroll. */
+  overflow-wrap: anywhere;
 }
 
 @keyframes rc-mount {

--- a/web/src/styles/08-picker.css
+++ b/web/src/styles/08-picker.css
@@ -166,6 +166,18 @@
   border-bottom: none;
 }
 
+/* Numeric cells scan as a column: right edge + lining figures. */
+.rc-table-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.rc-table-empty {
+  padding: 8px 12px;
+  color: var(--fg-dimmer);
+  font-size: 0.85em;
+}
+
 /* stat — the single-number KPI tile (S.3), the natural pin-dock resident */
 .rc-stat {
   max-width: 280px;
@@ -258,12 +270,17 @@
   border-color: var(--border-hover);
 }
 
+/* Vertical clamp mirrors the diff body's (06-tools.css): a dumped whole file
+   scrolls inside its panel instead of consuming the transcript; the copy
+   button already guarantees nothing is lost. */
 .rc-code-body {
   margin: 0;
   padding: 10px 0;
   background: var(--code-bg);
   font-size: 0.84em;
   overflow-x: auto;
+  max-height: 360px;
+  overflow-y: auto;
 }
 
 .rc-code-body code {
@@ -323,7 +340,10 @@
   width: 100%;
   height: 120px;
   border: 0;
-  background: #141a26; /* the frame's own pinned canvas, pre-render */
+  /* The frame body stays transparent, so the panel surface IS the diagram's
+     canvas — it follows the theme with no re-render (the diagram's own
+     colors re-render via the theme observer in Diagram.tsx). */
+  background: var(--surface);
 }
 
 .rc-diagram-loading {
@@ -456,6 +476,8 @@
   border-color: var(--err-border-strong);
 }
 
+/* Same vertical clamp as .rc-code-body: a 200k-char log excerpt must not
+   render thousands of lines inline. */
 .rc-console-body {
   margin: 0;
   padding: 10px 12px;
@@ -464,6 +486,8 @@
   font-size: 0.84em;
   line-height: 1.5;
   overflow-x: auto;
+  max-height: 360px;
+  overflow-y: auto;
 }
 
 .rc-console-clip {


### PR DESCRIPTION
From the 2026-08-13 paintings audit (full record in PLAN.md, "Paintings polish batch").

## Fixes
- **`.rc` wrap rule** — unbroken tokens (URLs, SHAs, paths) in any painting's prose no longer push the transcript sideways; inert on monospace bodies, which keep their horizontal scroll.
- **Chart** — line charts fit the y-domain to the data instead of a forced zero baseline (bars still anchor to zero); ≤2-point line charts draw always-on dots; the forced last x-label no longer collides with a stride label; grouped bars stay inside their band at high category×series counts. All four behaviors extracted as pure helpers (`chartDomain`, `showXLabel`, `groupedBarLayout`) and Tier-1-pinned.
- **Table** — rows render exactly one cell per column (surplus truncated, missing padded), numeric cells right-align with `tabular-nums`, empty `rows` shows "no rows". New `Table.test.ts`.
- **Code/Console** — 360px vertical clamp with scroll (the diff body's existing treatment).
- **Diagram (decision)** — diagrams now follow the app theme. Pinned-dark is the code-surface convention; a diagram is a picture, and on light themes it rendered as a dark slab. Frame body is transparent over the panel surface, mermaid re-initializes per message with the shell-computed dark flag + `--surface`, and a `data-theme` observer re-posts on theme switch. Sandbox posture unchanged.

## Instrumentation
One local log line per paint (`paint <component> agent=<agent>`) at `registry.deliver()` — the choke point all three adapters cross — so per-engine painting adoption is measurable from the daemon log. Local only; one `if` to delete.

## Also
Folds in the glossary work from another session (`GLOSSARY.md` + the `CLAUDE.md` pointer).

## Verification
All three tiers green: Tier-1 724/724 (7 new), Tier-2 152/152, Tier-3 e2e 97/97.

🤖 Generated with [Claude Code](https://claude.com/claude-code)