### PR TITLE
OpenCode adapter — the fourth agent (Phase OC)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2785,16 +2785,48 @@ gates come first.
   `emitPromptOptions` behind our two re-skins (engine rows badged
   `source: "opencode"`). 6 new Tier-1 tests; suite 757/757; typecheck
   green. — **Goal:** what an OpenCode user expects in-session.
-- [ ] **Step OC.4b — Onboarding + kind-into-Backend + Zen terms** —
-  **Goal:** the agent becomes offerable. **Build:** ADAPTER_AGENTS entry +
-  onboarding card + real agents-meta copy (gray-area disclosure only when
-  the chosen provider needs it); flow the session-start classified kind
-  into `Backend` so the ChatGPT gray path can run under its true kind
-  (relay-gate truth — the OC.3 refusal comes out then, with the
-  disclosure); read and cite OpenCode Zen's terms and either open the
-  free-models row or keep it closed with the citation. **Done when:**
-  onboarding→session flow works live end-to-end and a blocked/gray pick
-  shows its honest copy in the picker.
+- [x] **Step OC.4b — Offerable + Zen terms citation** — completed
+  2026-08-13 (the kind-into-Backend half split to OC.4c; live onboarding
+  proof folds into OC.5): `opencode` joined ADAPTER_AGENTS +
+  `defaultAgent`; one shallow `backendOptions` api-key row (existence
+  probe; the provider-resolved truth stays enforced at session start);
+  real agents-meta copy (connect hint names install + `opencode auth
+  login` + OPENCODE_MODEL and says plainly that subscriptions and Zen
+  aren't usable yet), `backendLabel` "API key (via opencode)", PromptBox
+  source badge. **Zen terms read and cited** in provider-policy.ts
+  (2026-08-13: no third-party-harness prohibition — the server API is
+  opencode's own documented programmatic surface; "own internal use"
+  clause; free-period training-data caveat): the disclosed-uncertainty
+  rule's exact shape, but opening a NEW provider under it is Kyle's call
+  (codex precedent), so the row stays CLOSED pending his decision — if
+  opened, local-only + caveat shown. Also fixed en route: the fourth
+  agent row overflowed the onboarding squeeze ramp by 14px — the
+  squeeze intercept moved 66→70 and the per-row floor metrics shaved
+  (full-chrome values untouched); the squeeze e2e passes with four READY
+  rows. Verification status, honestly: Tier-1 757/757 + Tier-2 152/152
+  green; e2e ran 96/97 before the CSS fix (the squeeze test its only
+  failure, after the hint-count assertion gained the fourth card) and
+  the fixed squeeze test passes in isolation — but two attempts at the
+  full post-fix e2e run were stopped externally mid-run (6/6 ok at each
+  stop), so ONE clean full-suite pass is still owed; folded into OC.5's
+  tier sweep.
+- [ ] **Step OC.4c — Classified kind into Backend (the ChatGPT-gray
+  unlock)** — **Goal:** the gray path runs under its TRUE kind. **Build:**
+  an optional `AgentSession.onBackendKind` seam (like `onResumeId`): the
+  OpenCode session publishes the OC.3-classified kind + provider at start;
+  the registry updates its `Backend` so the relay gate judges truth.
+  **The race that shapes the design:** hello-kind is optimistic
+  ("api-key"), so a relay viewport's FIRST prompt could slip the gate
+  before classification lands — closed by a `kindVerified` flag on
+  opencode Backends (server-side only): relay prompts refuse with an
+  honest "still verifying" message until the session publishes, local
+  viewports unaffected. Then the OC.3 session-level gray refusal lifts,
+  replaced by a Mirafold-composed disclosure notice at session start
+  (uncertainty stated, never permission — the codex CONNECT_HINT contract,
+  session-time edition). **Done when:** Tier-1 covers publish→registry
+  update, the pre-verification relay refusal, and the gray disclosure;
+  the relay itest proves a subscription-classified session never runs a
+  turn from a relay viewport.
 - [ ] **Step OC.5 — Tier-2/Tier-3 + live end-to-end** — **Goal:** the
   proof. **Build:** Tier-2 itest against a real spawned `opencode serve`
   (mock-forced provider if feasible); Tier-3 e2e onboarding→prompt→render;

--- a/PLAN.md
+++ b/PLAN.md
@@ -2725,7 +2725,18 @@ gates come first.
   (+ `.test.ts` with a fake SSE feed), `server/protocol.ts` (`AgentName` +
   fixtures — additive only). **Done when:** Tier-1 drives the full table
   through a fake event feed; `yarn typecheck` green.
-- [ ] **Step OC.2 — Render MCP + permission bridge** — **Goal:** generative
+- [x] **Step OC.2 — Render MCP + permission bridge** — completed
+  2026-08-13. The Tier-1 half had landed inside OC.1; this step ran the
+  live leg, $0 and credential-free (real `OpenCodeSession` → real spawned
+  engine → fake provider): **a card painted end-to-end** through the real
+  render-mcp stub, and **a permission ask round-tripped live** (ask → bar
+  shape → `once` → bash ran). It caught and fixed two adapter bugs
+  (health-poll wedge on pre-ready connections — per-attempt abort is
+  load-bearing; user-message parts echoing as text_delta — roles now
+  tracked, +1 test) and characterized one upstream engine behavior,
+  documented not gated: a cold server's first model call carries zero
+  tools; the engine self-recovers same-turn (spike appendix has the full
+  probe evidence). Suite 747/747, typecheck green. — **Goal:** generative
   UI and the permission bar, faithfully. **Build:** inject
   `renderMcpCommand()` under `MIRAFOLD_MCP` via `OPENCODE_CONFIG_CONTENT`
   (additive merge; user config untouched); recognize mirafold tool parts by

--- a/PLAN.md
+++ b/PLAN.md
@@ -2746,7 +2746,22 @@ gates come first.
   state), `PERMISSION_TIMEOUT_MS` deny-by-default. **Done when:** Tier-1
   proves render-call recognition + both permission outcomes + timeout; a
   live render paints end-to-end.
-- [ ] **Step OC.3 — Credential policy + registry wiring** — **Goal:** the
+- [x] **Step OC.3 — Credential policy + registry wiring** — completed
+  2026-08-13, including the "needs a real credential" residual — resolved
+  with auth.json FIXTURES in the jailed probe home (no real credential
+  needed): the engine's own catalog distinguishes every kind (`source`
+  api/env/config/custom + the `opencode-oauth-dummy-key` OAuth marker), it
+  leaks raw stored secrets (stripped at the transport seam, never past
+  it), and 1.18.18 ignores a stored anthropic OAuth wholesale. Landed:
+  `classifyOpenCodeProvider` matrix in provider-policy.ts (fail-closed:
+  unknown OAuth, Zen-pending-terms, unrecognized shapes all refuse with
+  human copy), session-start enforcement in opencode.ts (pin resolved
+  from OPENCODE_MODEL or the user's config `model`; refusals precede any
+  engine session), shallow hello detection in index.ts (binary +
+  auth.json existence — contents unread), `Backend.provider` from the
+  pin. ChatGPT gray: policy-allowed, session-refused until OC.4 flows
+  classified kind into Backend (relay-gate truth). 8 policy tests + 3
+  session tests; suite 752/752; typecheck green. — **Goal:** the
   policy matrix applied provider-aware, fail-closed. **Build:**
   `provider-policy.ts` gains the OpenCode provider classification
   (anthropic/google oauth → blocked; openai oauth → disclosed gray area;

--- a/PLAN.md
+++ b/PLAN.md
@@ -2773,13 +2773,28 @@ gates come first.
   carries the pick. Relay gate unchanged (already refuses `subscription`).
   **Done when:** Tier-1 covers every matrix row incl. the fail-closed
   default; blocked/gray states render their correct copy.
-- [ ] **Step OC.4 — Fidelity surface** — **Goal:** what an OpenCode user
-  expects. **Build:** onboarding card + agents-meta entry (gray-area
-  disclosure only when the chosen provider needs it), build/plan agent
-  toggle (per-prompt `agent`), cross-provider model picker from the server
-  catalog, command catalog → `emitPromptOptions` (optional-feature rule if
-  unexposed). **Done when:** onboarding→session flow works live; pickers
-  reflect the user's own config (whitelists, custom agents).
+- [x] **Step OC.4 — In-session fidelity surface** — completed 2026-08-13
+  (the original OC.4 split in two; the onboarding half is OC.4b below):
+  `opencode-commands.ts` on the codex picker pattern — `/model` paints the
+  cross-provider catalog (policy-filtered: only providers a pick can
+  actually run; a typed blocked pick refuses with its reason and keeps the
+  pin), `/agent` paints user-facing primaries only (`hidden` internals and
+  subagents excluded; pick rides every subsequent prompt), the engine's
+  own command catalog routes `/name` inputs to `POST /session/:id/command`
+  (the engine's real dispatcher, with pin + agent) and feeds
+  `emitPromptOptions` behind our two re-skins (engine rows badged
+  `source: "opencode"`). 6 new Tier-1 tests; suite 757/757; typecheck
+  green. — **Goal:** what an OpenCode user expects in-session.
+- [ ] **Step OC.4b — Onboarding + kind-into-Backend + Zen terms** —
+  **Goal:** the agent becomes offerable. **Build:** ADAPTER_AGENTS entry +
+  onboarding card + real agents-meta copy (gray-area disclosure only when
+  the chosen provider needs it); flow the session-start classified kind
+  into `Backend` so the ChatGPT gray path can run under its true kind
+  (relay-gate truth — the OC.3 refusal comes out then, with the
+  disclosure); read and cite OpenCode Zen's terms and either open the
+  free-models row or keep it closed with the citation. **Done when:**
+  onboarding→session flow works live end-to-end and a blocked/gray pick
+  shows its honest copy in the picker.
 - [ ] **Step OC.5 — Tier-2/Tier-3 + live end-to-end** — **Goal:** the
   proof. **Build:** Tier-2 itest against a real spawned `opencode serve`
   (mock-forced provider if feasible); Tier-3 e2e onboarding→prompt→render;

--- a/PLAN.md
+++ b/PLAN.md
@@ -2810,8 +2810,22 @@ gates come first.
   full post-fix e2e run were stopped externally mid-run (6/6 ok at each
   stop), so ONE clean full-suite pass is still owed; folded into OC.5's
   tier sweep.
-- [ ] **Step OC.4c — Classified kind into Backend (the ChatGPT-gray
-  unlock)** — **Goal:** the gray path runs under its TRUE kind. **Build:**
+- [x] **Step OC.4c — Classified kind into Backend + ZEN OPENED** —
+  completed 2026-08-13, same day Kyle said "open Zen" (the decision the
+  OC.4b citation was waiting on). Built exactly per the design below:
+  `onBackendKind` seam + registry adoption at `activate()` (truthful kind
+  checkpointed), `kindPending` refusing remote actions pre-verification,
+  and the three relay-gate sites (attach, cockpit acts, uploads) unified
+  on one `relayGateRefusal` verdict in provider-policy.ts. The ChatGPT
+  gray now RUNS locally with its uncertainty disclosure (once per
+  provider, Mirafold-composed, no badge). **Zen**: new `gateway`
+  CredentialKind (additive on every wire union) — allowed locally for
+  opencode with the uncertainty + training-data disclosure, NEVER
+  relay-eligible (the allow-list refuses it by design); fresh
+  binary-only installs now detect live out of the box, and the /model
+  picker offers Zen rows. 761/761 + 152/152 green; the full-e2e sweep
+  remains owed to OC.5 (two prior runs externally stopped). — original
+  goal + design: **Goal:** the gray path runs under its TRUE kind. **Build:**
   an optional `AgentSession.onBackendKind` seam (like `onResumeId`): the
   OpenCode session publishes the OC.3-classified kind + provider at start;
   the registry updates its `Backend` so the relay gate judges truth.

--- a/PLAN.md
+++ b/PLAN.md
@@ -2676,7 +2676,19 @@ the permission reply round-trip, and the provider-keyed credential-policy
 design all live there — the steps below execute that doc, and its two live
 gates come first.
 
-- [ ] **Step OC.0 — Live gates + shape capture** — **Goal:** de-risk the
+- [x] **Step OC.0 — Live gates + shape capture** — completed 2026-08-13,
+  same day, $0 and credential-free: scratchpad-local `opencode-ai@1.18.18`
+  with HOME jailed; Gate 1 PASSED (`OPENCODE_CONFIG_CONTENT` alone
+  connected the render MCP; tools advertise as `mirafold_render_*`), Gate 2
+  PASSED via a fake OpenAI-compatible provider (ask event is
+  **`permission.asked`** — published SDK types drift — reply `once` ran the
+  tool through to `session.idle`). Streaming is a true delta channel
+  (`message.part.delta`), usage + `modelID` ride each assistant message.
+  Bonuses: 1.18.18 offers no Anthropic/Google OAuth at all, and a fresh
+  install ships the free "OpenCode Zen" provider (needs its own OC.3
+  policy row). One residual folded into OC.3: confirm a stored
+  credential's oauth-vs-api kind is server-readable (needs a real
+  connected credential). Full appendix in the spike doc. — **Goal:** de-risk the
   two spike gates and lock real shapes before adapter code exists.
   **Build:** run `opencode serve` (scratchpad-local install is fine; no
   global mutation) and confirm: (1) `OPENCODE_CONFIG_CONTENT` loads the

--- a/PLAN.md
+++ b/PLAN.md
@@ -2700,7 +2700,19 @@ gates come first.
   (Ollama or an existing API key) is needed for gate 2 only. **Done when:**
   the spike doc's "confirm live" flags are each resolved GREEN/RED with
   captured payloads appended to the doc.
-- [ ] **Step OC.1 — Core adapter + Tier-1** — **Goal:** an OpenCode session
+- [x] **Step OC.1 — Core adapter + Tier-1** — completed 2026-08-13:
+  `opencode.ts` (session: lazy spawn-with-retry latch, serial queue,
+  first-turn guidance flipped only after prompt acceptance, permission
+  bridge with deny-by-default timeout + external-reply handling +
+  interrupt grace fallback) + `opencode-events.ts` (mapper: delta/snapshot
+  text accrual, tool lifecycle, mirafold `render_*` recognition with
+  honest fallback, todo checklist, per-turn usage summing) +
+  `opencode-client.ts` (raw HTTP+SSE transport — the spike's SDK
+  recommendation REVERSED with the reason recorded there: live shapes
+  beat drifting generated types). 22 Tier-1 tests on captured shapes;
+  full Tier-1 suite 746/746; typecheck green. `AgentName` grew additively
+  (policy row fails closed, agent not in ADAPTER_AGENTS, so nothing is
+  offered before OC.3/OC.4). — **Goal:** an OpenCode session
   behind the `AgentSession` seam, mock-verified. **Build:**
   `server/adapters/opencode.ts` — spawn `opencode serve` on a free port
   with a per-session `OPENCODE_SERVER_PASSWORD`, create the session, prompt

--- a/PLAN.md
+++ b/PLAN.md
@@ -2841,12 +2841,21 @@ gates come first.
   update, the pre-verification relay refusal, and the gray disclosure;
   the relay itest proves a subscription-classified session never runs a
   turn from a relay viewport.
-- [ ] **Step OC.5 — Tier-2/Tier-3 + live end-to-end** — **Goal:** the
-  proof. **Build:** Tier-2 itest against a real spawned `opencode serve`
-  (mock-forced provider if feasible); Tier-3 e2e onboarding→prompt→render;
-  live run on the $0 provider: one tool call, one permission round-trip,
-  one render, usage + resume verified. README/ADAPTERS.md updated. **Done
-  when:** all three tiers green and the live loop observed.
+- [x] **Step OC.5 — Tier sweep + live end-to-end** — completed 2026-08-13
+  (one residual below): **`opencode-live.ltest.ts`** joins Tier 4 on the
+  codex pattern (real binary, never a hosted model; the scripted
+  OpenAI-compatible provider from the OC.2 probe; HOME/XDG jailed via a
+  new transport `env` seam so a real engine run never touches the
+  developer's own opencode state; skips cleanly when opencode isn't
+  installed). One 17s test drives the WHOLE loop through shipped code:
+  render through the real MCP stub, headless permission ask answered via
+  the bridge, usage, kind publish (config→local), and **resume across a
+  full engine restart**. All tiers green same-sitting: Tier-1 761/761,
+  Tier-2 152/152, Tier-3 97/97 (the sweep owed since OC.4b — paid),
+  Tier-4 1/1 live + verified clean skip. **Residual, needs Kyle:** the
+  real-install confirmation — `npm i -g opencode-ai`, then one browser
+  click-through on Zen (his machine, his eyes); the walkthrough is
+  queued. README/ADAPTERS.md refresh rides the wrapup.
 
 ## Phase PN — Panes (file views beside the transcript)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2852,10 +2852,13 @@ gates come first.
   the bridge, usage, kind publish (config→local), and **resume across a
   full engine restart**. All tiers green same-sitting: Tier-1 761/761,
   Tier-2 152/152, Tier-3 97/97 (the sweep owed since OC.4b — paid),
-  Tier-4 1/1 live + verified clean skip. **Residual, needs Kyle:** the
-  real-install confirmation — `npm i -g opencode-ai`, then one browser
-  click-through on Zen (his machine, his eyes); the walkthrough is
-  queued. README/ADAPTERS.md refresh rides the wrapup.
+  Tier-4 1/1 live + verified clean skip. **Residual CONFIRMED by Kyle
+  2026-08-13**: real global install (`npm i -g opencode-ai` — his npm's
+  install-scripts blocking required the manual postinstall, the exact
+  failure the transport's stderr surfacing named; the session's
+  start-latch retry then worked as designed, no restarts) and a live
+  browser session on Zen: "heyyyy it works". Phase OC complete.
+  README/ADAPTERS.md refresh rides the wrapup.
 
 ## Phase PN — Panes (file views beside the transcript)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2662,6 +2662,81 @@ first, measurement second, new paintings demand-gated.
   (housekeeping); HBar tooltip parks at `left: 40%`. Each is a candidate
   for a follow-up surfacing-parity step.
 
+## Phase OC — OpenCode adapter (opened 2026-08-13; Kyle-directed)
+
+**Product call.** Kyle, from a 2026-08-13 market check: OpenCode (~195k
+GitHub stars) is now the dominant open-source terminal agent — the largest
+user population Mirafold doesn't cover — and becomes the fourth adapter.
+(Same check surfaced that Gemini CLI was retired upstream 2026-06-18,
+replaced by the closed-source Antigravity CLI; Gemini-adapter sunset is
+agreed but explicitly deferred — NOT part of this phase.) The feasibility
+spike is **`server/adapters/opencode.spike.md`** (verdict GREEN): the
+event→`WireMsg` table, the `OPENCODE_CONFIG_CONTENT` MCP-injection path,
+the permission reply round-trip, and the provider-keyed credential-policy
+design all live there — the steps below execute that doc, and its two live
+gates come first.
+
+- [ ] **Step OC.0 — Live gates + shape capture** — **Goal:** de-risk the
+  two spike gates and lock real shapes before adapter code exists.
+  **Build:** run `opencode serve` (scratchpad-local install is fine; no
+  global mutation) and confirm: (1) `OPENCODE_CONFIG_CONTENT` loads the
+  mirafold render MCP and its tools appear (exact tool-name prefix
+  captured); (2) a permission ask surfaces as `permission.updated` headless
+  and the reply endpoint resolves it; plus capture the provider catalog's
+  auth exposure (oauth-vs-api visible without reading `auth.json`?), the
+  streaming part-update granularity, and usage field names. A $0 provider
+  (Ollama or an existing API key) is needed for gate 2 only. **Done when:**
+  the spike doc's "confirm live" flags are each resolved GREEN/RED with
+  captured payloads appended to the doc.
+- [ ] **Step OC.1 — Core adapter + Tier-1** — **Goal:** an OpenCode session
+  behind the `AgentSession` seam, mock-verified. **Build:**
+  `server/adapters/opencode.ts` — spawn `opencode serve` on a free port
+  with a per-session `OPENCODE_SERVER_PASSWORD`, create the session, prompt
+  via `prompt_async` with the pinned `model`, normalize the SSE stream per
+  the spike table (text/reasoning accrual → deltas, tool parts →
+  `tool_use`/`tool_result` with `capOutput`, `todo.updated` → checklist,
+  `session.idle` → `turn_end`, `session.error` → sourced notice),
+  `interrupt()` → abort, `resumeId` = session id. SDK-vs-raw call finalized
+  at install per the spike. **Files:** `server/adapters/opencode.ts`
+  (+ `.test.ts` with a fake SSE feed), `server/protocol.ts` (`AgentName` +
+  fixtures — additive only). **Done when:** Tier-1 drives the full table
+  through a fake event feed; `yarn typecheck` green.
+- [ ] **Step OC.2 — Render MCP + permission bridge** — **Goal:** generative
+  UI and the permission bar, faithfully. **Build:** inject
+  `renderMcpCommand()` under `MIRAFOLD_MCP` via `OPENCODE_CONFIG_CONTENT`
+  (additive merge; user config untouched); recognize mirafold tool parts by
+  the OC.0-confirmed prefix → `generativeUIMsg` (skip the raw tool block);
+  `permission.updated` → `permission_request`, `resolvePermission` → reply
+  `once`/`reject` (**never `always`** — that writes the user's own approval
+  state), `PERMISSION_TIMEOUT_MS` deny-by-default. **Done when:** Tier-1
+  proves render-call recognition + both permission outcomes + timeout; a
+  live render paints end-to-end.
+- [ ] **Step OC.3 — Credential policy + registry wiring** — **Goal:** the
+  policy matrix applied provider-aware, fail-closed. **Build:**
+  `provider-policy.ts` gains the OpenCode provider classification
+  (anthropic/google oauth → blocked; openai oauth → disclosed gray area;
+  api-key/env → `api-key`; local → `local`; **unclassified oauth →
+  blocked**), detection per the OC.0-confirmed path (server catalog
+  preferred; `auth.json` only with explicit consent); model pinned
+  per-prompt so the session provider is the one Mirafold set; registry:
+  `createSession` case, `agentHasCredentials("opencode")`, `Backend.provider`
+  carries the pick. Relay gate unchanged (already refuses `subscription`).
+  **Done when:** Tier-1 covers every matrix row incl. the fail-closed
+  default; blocked/gray states render their correct copy.
+- [ ] **Step OC.4 — Fidelity surface** — **Goal:** what an OpenCode user
+  expects. **Build:** onboarding card + agents-meta entry (gray-area
+  disclosure only when the chosen provider needs it), build/plan agent
+  toggle (per-prompt `agent`), cross-provider model picker from the server
+  catalog, command catalog → `emitPromptOptions` (optional-feature rule if
+  unexposed). **Done when:** onboarding→session flow works live; pickers
+  reflect the user's own config (whitelists, custom agents).
+- [ ] **Step OC.5 — Tier-2/Tier-3 + live end-to-end** — **Goal:** the
+  proof. **Build:** Tier-2 itest against a real spawned `opencode serve`
+  (mock-forced provider if feasible); Tier-3 e2e onboarding→prompt→render;
+  live run on the $0 provider: one tool call, one permission round-trip,
+  one render, usage + resume verified. README/ADAPTERS.md updated. **Done
+  when:** all three tiers green and the live loop observed.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -143,9 +143,12 @@ function credentialKind(agent: AgentName): CredentialKind {
       const dataDir = process.env.XDG_DATA_HOME
         ? path.join(process.env.XDG_DATA_HOME, "opencode")
         : undefined;
+      // No stored credential ⇒ the built-in free Zen gateway still backs the
+      // engine out of the box — "gateway", the Zen-opened kind (2026-08-13):
+      // usable locally with its disclosure, never over the relay.
       return loginFileExists(dataDir, path.join(".local", "share", "opencode"), "auth.json")
         ? "api-key"
-        : "none";
+        : "gateway";
     }
   }
 }
@@ -297,11 +300,12 @@ export function backendOptions(agent: AgentName): BackendOption[] {
       if (process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) addCredentialRow("api-key");
       break;
     case "opencode": {
-      // One shallow row: a stored credential exists (existence only — the
-      // provider-resolved truth is enforced at session start, OC.3). Richer
-      // per-provider rows need a running engine; that probe is a post-OC.5
-      // idea, not a hello-time cost.
-      if (credentialKind("opencode") === "api-key") addCredentialRow("api-key");
+      // One shallow row: a stored credential (or the built-in Zen gateway) —
+      // existence only; the provider-resolved truth is enforced at session
+      // start (OC.3). Richer per-provider rows need a running engine; that
+      // probe is a post-OC.5 idea, not a hello-time cost.
+      const kind = credentialKind("opencode");
+      if (kind === "api-key" || kind === "gateway") addCredentialRow(kind);
       break;
     }
   }
@@ -563,7 +567,7 @@ export function resolveChosenBackend(
     model?: unknown;
   };
   const kind = c.kind;
-  if (kind !== "api-key" && kind !== "subscription" && kind !== "local")
+  if (kind !== "api-key" && kind !== "subscription" && kind !== "local" && kind !== "gateway")
     return { error: "unknown backend choice" };
   if (
     (c.endpoint !== undefined && typeof c.endpoint !== "string") ||
@@ -699,7 +703,11 @@ export function createSession(
   opts: { cwd: string; resumeId?: string },
 ): AgentSession {
   if (!backend.live) return new MockSession(backend.agent);
-  const kind = backend.kind === "none" ? undefined : backend.kind;
+  // "gateway" is OpenCode-only (Zen) and the OpenCode adapter classifies its
+  // own backing at start — the per-adapter `kind` option below is for the
+  // engines that take one, and none of them can be gateway-backed.
+  const kind =
+    backend.kind === "none" || backend.kind === "gateway" ? undefined : backend.kind;
   switch (backend.agent) {
     case "claude-code":
       return new ClaudeCodeSession({

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -163,7 +163,9 @@ export function resolveBackend(): Backend {
 /** The env-configured default agent — a pre-selection hint, never assumed. */
 export function defaultAgent(): AgentName {
   const requested = process.env.MIRAFOLD_AGENT;
-  return requested === "codex" || requested === "gemini-cli" ? requested : "claude-code";
+  return requested === "codex" || requested === "gemini-cli" || requested === "opencode"
+    ? requested
+    : "claude-code";
 }
 
 /** Resolve one named agent's backend (kind + live + model), per-session (P.4). */
@@ -203,7 +205,7 @@ export function resolveBackendFor(agent: AgentName): Backend {
 }
 
 // Agents with a landed adapter — the onboarding picker's universe.
-export const ADAPTER_AGENTS: AgentName[] = ["claude-code", "codex", "gemini-cli"];
+export const ADAPTER_AGENTS: AgentName[] = ["claude-code", "codex", "gemini-cli", "opencode"];
 
 /** One way an agent could run on this machine. `usable` is provider-policy's
  *  verdict; a present-but-prohibited subscription rides as `blocked` —
@@ -294,6 +296,14 @@ export function backendOptions(agent: AgentName): BackendOption[] {
     case "gemini-cli":
       if (process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY) addCredentialRow("api-key");
       break;
+    case "opencode": {
+      // One shallow row: a stored credential exists (existence only — the
+      // provider-resolved truth is enforced at session start, OC.3). Richer
+      // per-provider rows need a running engine; that probe is a post-OC.5
+      // idea, not a hello-time cost.
+      if (credentialKind("opencode") === "api-key") addCredentialRow("api-key");
+      break;
+    }
   }
   return options;
 }

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -6,8 +6,9 @@ import { isIP } from "node:net";
 import { ClaudeCodeSession } from "./claude-code";
 import { CodexSession } from "./codex";
 import { GeminiCliSession } from "./gemini-cli";
-import { OpenCodeSession } from "./opencode";
+import { OpenCodeSession, parseModelPin } from "./opencode";
 import { MockSession } from "./mock";
+import { installedAgentBin } from "./types";
 import type { AgentName, AgentSession, Backend } from "./types";
 import type { AgentBackend, AgentInfo } from "../protocol";
 import { allowedLocally, type CredentialKind } from "../provider-policy";
@@ -126,12 +127,26 @@ function credentialKind(agent: AgentName): CredentialKind {
       // prohibits subscription use in third-party tools — so there is no
       // subscription kind to detect. GOOGLE_API_KEY is the CLI's other name.
       return process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY ? "api-key" : "none";
-    case "opencode":
-      // Detection lands in PLAN OC.3 (the provider-keyed policy: which of
-      // OpenCode's connected providers backs the session, and with what kind
-      // of credential). Until then the agent detects as credential-less, is
-      // absent from ADAPTER_AGENTS, and never resolves live.
-      return "none";
+    case "opencode": {
+      // Hello-time detection is deliberately SHALLOW (OC.3): the truthful,
+      // provider-resolved classification needs the engine's own catalog,
+      // which only a running `opencode serve` can give — so it's enforced at
+      // session start (opencode.ts enforceProviderPolicy), the same
+      // never-trust-the-pick posture as resolveChosenBackend. Here: the
+      // binary plus a stored-credential file (existence only, the
+      // claude/codex precedent — its CONTENTS stay unread) reads as
+      // "api-key", and a session whose pinned provider turns out to be a
+      // subscription OAuth or unclassified is refused at start with the
+      // reason. A config-only setup (e.g. Ollama declared in opencode.json,
+      // no auth.json) detects as none until OC.4's picker probes the engine.
+      if (!installedAgentBin("OPENCODE_BIN", "opencode")) return "none";
+      const dataDir = process.env.XDG_DATA_HOME
+        ? path.join(process.env.XDG_DATA_HOME, "opencode")
+        : undefined;
+      return loginFileExists(dataDir, path.join(".local", "share", "opencode"), "auth.json")
+        ? "api-key"
+        : "none";
+    }
   }
 }
 
@@ -177,6 +192,11 @@ export function resolveBackendFor(agent: AgentName): Backend {
     }
   } else if (kind === "local" && agent === "codex") {
     const provider = codexConfigProvider()?.provider;
+    if (provider) backend.provider = provider;
+  } else if (agent === "opencode") {
+    // The pinned provider (OPENCODE_MODEL's provider half) — the input the
+    // relay gate and the OC.3 session-start classification both judge.
+    const provider = parseModelPin(backend.model)?.providerID;
     if (provider) backend.provider = provider;
   }
   return backend;

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -6,6 +6,7 @@ import { isIP } from "node:net";
 import { ClaudeCodeSession } from "./claude-code";
 import { CodexSession } from "./codex";
 import { GeminiCliSession } from "./gemini-cli";
+import { OpenCodeSession } from "./opencode";
 import { MockSession } from "./mock";
 import type { AgentName, AgentSession, Backend } from "./types";
 import type { AgentBackend, AgentInfo } from "../protocol";
@@ -125,6 +126,12 @@ function credentialKind(agent: AgentName): CredentialKind {
       // prohibits subscription use in third-party tools — so there is no
       // subscription kind to detect. GOOGLE_API_KEY is the CLI's other name.
       return process.env.GEMINI_API_KEY || process.env.GOOGLE_API_KEY ? "api-key" : "none";
+    case "opencode":
+      // Detection lands in PLAN OC.3 (the provider-keyed policy: which of
+      // OpenCode's connected providers backs the session, and with what kind
+      // of credential). Until then the agent detects as credential-less, is
+      // absent from ADAPTER_AGENTS, and never resolves live.
+      return "none";
   }
 }
 
@@ -324,6 +331,9 @@ const AGENT_DIALECT: Record<AgentName, LocalDialect | null> = {
   "claude-code": "anthropic",
   codex: "openai",
   "gemini-cli": null,
+  // OpenCode reaches local servers through its own provider config, not a
+  // Mirafold-injected endpoint — no discovered-server rows until OC.4 decides.
+  opencode: null,
 };
 
 /**
@@ -494,6 +504,10 @@ function modelFor(agent: AgentName): string | undefined {
       return process.env.CODEX_MODEL;
     case "gemini-cli":
       return process.env.GEMINI_MODEL;
+    case "opencode":
+      // `provider/model` (OpenCode's own addressing); a bare model id pins
+      // nothing and the engine default runs — opencode.ts parseModelPin.
+      return process.env.OPENCODE_MODEL;
   }
 }
 
@@ -677,6 +691,12 @@ export function createSession(
       });
     case "gemini-cli":
       return new GeminiCliSession({
+        workspaceDir: opts.cwd,
+        model: backend.model,
+        resumeId: opts.resumeId,
+      });
+    case "opencode":
+      return new OpenCodeSession({
         workspaceDir: opts.cwd,
         model: backend.model,
         resumeId: opts.resumeId,

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import net from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 import { envInt } from "../env";
+import type { OpenCodeProviderEntry } from "../provider-policy";
 import { errText } from "./types";
 
 /** One event off `GET /event` — `properties` is the engine's payload,
@@ -23,6 +24,13 @@ export interface OpenCodeTransport {
    *  prompt; the turn itself streams back over events. */
   prompt(sessionID: string, body: Record<string, unknown>): Promise<void>;
   abort(sessionID: string): Promise<void>;
+  /** The engine's connected-provider catalog, STRIPPED to classification
+   *  fields — the raw endpoint exposes stored secrets (`key`), which must
+   *  never travel past this seam. */
+  providerCatalog(): Promise<OpenCodeProviderEntry[]>;
+  /** The user's own configured default model (`model` in their opencode
+   *  config), `provider/model` form; undefined when they set none. */
+  configModel(): Promise<string | undefined>;
   replyPermission(
     sessionID: string,
     permissionID: string,
@@ -223,6 +231,29 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
     } catch {
       return false;
     }
+  }
+
+  async providerCatalog(): Promise<OpenCodeProviderEntry[]> {
+    const res = await this.request("/config/providers");
+    const data = (await res.json()) as { providers?: unknown };
+    const list = Array.isArray(data.providers) ? data.providers : [];
+    return list.map((raw) => {
+      const p = (raw ?? {}) as Record<string, unknown>;
+      const options = (p["options"] ?? {}) as Record<string, unknown>;
+      // Deliberate strip: `p.key` is the user's raw stored secret. Only the
+      // classification facts leave this method (provider-policy.ts shape).
+      return {
+        id: String(p["id"]),
+        source: String(p["source"]) as OpenCodeProviderEntry["source"],
+        ...(typeof options["apiKey"] === "string" ? { apiKeyOption: options["apiKey"] } : {}),
+      };
+    });
+  }
+
+  async configModel(): Promise<string | undefined> {
+    const res = await this.request("/config");
+    const config = (await res.json()) as { model?: unknown };
+    return typeof config.model === "string" && config.model ? config.model : undefined;
   }
 
   async prompt(sessionID: string, body: Record<string, unknown>): Promise<void> {

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -31,6 +31,17 @@ export interface OpenCodeTransport {
   /** The user's own configured default model (`model` in their opencode
    *  config), `provider/model` form; undefined when they set none. */
   configModel(): Promise<string | undefined>;
+  agentCatalog(): Promise<OpenCodeAgentEntry[]>;
+  commandCatalog(): Promise<OpenCodeCommandEntry[]>;
+  modelCatalog(): Promise<OpenCodeModelEntry[]>;
+  /** Run an engine command (`/init`, a custom command, …) as this session's
+   *  turn — the engine's own dispatcher, not prompt text. */
+  command(
+    sessionID: string,
+    name: string,
+    args: string,
+    opts: { model?: string; agent?: string },
+  ): Promise<void>;
   replyPermission(
     sessionID: string,
     permissionID: string,
@@ -42,6 +53,23 @@ export interface OpenCodeTransport {
 }
 
 const START_DEADLINE_MS = envInt("MIRAFOLD_OPENCODE_START_TIMEOUT_MS", 20_000);
+
+/** One agent from `GET /agent` — `hidden: true` marks the engine's internal
+ *  primaries (compaction/summary/title), which no picker should offer. */
+export type OpenCodeAgentEntry = {
+  name: string;
+  mode: "primary" | "subagent";
+  hidden?: boolean;
+  description?: string;
+};
+
+/** One command from `GET /command` (built-ins + the user's own custom
+ *  commands) — dispatched faithfully via `POST /session/:id/command`. */
+export type OpenCodeCommandEntry = { name: string; description?: string };
+
+/** One model of a CONNECTED provider (`GET /config/providers`), the user's
+ *  own whitelist/blacklist already applied server-side. */
+export type OpenCodeModelEntry = { providerID: string; modelID: string; name?: string };
 
 /** An ephemeral localhost port. Classic listen-then-close: the tiny race
  *  window before opencode binds is acceptable on loopback. */
@@ -254,6 +282,67 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
     const res = await this.request("/config");
     const config = (await res.json()) as { model?: unknown };
     return typeof config.model === "string" && config.model ? config.model : undefined;
+  }
+
+  async agentCatalog(): Promise<OpenCodeAgentEntry[]> {
+    const res = await this.request("/agent");
+    const list = (await res.json()) as Record<string, unknown>[];
+    return list.map((a) => ({
+      name: String(a["name"]),
+      mode: a["mode"] === "subagent" ? "subagent" : "primary",
+      ...(a["hidden"] === true ? { hidden: true } : {}),
+      ...(typeof a["description"] === "string" && a["description"]
+        ? { description: a["description"] }
+        : {}),
+    }));
+  }
+
+  async commandCatalog(): Promise<OpenCodeCommandEntry[]> {
+    const res = await this.request("/command");
+    const list = (await res.json()) as Record<string, unknown>[];
+    return list.map((c) => ({
+      name: String(c["name"]),
+      ...(typeof c["description"] === "string" && c["description"]
+        ? { description: c["description"] }
+        : {}),
+    }));
+  }
+
+  async modelCatalog(): Promise<OpenCodeModelEntry[]> {
+    const res = await this.request("/config/providers");
+    const data = (await res.json()) as { providers?: unknown };
+    const list = Array.isArray(data.providers) ? data.providers : [];
+    const models: OpenCodeModelEntry[] = [];
+    for (const raw of list) {
+      const p = (raw ?? {}) as Record<string, unknown>;
+      const providerID = String(p["id"]);
+      for (const [modelID, model] of Object.entries((p["models"] ?? {}) as Record<string, unknown>)) {
+        const name = ((model ?? {}) as Record<string, unknown>)["name"];
+        models.push({
+          providerID,
+          modelID,
+          ...(typeof name === "string" && name ? { name } : {}),
+        });
+      }
+    }
+    return models;
+  }
+
+  async command(
+    sessionID: string,
+    name: string,
+    args: string,
+    opts: { model?: string; agent?: string },
+  ): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionID)}/command`, {
+      method: "POST",
+      body: JSON.stringify({
+        command: name,
+        ...(args ? { arguments: args } : {}),
+        ...(opts.model ? { model: opts.model } : {}),
+        ...(opts.agent ? { agent: opts.agent } : {}),
+      }),
+    });
   }
 
   async prompt(sessionID: string, body: Record<string, unknown>): Promise<void> {

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -115,18 +115,51 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
             (this.stderrTail ? `: ${this.stderrTail.trim().slice(-300)}` : ""),
         );
       try {
+        // Per-attempt abort is load-bearing, not hygiene: a connection made
+        // in the window between the port binding and the app serving is never
+        // answered, and awaiting it forever wedges start() past the deadline
+        // (observed live, OC.2 probe 2026-08-13). Abandon and re-poll.
         const res = await fetch(`${this.base}/global/health`, {
           headers: { authorization: this.auth },
+          signal: AbortSignal.timeout(1_000),
         });
         if (res.ok) break;
       } catch {
-        // not up yet
+        // not up yet (or the wedged-connection abort above)
       }
       if (Date.now() > deadline)
         throw new Error(`opencode serve did not become healthy within ${START_DEADLINE_MS}ms`);
       await delay(250);
     }
+    await this.waitForInjectedMcp(deadline);
     void this.pumpEvents(onEvent);
+  }
+
+  /** The engine's tool registry (and MCP connections) initialize lazily; a
+   *  prompt sent immediately after health races it and the model is offered
+   *  ZERO tools — observed live (OC.2 probe: request 1 carried no tools, so
+   *  the scripted render call bounced). The injected render server reporting
+   *  "connected" is the readiness signal start() actually promises. On
+   *  deadline we proceed anyway: the engine still converses, renders just
+   *  arrive with a later turn — degraded, not dead. */
+  private async waitForInjectedMcp(deadline: number): Promise<void> {
+    const injected = Object.keys((this.options.configContent["mcp"] as object | undefined) ?? {});
+    if (!injected.length) return;
+    while (Date.now() <= deadline && !this.closed) {
+      try {
+        const res = await fetch(`${this.base}/mcp`, {
+          headers: { authorization: this.auth },
+          signal: AbortSignal.timeout(1_000),
+        });
+        if (res.ok) {
+          const statuses = (await res.json()) as Record<string, { status?: string }>;
+          if (injected.every((name) => statuses[name]?.status === "connected")) return;
+        }
+      } catch {
+        // poll again
+      }
+      await delay(250);
+    }
   }
 
   /** Read the SSE stream for the server's whole life, reconnecting on drops. */

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -112,6 +112,10 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
        *  written, or created). A user's own OPENCODE_CONFIG_CONTENT env is
        *  superseded for sessions we spawn; their config FILES still load. */
       configContent: Record<string, unknown>;
+      /** Test seam: the spawned engine's base environment (default
+       *  process.env). The live itest jails HOME/XDG here so a REAL engine
+       *  run never reads or writes the developer's own opencode state. */
+      env?: Record<string, string | undefined>;
     },
   ) {}
 
@@ -128,7 +132,7 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
       {
         cwd: this.options.cwd,
         env: {
-          ...process.env,
+          ...(this.options.env ?? process.env),
           OPENCODE_CONFIG_CONTENT: JSON.stringify(this.options.configContent),
           OPENCODE_SERVER_PASSWORD: password,
         },

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -1,0 +1,225 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import net from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import { envInt } from "../env";
+import { errText } from "./types";
+
+/** One event off `GET /event` — `properties` is the engine's payload,
+ *  deliberately loose: shapes are locked by the OC.0 live capture (see
+ *  opencode.spike.md), and the published SDK types demonstrably drift from
+ *  the live server (permission.asked vs permission.updated), so we type at
+ *  the seam we verified rather than trust a generated union. */
+export type OpenCodeEvent = { type: string; properties: Record<string, unknown> };
+
+/** The transport seam between OpenCodeSession and a live `opencode serve` —
+ *  swapped for a fake in Tier-1 tests. */
+export interface OpenCodeTransport {
+  /** Spawn + health-check the server and subscribe the event stream. */
+  start(onEvent: (ev: OpenCodeEvent) => void): Promise<void>;
+  createSession(): Promise<{ id: string }>;
+  sessionExists(id: string): Promise<boolean>;
+  /** POST /session/:id/prompt_async — resolves once the engine ACCEPTED the
+   *  prompt; the turn itself streams back over events. */
+  prompt(sessionID: string, body: Record<string, unknown>): Promise<void>;
+  abort(sessionID: string): Promise<void>;
+  replyPermission(
+    sessionID: string,
+    permissionID: string,
+    // Never "always": that would persist an approval into the user's own
+    // OpenCode state, which is theirs to grant in their own tool.
+    response: "once" | "reject",
+  ): Promise<void>;
+  close(): void;
+}
+
+const START_DEADLINE_MS = envInt("MIRAFOLD_OPENCODE_START_TIMEOUT_MS", 20_000);
+
+/** An ephemeral localhost port. Classic listen-then-close: the tiny race
+ *  window before opencode binds is acceptable on loopback. */
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.once("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const address = srv.address();
+      srv.close(() =>
+        typeof address === "object" && address
+          ? resolve(address.port)
+          : reject(new Error("no port assigned")),
+      );
+    });
+  });
+}
+
+/**
+ * Production transport: one `opencode serve` per session (the server is
+ * project-scoped by cwd), driven raw over its documented HTTP + SSE surface.
+ * Deliberately no `@opencode-ai/sdk` (decision finalized at OC.1): the live
+ * probe caught the generated types drifting from the real server, our surface
+ * is six endpoints + an SSE parse, and zero dependencies beats stale types —
+ * the shapes we rely on are the ones OC.0 captured.
+ */
+export class OpenCodeServerProcess implements OpenCodeTransport {
+  private child?: ChildProcess;
+  private base = "";
+  private auth = "";
+  private closed = false;
+  private stderrTail = "";
+
+  constructor(
+    private readonly options: {
+      bin: string;
+      cwd: string;
+      /** Serialized into OPENCODE_CONFIG_CONTENT — the additive, file-free
+       *  injection path (trust rule: no user-owned config is read differently,
+       *  written, or created). A user's own OPENCODE_CONFIG_CONTENT env is
+       *  superseded for sessions we spawn; their config FILES still load. */
+      configContent: Record<string, unknown>;
+    },
+  ) {}
+
+  async start(onEvent: (ev: OpenCodeEvent) => void): Promise<void> {
+    const port = await freePort();
+    // The port is loopback-bound but otherwise open to any local process;
+    // basic auth with a per-session secret closes that (spike §surface).
+    const password = randomBytes(24).toString("hex");
+    this.base = `http://127.0.0.1:${port}`;
+    this.auth = "Basic " + Buffer.from(`opencode:${password}`).toString("base64");
+    const child = spawn(
+      this.options.bin,
+      ["serve", "--port", String(port), "--hostname", "127.0.0.1"],
+      {
+        cwd: this.options.cwd,
+        env: {
+          ...process.env,
+          OPENCODE_CONFIG_CONTENT: JSON.stringify(this.options.configContent),
+          OPENCODE_SERVER_PASSWORD: password,
+        },
+        stdio: ["ignore", "ignore", "pipe"],
+      },
+    );
+    this.child = child;
+    let spawnError: string | undefined;
+    child.once("error", (err) => (spawnError = errText(err)));
+    child.stderr?.on("data", (chunk: Buffer) => {
+      this.stderrTail = (this.stderrTail + chunk.toString()).slice(-2000);
+    });
+    const deadline = Date.now() + START_DEADLINE_MS;
+    for (;;) {
+      if (this.closed) throw new Error("session closed during startup");
+      if (spawnError) throw new Error(`could not start opencode (${this.options.bin}): ${spawnError}`);
+      if (child.exitCode !== null)
+        throw new Error(
+          `opencode serve exited (code ${child.exitCode}) before becoming healthy` +
+            (this.stderrTail ? `: ${this.stderrTail.trim().slice(-300)}` : ""),
+        );
+      try {
+        const res = await fetch(`${this.base}/global/health`, {
+          headers: { authorization: this.auth },
+        });
+        if (res.ok) break;
+      } catch {
+        // not up yet
+      }
+      if (Date.now() > deadline)
+        throw new Error(`opencode serve did not become healthy within ${START_DEADLINE_MS}ms`);
+      await delay(250);
+    }
+    void this.pumpEvents(onEvent);
+  }
+
+  /** Read the SSE stream for the server's whole life, reconnecting on drops. */
+  private async pumpEvents(onEvent: (ev: OpenCodeEvent) => void): Promise<void> {
+    while (!this.closed) {
+      try {
+        const res = await fetch(`${this.base}/event`, { headers: { authorization: this.auth } });
+        if (!res.ok || !res.body) throw new Error(`event stream HTTP ${res.status}`);
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buffer = "";
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buffer += decoder.decode(value, { stream: true });
+          let boundary;
+          while ((boundary = buffer.indexOf("\n\n")) >= 0) {
+            const chunk = buffer.slice(0, boundary);
+            buffer = buffer.slice(boundary + 2);
+            const data = chunk.split("\n").find((line) => line.startsWith("data: "));
+            if (!data) continue;
+            try {
+              onEvent(JSON.parse(data.slice(6)) as OpenCodeEvent);
+            } catch {
+              // one unparseable frame must not kill the stream
+            }
+          }
+        }
+      } catch {
+        // fall through to reconnect
+      }
+      if (!this.closed) await delay(500);
+    }
+  }
+
+  private async request(pathname: string, init?: RequestInit): Promise<Response> {
+    const res = await fetch(`${this.base}${pathname}`, {
+      ...init,
+      headers: {
+        authorization: this.auth,
+        "content-type": "application/json",
+        ...(init?.headers ?? {}),
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      throw new Error(`opencode ${pathname} HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+    }
+    return res;
+  }
+
+  async createSession(): Promise<{ id: string }> {
+    const res = await this.request("/session", { method: "POST", body: "{}" });
+    return (await res.json()) as { id: string };
+  }
+
+  async sessionExists(id: string): Promise<boolean> {
+    try {
+      await this.request(`/session/${encodeURIComponent(id)}`);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async prompt(sessionID: string, body: Record<string, unknown>): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionID)}/prompt_async`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    });
+  }
+
+  async abort(sessionID: string): Promise<void> {
+    await this.request(`/session/${encodeURIComponent(sessionID)}/abort`, {
+      method: "POST",
+      body: "{}",
+    });
+  }
+
+  async replyPermission(
+    sessionID: string,
+    permissionID: string,
+    response: "once" | "reject",
+  ): Promise<void> {
+    await this.request(
+      `/session/${encodeURIComponent(sessionID)}/permissions/${encodeURIComponent(permissionID)}`,
+      { method: "POST", body: JSON.stringify({ response }) },
+    );
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.child?.kill();
+  }
+}

--- a/server/adapters/opencode-commands.ts
+++ b/server/adapters/opencode-commands.ts
@@ -1,0 +1,165 @@
+import type { PromptOption, WireMsg } from "../protocol";
+import { emitPromptOptions, errText } from "./types";
+import { emitModelPicker } from "./model-picker";
+import type {
+  OpenCodeAgentEntry,
+  OpenCodeCommandEntry,
+  OpenCodeModelEntry,
+} from "./opencode-client";
+
+type Emit = (message: WireMsg) => void;
+
+// OpenCode's TUI default primary agent — what runs before any explicit pick.
+export const OPENCODE_DEFAULT_AGENT = "build";
+
+/** Slash commands use the same visible turn envelope as engine turns. */
+async function runSlashTurn(emit: Emit, body: () => Promise<void> | void): Promise<void> {
+  emit({ type: "status", state: "thinking" });
+  try {
+    await body();
+  } finally {
+    emit({ type: "turn_end" });
+  }
+}
+
+/** `/model` + `/agent` are Mirafold's own re-skins (no source badge); the
+ *  engine's command catalog rides behind them, badged `opencode` because the
+ *  descriptions are the engine's/user's own text. */
+export function opencodeSlashOptions(engineCommands: OpenCodeCommandEntry[]): PromptOption[] {
+  return [
+    {
+      trigger: "/",
+      value: "/model",
+      label: "model",
+      description: "choose what model to use",
+      kind: "command",
+    },
+    {
+      trigger: "/",
+      value: "/agent",
+      label: "agent",
+      description: "switch the OpenCode agent (build, plan, …)",
+      kind: "command",
+    },
+    ...engineCommands.map(
+      (command): PromptOption => ({
+        trigger: "/",
+        value: `/${command.name}`,
+        label: command.name,
+        ...(command.description ? { description: command.description } : {}),
+        kind: "command",
+        source: "opencode",
+      }),
+    ),
+  ];
+}
+
+export function runOpenCodeModelCommand(options: {
+  arg: string;
+  emit: Emit;
+  /** Models of ALLOWED providers only — the picker never offers a row the
+   *  policy would refuse; a typed blocked pick still refuses with its reason
+   *  through `setModel`. */
+  listModels: () => Promise<OpenCodeModelEntry[]>;
+  isCurrent: (providerID: string, modelID: string) => boolean;
+  /** Resolves to a refusal/usage reason, or undefined on success. */
+  setModel: (id: string) => Promise<string | undefined>;
+}): Promise<void> {
+  const { arg, emit, listModels, isCurrent, setModel } = options;
+  return runSlashTurn(emit, async () => {
+    if (arg === "") {
+      let models: OpenCodeModelEntry[];
+      try {
+        models = await listModels();
+      } catch (error) {
+        emit({
+          type: "error",
+          message: `Could not read the model list from opencode: ${errText(error)}`,
+        });
+        return;
+      }
+      emitModelPicker(
+        emit,
+        models.map((model) => ({
+          id: `${model.providerID}/${model.modelID}`,
+          displayName: `${model.providerID}/${model.modelID}`,
+          description: model.name && model.name !== model.modelID ? model.name : "",
+          current: isCurrent(model.providerID, model.modelID),
+        })),
+        {
+          clickText: (id) => `/model ${id}`,
+          switchHint: "Send `/model <provider>/<model>` to switch.",
+        },
+      );
+    } else if (/\s/.test(arg) || arg.startsWith("-")) {
+      emit({ type: "text_delta", text: "Usage: `/model` to pick, or `/model <provider>/<model>`." });
+    } else {
+      const reason = await setModel(arg);
+      if (reason) emit({ type: "error", message: reason });
+      else emit({ type: "text_delta", text: `Model set to ${arg}.` });
+    }
+  });
+}
+
+export function runOpenCodeAgentCommand(options: {
+  arg: string;
+  emit: Emit;
+  listAgents: () => Promise<OpenCodeAgentEntry[]>;
+  currentAgent: string;
+  setAgent: (name: string) => void;
+}): Promise<void> {
+  const { arg, emit, listAgents, currentAgent, setAgent } = options;
+  return runSlashTurn(emit, async () => {
+    let agents: OpenCodeAgentEntry[];
+    try {
+      agents = (await listAgents()).filter((a) => a.mode === "primary" && !a.hidden);
+    } catch (error) {
+      emit({
+        type: "error",
+        message: `Could not read the agent list from opencode: ${errText(error)}`,
+      });
+      return;
+    }
+    if (arg === "") {
+      emitModelPicker(
+        emit,
+        agents.map((agent) => ({
+          id: agent.name,
+          displayName: agent.name,
+          description: agent.description ?? "",
+          current: agent.name === currentAgent,
+        })),
+        {
+          clickText: (id) => `/agent ${id}`,
+          switchHint: "Send `/agent <name>` to switch.",
+          question: "Select an agent",
+        },
+      );
+    } else if (agents.some((a) => a.name === arg)) {
+      setAgent(arg);
+      emit({ type: "text_delta", text: `Agent set to ${arg}.` });
+    } else {
+      emit({
+        type: "text_delta",
+        text: `Usage: \`/agent\` to pick, or \`/agent <name>\` (${agents.map((a) => a.name).join(", ")}).`,
+      });
+    }
+  });
+}
+
+export function refreshOpenCodePromptOptions(options: {
+  emit: Emit;
+  listCommands: () => Promise<OpenCodeCommandEntry[]>;
+  isClosed: () => boolean;
+}): void {
+  // The Mirafold re-skins are useful immediately; the engine catalog fills
+  // in asynchronously (and its absence costs only those rows).
+  emitPromptOptions(options.emit, opencodeSlashOptions([]));
+  options
+    .listCommands()
+    .then((commands) => {
+      if (options.isClosed() || !commands.length) return;
+      emitPromptOptions(options.emit, opencodeSlashOptions(commands));
+    })
+    .catch(() => {});
+}

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -29,6 +29,12 @@ type TurnTokens = { input: number; output: number; cost: number };
  */
 export class OpenCodeEventMapper {
   private parts = new Map<string, PartTrack>();
+  // messageID → role. The stream echoes the USER message's parts exactly like
+  // assistant ones (observed live, OC.2 probe); without this the user's own
+  // prompt — guidance prefix included — replays into the transcript as
+  // text_delta. message.updated always precedes a message's parts (OC.0/OC.2
+  // captures), so an unknown role is treated as assistant.
+  private roles = new Map<string, string>();
   // Per assistant message, latest token/cost report — summed at idle into the
   // turn's one `usage`. Cleared each startTurn so only this turn counts.
   private turnUsage = new Map<string, TurnTokens>();
@@ -132,6 +138,7 @@ export class OpenCodeEventMapper {
   private onMessage(p: Record<string, unknown>) {
     const info = p["info"] as Record<string, unknown> | undefined;
     if (!info || !this.options.isOurs(info["sessionID"] ?? p["sessionID"])) return;
+    if (typeof info["role"] === "string") this.roles.set(String(info["id"]), info["role"]);
     if (info["role"] !== "assistant") return;
     const modelID = typeof info["modelID"] === "string" ? info["modelID"] : undefined;
     if (modelID) {
@@ -185,14 +192,17 @@ export class OpenCodeEventMapper {
     if (!part || !this.options.isOurs(part["sessionID"] ?? p["sessionID"])) return;
     const partID = String(part["id"]);
     const type = String(part["type"]);
+    const fromUser = this.roles.get(String(part["messageID"])) === "user";
     switch (type) {
       case "step-start":
         this.status("thinking");
         break;
       case "text":
+        if (fromUser) break; // the prompt's own echo — never replayed as output
         this.emitTextSuffix(this.track(partID, "text"), String(part["text"] ?? ""));
         break;
       case "reasoning":
+        if (fromUser) break;
         this.status("thinking");
         this.emitTextSuffix(this.track(partID, "reasoning"), String(part["text"] ?? ""));
         break;
@@ -205,6 +215,7 @@ export class OpenCodeEventMapper {
   private onPartDelta(p: Record<string, unknown>) {
     if (!this.options.isOurs(p["sessionID"])) return;
     if (p["field"] !== "text") return;
+    if (this.roles.get(String(p["messageID"])) === "user") return;
     // Deltas can beat the part's first snapshot; an unknown part defaults to
     // text (reasoning parts snapshot before streaming in the OC.0 capture).
     const track = this.track(String(p["partID"]), "text");

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -1,0 +1,365 @@
+import { randomUUID } from "node:crypto";
+import type { WireMsg } from "../protocol";
+import { capOutput, toolDetail, type TodoItem } from "./types";
+import { generativeUIMsg, MIRAFOLD_MCP, RENDER_ID_RE } from "./render-mcp-cmd";
+import type { OpenCodeEvent } from "./opencode-client";
+
+// OpenCode advertises MCP tools as `<server>_<tool>` (OC.0 capture:
+// `mirafold_render_card`), so this prefix is the recognition test.
+const MCP_PREFIX = `${MIRAFOLD_MCP}_`;
+
+type PartKind = "text" | "reasoning" | "tool" | "other";
+
+type PartTrack = {
+  kind: PartKind;
+  // Characters already sent as deltas — the final part snapshot repeats the
+  // full text, so emission is always "the suffix beyond this mark". Handles
+  // both live streams (delta events) and buffered parts (snapshot only).
+  emitted: number;
+  announced?: boolean;
+  finished?: boolean;
+};
+
+type TurnTokens = { input: number; output: number; cost: number };
+
+/**
+ * Normalizes the OpenCode event stream (shapes locked by the OC.0 live
+ * capture — see opencode.spike.md) into WireMsg. Session-scoped state only;
+ * the owning OpenCodeSession supplies turn lifecycle and permission plumbing.
+ */
+export class OpenCodeEventMapper {
+  private parts = new Map<string, PartTrack>();
+  // Per assistant message, latest token/cost report — summed at idle into the
+  // turn's one `usage`. Cleared each startTurn so only this turn counts.
+  private turnUsage = new Map<string, TurnTokens>();
+  private lastModel?: string;
+  private lastStatus?: "thinking" | "tool";
+  private todoRenderId?: string;
+
+  constructor(
+    private readonly options: {
+      emit: (msg: WireMsg) => void;
+      workspaceDir: string;
+      /** The one session this mapper narrates. Subagent child sessions share
+       *  the event stream under their own ids and are skipped whole — their
+       *  work surfaces through the parent's `task` tool part. */
+      isOurs: (sessionID: unknown) => boolean;
+      learnModel: (modelID: string) => void;
+      onPermissionAsked: (ask: {
+        id: string;
+        permission: string;
+        detail: string;
+      }) => void;
+      /** A reply observed on the stream (answered by another client, e.g. a
+       *  TUI attached to the same engine session) — not our own echo. */
+      onPermissionReplied: (requestID: string, reply: string) => void;
+      endTurn: () => void;
+    },
+  ) {}
+
+  startTurn() {
+    this.turnUsage.clear();
+    this.lastStatus = undefined;
+  }
+
+  endTurn() {
+    this.todoRenderId = undefined;
+    this.lastStatus = undefined;
+  }
+
+  handle(event: OpenCodeEvent) {
+    const p = event.properties ?? {};
+    switch (event.type) {
+      case "message.updated":
+        this.onMessage(p);
+        break;
+      case "message.part.updated":
+        this.onPartSnapshot(p);
+        break;
+      case "message.part.delta":
+        this.onPartDelta(p);
+        break;
+      case "session.status":
+        if (this.options.isOurs(p["sessionID"]) && this.statusType(p) === "busy")
+          this.status("thinking");
+        break;
+      case "todo.updated":
+        if (this.options.isOurs(p["sessionID"])) this.onTodos(p["todos"]);
+        break;
+      case "permission.asked": {
+        if (!this.options.isOurs(p["sessionID"])) break;
+        const patterns = Array.isArray(p["patterns"]) ? p["patterns"].map(String) : [];
+        this.options.onPermissionAsked({
+          id: String(p["id"]),
+          permission: String(p["permission"] ?? "tool"),
+          detail: patterns.join(", ") || String(p["permission"] ?? ""),
+        });
+        break;
+      }
+      case "permission.replied":
+        if (this.options.isOurs(p["sessionID"]))
+          this.options.onPermissionReplied(String(p["requestID"]), String(p["reply"]));
+        break;
+      case "session.error": {
+        // `sessionID` can be absent on transport-level errors; treat those as
+        // ours rather than swallow them.
+        if (p["sessionID"] !== undefined && !this.options.isOurs(p["sessionID"])) break;
+        this.options.emit({ type: "error", message: `OpenCode error: ${sessionErrorText(p)}` });
+        this.options.endTurn();
+        break;
+      }
+      case "session.idle":
+        if (!this.options.isOurs(p["sessionID"])) break;
+        this.flushUsage();
+        this.options.endTurn();
+        break;
+    }
+  }
+
+  private statusType(p: Record<string, unknown>): string | undefined {
+    const status = p["status"];
+    if (typeof status === "object" && status !== null)
+      return String((status as Record<string, unknown>)["type"]);
+    return undefined;
+  }
+
+  private status(state: "thinking" | "tool", label?: string) {
+    if (this.lastStatus === state) return;
+    this.lastStatus = state;
+    this.options.emit({ type: "status", state, ...(label ? { label } : {}) });
+  }
+
+  private onMessage(p: Record<string, unknown>) {
+    const info = p["info"] as Record<string, unknown> | undefined;
+    if (!info || !this.options.isOurs(info["sessionID"] ?? p["sessionID"])) return;
+    if (info["role"] !== "assistant") return;
+    const modelID = typeof info["modelID"] === "string" ? info["modelID"] : undefined;
+    if (modelID) {
+      this.lastModel = modelID;
+      this.options.learnModel(modelID);
+    }
+    const tokens = info["tokens"] as Record<string, unknown> | undefined;
+    if (tokens) {
+      this.turnUsage.set(String(info["id"]), {
+        input: num(tokens["input"]),
+        // `reasoning` is reported separately and NOT folded in — mirror of the
+        // codex adapter's choice: the status bar counts billed output.
+        output: num(tokens["output"]),
+        cost: num(info["cost"]),
+      });
+    }
+  }
+
+  /** The turn's one usage message, just before turn_end (protocol contract). */
+  private flushUsage() {
+    if (!this.turnUsage.size) return;
+    let input = 0;
+    let output = 0;
+    let cost = 0;
+    for (const t of this.turnUsage.values()) {
+      input += t.input;
+      output += t.output;
+      cost += t.cost;
+    }
+    this.options.emit({
+      type: "usage",
+      ...(this.lastModel ? { model: this.lastModel } : {}),
+      inputTokens: input,
+      outputTokens: output,
+      ...(cost > 0 ? { costUsd: cost } : {}),
+    });
+    this.turnUsage.clear();
+  }
+
+  private track(partID: string, kind: PartKind): PartTrack {
+    let track = this.parts.get(partID);
+    if (!track) {
+      track = { kind, emitted: 0 };
+      this.parts.set(partID, track);
+    }
+    return track;
+  }
+
+  private onPartSnapshot(p: Record<string, unknown>) {
+    const part = p["part"] as Record<string, unknown> | undefined;
+    if (!part || !this.options.isOurs(part["sessionID"] ?? p["sessionID"])) return;
+    const partID = String(part["id"]);
+    const type = String(part["type"]);
+    switch (type) {
+      case "step-start":
+        this.status("thinking");
+        break;
+      case "text":
+        this.emitTextSuffix(this.track(partID, "text"), String(part["text"] ?? ""));
+        break;
+      case "reasoning":
+        this.status("thinking");
+        this.emitTextSuffix(this.track(partID, "reasoning"), String(part["text"] ?? ""));
+        break;
+      case "tool":
+        this.onToolPart(partID, part);
+        break;
+    }
+  }
+
+  private onPartDelta(p: Record<string, unknown>) {
+    if (!this.options.isOurs(p["sessionID"])) return;
+    if (p["field"] !== "text") return;
+    // Deltas can beat the part's first snapshot; an unknown part defaults to
+    // text (reasoning parts snapshot before streaming in the OC.0 capture).
+    const track = this.track(String(p["partID"]), "text");
+    const delta = String(p["delta"] ?? "");
+    if (!delta || track.kind === "tool" || track.kind === "other") return;
+    track.emitted += delta.length;
+    this.options.emit({
+      type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
+      text: delta,
+    });
+  }
+
+  private emitTextSuffix(track: PartTrack, text: string) {
+    if (text.length <= track.emitted) return;
+    const suffix = text.slice(track.emitted);
+    track.emitted = text.length;
+    this.options.emit({
+      type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
+      text: suffix,
+    });
+  }
+
+  private onToolPart(partID: string, part: Record<string, unknown>) {
+    const track = this.track(partID, "tool");
+    track.kind = "tool";
+    const tool = String(part["tool"] ?? "");
+    const state = (part["state"] ?? {}) as Record<string, unknown>;
+    const status = String(state["status"] ?? "");
+    const input = (state["input"] ?? {}) as Record<string, unknown>;
+    if (tool.startsWith(MCP_PREFIX)) {
+      this.onMirafoldTool(partID, track, tool, state, input);
+      return;
+    }
+    if (status === "running" || status === "completed" || status === "error")
+      this.announceTool(track, partID, tool, input);
+    if (track.finished) return;
+    if (status === "completed") {
+      track.finished = true;
+      const { text, truncatedBytes } = capOutput(String(state["output"] ?? ""));
+      this.options.emit({
+        type: "tool_result",
+        output: text,
+        id: partID,
+        ...(truncatedBytes ? { truncatedBytes } : {}),
+      });
+    } else if (status === "error") {
+      track.finished = true;
+      this.options.emit({
+        type: "tool_result",
+        output: String(state["error"] ?? "tool failed"),
+        isError: true,
+        id: partID,
+      });
+    }
+  }
+
+  private announceTool(
+    track: PartTrack,
+    partID: string,
+    tool: string,
+    input: Record<string, unknown>,
+  ) {
+    if (track.announced) return;
+    track.announced = true;
+    this.status("tool", tool);
+    this.options.emit({
+      type: "tool_use",
+      name: tool,
+      detail: toolDetail(input),
+      id: partID,
+      input,
+    });
+  }
+
+  /** A Mirafold render/artifact call: the stub validated the args and acked
+   *  with the component id; the paint happens here, from the part we watched
+   *  in the engine's own stream. No raw tool block for the recognized path —
+   *  the painting IS its transcript record. */
+  private onMirafoldTool(
+    partID: string,
+    track: PartTrack,
+    tool: string,
+    state: Record<string, unknown>,
+    input: Record<string, unknown>,
+  ) {
+    const status = String(state["status"] ?? "");
+    if (track.finished || (status !== "completed" && status !== "error")) return;
+    track.finished = true;
+    const renderTool = tool.slice(MCP_PREFIX.length);
+    const ackId = RENDER_ID_RE.exec(String(state["output"] ?? ""))?.[1];
+    const msg =
+      status === "completed" && ackId
+        ? generativeUIMsg(renderTool, input, ackId, this.options.workspaceDir)
+        : null;
+    if (msg) {
+      this.options.emit(msg);
+      return;
+    }
+    // Unrecognized render ack or a failed call: fall back to the honest tool
+    // record rather than silently dropping what the agent did.
+    this.announceTool(track, partID, tool, input);
+    this.options.emit({
+      type: "tool_result",
+      output: String(state["error"] ?? state["output"] ?? ""),
+      ...(status === "error" ? { isError: true as const } : {}),
+      id: partID,
+    });
+  }
+
+  private onTodos(todos: unknown) {
+    const list = Array.isArray(todos) ? todos : [];
+    // Never paint an empty checklist, but an emptied list must still update
+    // one already painted during this turn (same rule as the codex mapper).
+    if (!list.length && !this.todoRenderId) return;
+    this.todoRenderId ??= randomUUID();
+    const items: TodoItem[] = list.map((t) => {
+      const todo = (t ?? {}) as Record<string, unknown>;
+      const status = String(todo["status"] ?? "pending");
+      return {
+        content: String(todo["content"] ?? ""),
+        status:
+          status === "completed" || status === "in_progress"
+            ? (status as TodoItem["status"])
+            : "pending",
+      };
+    });
+    this.options.emit({
+      type: "render",
+      component: "todo-list",
+      props: { todos: items },
+      id: this.todoRenderId,
+    });
+  }
+}
+
+function num(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+/** Best human text out of a session.error payload without trusting a shape:
+ *  {error: {data: {message}}} (observed), {error: {message|name}}, or JSON. */
+function sessionErrorText(p: Record<string, unknown>): string {
+  const error = p["error"];
+  if (typeof error === "object" && error !== null) {
+    const e = error as Record<string, unknown>;
+    const data = e["data"];
+    if (typeof data === "object" && data !== null) {
+      const message = (data as Record<string, unknown>)["message"];
+      if (typeof message === "string" && message) return message;
+    }
+    for (const key of ["message", "name"]) {
+      const value = e[key];
+      if (typeof value === "string" && value) return value;
+    }
+  }
+  const json = JSON.stringify(error ?? p);
+  return json && json !== "{}" ? json.slice(0, 300) : "unknown error";
+}

--- a/server/adapters/opencode-live.ltest.ts
+++ b/server/adapters/opencode-live.ltest.ts
@@ -1,0 +1,214 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import type { WireMsg } from "../protocol";
+import { OpenCodeSession } from "./opencode";
+import { OpenCodeServerProcess } from "./opencode-client";
+
+// Tier 4 — the REAL opencode binary, driven end to end (PLAN OC.5).
+//
+// Tier 1 hand-feeds captured event shapes; this tier proves the actual
+// engine still speaks them: `opencode serve` spawned by the production
+// transport, the render MCP injected through OPENCODE_CONFIG_CONTENT, a
+// permission ask surfacing headless and answered through the production
+// bridge, and engine-side session persistence carrying a resume.
+//
+// The codex-tier bound holds: real binary, yes; real HOSTED model, never.
+// The model is a scripted OpenAI-compatible endpoint on loopback (the OC.2
+// probe recipe): deterministic turns, zero network, zero spend. HOME and
+// XDG are jailed to throwaway dirs so a real engine run never reads or
+// writes the developer's own opencode state (config, auth, sessions).
+//
+// Skips cleanly when opencode isn't installed (OPENCODE_BIN or PATH).
+
+function opencodeBin(): string | undefined {
+  if (process.env.OPENCODE_BIN) return process.env.OPENCODE_BIN;
+  const found = spawnSync("which", ["opencode"], { encoding: "utf8" });
+  const bin = found.status === 0 ? found.stdout.trim() : "";
+  return bin || undefined;
+}
+
+const BIN = opencodeBin();
+
+type Any = WireMsg & Record<string, any>;
+
+const waitFor = (cond: () => boolean, what: string, timeoutMs = 60_000) =>
+  new Promise<void>((resolve, reject) => {
+    const t0 = Date.now();
+    const poll = setInterval(() => {
+      if (cond()) {
+        clearInterval(poll);
+        resolve();
+      } else if (Date.now() - t0 > timeoutMs) {
+        clearInterval(poll);
+        reject(new Error(`timed out waiting for ${what}`));
+      }
+    }, 25);
+  });
+
+/** The scripted model: keeps requesting the render until its ack is in
+ *  history (rides out the engine's cold first call carrying zero tools —
+ *  see opencode.spike.md), then a permission-gated bash on the probe turn. */
+function startFakeModel(): Promise<{ port: number; close: () => void }> {
+  let n = 0;
+  const sse = (res: http.ServerResponse, obj: unknown) =>
+    res.write(`data: ${JSON.stringify(obj)}\n\n`);
+  const server = http.createServer((req, res) => {
+    let body = "";
+    req.on("data", (c) => (body += c));
+    req.on("end", () => {
+      n++;
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      const base = { id: `c${n}`, object: "chat.completion.chunk", created: 1, model: "fake-model" };
+      const messages: { role: string; content?: unknown }[] = JSON.parse(body || "{}").messages ?? [];
+      const flat = JSON.stringify(messages);
+      const toolCall = (name: string, args: unknown) => {
+        sse(res, {
+          ...base,
+          choices: [
+            {
+              index: 0,
+              delta: {
+                role: "assistant",
+                tool_calls: [
+                  { index: 0, id: `call_${n}`, type: "function", function: { name, arguments: JSON.stringify(args) } },
+                ],
+              },
+              finish_reason: null,
+            },
+          ],
+        });
+        sse(res, { ...base, choices: [{ index: 0, delta: {}, finish_reason: "tool_calls" }] });
+      };
+      const text = (content: string) => {
+        sse(res, { ...base, choices: [{ index: 0, delta: { role: "assistant", content }, finish_reason: null }] });
+        sse(res, {
+          ...base,
+          choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
+        });
+      };
+      const renderDone = flat.includes("Rendered card");
+      const probeTurn = flat.includes("probe command");
+      const bashDone = messages.some(
+        (m) => m.role === "tool" && /oc5-live/.test(JSON.stringify(m.content ?? "")),
+      );
+      if (!renderDone) toolCall("mirafold_render_card", { title: "Live Probe", body: "OC.5 end to end" });
+      else if (!probeTurn) text("CARD DONE");
+      else if (!bashDone) toolCall("bash", { command: "echo oc5-live", description: "probe" });
+      else text("BASH DONE");
+      res.write("data: [DONE]\n\n");
+      res.end();
+    });
+  });
+  return new Promise((resolve) => {
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      resolve({
+        port: typeof address === "object" && address ? address.port : 0,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+test("OC.5: real engine — render, permission, usage, resume, all through the shipped code", {
+  skip: BIN ? false : "opencode is not installed (set OPENCODE_BIN or install it)",
+  timeout: 180_000,
+}, async () => {
+  const model = await startFakeModel();
+  const home = mkdtempSync(path.join(os.tmpdir(), "mirafold-oc5-home-"));
+  const work = mkdtempSync(path.join(os.tmpdir(), "mirafold-oc5-work-"));
+  mkdirSync(path.join(home, ".config", "opencode"), { recursive: true });
+  writeFileSync(
+    path.join(home, ".config", "opencode", "opencode.json"),
+    JSON.stringify({
+      provider: {
+        fake: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Fake Local",
+          options: { baseURL: `http://127.0.0.1:${model.port}/v1` },
+          models: { "fake-model": { name: "Fake Model", tool_call: true } },
+        },
+      },
+      permission: { bash: "ask" },
+    }),
+  );
+  const jailedEnv = {
+    ...process.env,
+    HOME: home,
+    XDG_CONFIG_HOME: path.join(home, ".config"),
+    XDG_DATA_HOME: path.join(home, ".local", "share"),
+    XDG_CACHE_HOME: path.join(home, ".cache"),
+    XDG_STATE_HOME: path.join(home, ".state"),
+  };
+  const makeSession = (resumeId?: string) => {
+    const session = new OpenCodeSession({
+      workspaceDir: work,
+      model: "fake/fake-model",
+      resumeId,
+      makeTransport: (config) =>
+        new OpenCodeServerProcess({ bin: BIN as string, cwd: work, configContent: config, env: jailedEnv }),
+    });
+    const msgs: Any[] = [];
+    session.onMessage((m) => msgs.push(m as Any));
+    const turnEnds = () => msgs.filter((m) => m.type === "turn_end").length;
+    return { session, msgs, turnEnds };
+  };
+
+  const first = makeSession();
+  try {
+    const published: { kind: string; provider?: string }[] = [];
+    first.session.onBackendKind?.((u) => published.push(u));
+
+    // Turn 1: the render paints through the real MCP stub.
+    first.session.pushPrompt("paint a card please");
+    await waitFor(() => first.turnEnds() >= 1, "turn 1 (render)", 120_000);
+    const render = first.msgs.find((m) => m.type === "render" && m.component === "card");
+    assert.ok(render, "card rendered through the real engine");
+    assert.equal(render?.props?.["title"], "Live Probe");
+    assert.ok(first.msgs.some((m) => m.type === "text_delta" && /CARD DONE/.test(m.text)));
+    const usage = first.msgs.find((m) => m.type === "usage");
+    assert.ok((usage?.inputTokens ?? 0) > 0, "usage rode the turn");
+    assert.deepEqual(published, [{ kind: "local", provider: "fake" }], "kind published (config → local)");
+
+    // Turn 2: the permission round-trip, answered through the bridge.
+    first.session.pushPrompt("now run the probe command");
+    await waitFor(() => first.msgs.some((m) => m.type === "permission_request"), "the ask");
+    const ask = first.msgs.find((m) => m.type === "permission_request");
+    assert.equal(ask?.tool, "bash");
+    first.session.resolvePermission(ask!.id, true);
+    await waitFor(() => first.turnEnds() >= 2, "turn 2 (bash)", 120_000);
+    assert.ok(first.msgs.some((m) => m.type === "permission_resolved" && m.allow === true));
+    assert.ok(
+      first.msgs.some((m) => m.type === "tool_result" && /oc5-live/.test(m.output)),
+      "the engine really ran the command",
+    );
+    // The fake provider is the user's own config — no gray disclosure rides.
+    assert.equal(first.msgs.filter((m) => m.type === "notice").length, 0);
+
+    // Resume: engine-side persistence across a full server restart.
+    const resumeId = first.session.resumeId;
+    assert.ok(resumeId, "the engine session id was published");
+    first.session.close();
+
+    const second = makeSession(resumeId);
+    try {
+      second.session.pushPrompt("still with me?");
+      await waitFor(() => second.turnEnds() >= 1, "resumed turn", 120_000);
+      assert.equal(second.session.resumeId, resumeId, "reattached, not recreated");
+      assert.ok(second.msgs.some((m) => m.type === "text_delta" && /BASH DONE/.test(m.text)));
+    } finally {
+      second.session.close();
+    }
+  } finally {
+    first.session.close();
+    model.close();
+    rmSync(home, { recursive: true, force: true });
+    rmSync(work, { recursive: true, force: true });
+  }
+});

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -307,3 +307,34 @@ suggesting a persistent rule — reinforces the never-send-`always` call.
 i.e. Kyle): whether a *stored* credential's kind (oauth vs api) is
 readable from the running server for the OC.3 detection path — the jailed
 home had none to observe. Everything else in OC.0 is resolved.
+
+## OC.2 live leg (2026-08-13) — full loop GREEN through the real adapter
+
+The real `OpenCodeSession` drove a real spawned engine (fake provider, $0):
+a card **rendered end-to-end** (scripted `mirafold_render_card` → engine ran
+the real render-mcp.ts stub over stdio → ack id recognized → `render`
+WireMsg with exact props) and a **permission round-trip completed live**
+(`permission.asked` → shell bar shape → reply `once` → bash ran → result).
+Three findings, two of them adapter bugs fixed on the spot:
+
+1. **Health-poll wedge (fixed)**: a connection made between the port
+   binding and the app serving is never answered; without a per-attempt
+   abort the poll awaited it forever and the deadline never re-evaluated.
+   Per-attempt `AbortSignal.timeout` is load-bearing in the transport.
+2. **User-echo (fixed)**: the stream replays the USER message's parts in
+   the same snapshot/delta shapes as assistant output — without role
+   tracking the user's own prompt (guidance included) re-emitted as
+   `text_delta`. The mapper now records roles from `message.updated`
+   (which always precedes a message's parts) and skips user parts.
+3. **Cold first model call carries ZERO tools (upstream engine behavior,
+   documented not gated)**: on a freshly spawned server the first turn's
+   first model request has no tools — not even builtins — while the
+   engine's own follow-up request in the same turn has all of them.
+   Exhaustively probed: `/mcp` "connected", the `/experimental/tool`
+   preflight, and a 3s settle all pass while the first call still ships
+   toolless; model `toolcall: true` confirmed parsed. The engine
+   self-recovers (an invalid tool call is fed back and re-requested, now
+   with tools; a real model offered no tools just answers in text). Impact:
+   a cold session's first turn may reply without renders; every later turn
+   is fine. The transport's `/mcp` connected gate stays — it's the correct
+   half of readiness we CAN observe.

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -233,3 +233,69 @@ which spawns its own.
 Next actions, gated on Kyle: install the binary + connect a $0 provider,
 run the two live gates, lock the event/tool shapes, then phase the adapter
 into PLAN.md. The rest of the adapter can be written offline from the above.
+
+## Live probe results (2026-08-13) — both gates GREEN, $0, no credentials
+
+Ran `opencode-ai@1.18.18` scratchpad-local (npm install + manual
+postinstall; no global mutation), `HOME`/XDG jailed to the scratchpad so no
+user-owned file was read or written. Gate 2 needed no real provider: a
+**fake OpenAI-compatible endpoint** registered via config
+(`provider.fake = {npm: "@ai-sdk/openai-compatible", options.baseURL →
+localhost}`) scripted a bash tool call, which also logs the request body —
+revealing the full tool list the engine advertises. Raw captures in
+`scratchpad/oc-probe/` (events.ndjson, requests.ndjson, messages.json).
+
+**Gate 1 — MCP injection: PASSED.** `OPENCODE_CONFIG_CONTENT` alone loaded
+the render server: `GET /mcp` → `{"mirafold":{"status":"connected"}}`, and
+the model was offered all 18 tools named
+**`mirafold_render_card` … `mirafold_emit_artifact`** — underscore-joined
+`<server>_<tool>`, so recognition = `startsWith(MIRAFOLD_MCP + "_")`.
+The #20072 worry doesn't apply to additive entries.
+
+**Gate 2 — headless permissions: PASSED.** With `permission: {bash: "ask"}`
+the engine paused the tool (`status: running`) and emitted
+**`permission.asked`** — NOT `permission.updated` as the published SDK
+types said (real drift; trust live capture and pin the SDK version).
+Payload: `{id, sessionID, permission: "bash", patterns: ["echo
+mirafold-probe"], metadata: {command}, always: ["echo *"], tool:
+{messageID, callID}}`. Reply `POST /session/:id/permissions/:permID
+{response: "once"}` → `true` → bash executed and the turn completed
+(`permission.replied` observed). The `always` field is the engine
+suggesting a persistent rule — reinforces the never-send-`always` call.
+
+**Shapes locked for OC.1:**
+
+- **Streaming**: text arrives via **`message.part.delta`**
+  `{sessionID, messageID, partID, field: "text", delta}` — a true delta
+  channel (no accrual-diff needed); `message.part.updated` carries part
+  snapshots (tool state transitions land here). Turn end: `session.idle`.
+- **Usage**: per assistant message (`message.updated` / `GET
+  /session/:id/message`): `tokens: {total, input, output, reasoning,
+  cache: {read, write}}`, `cost`, and **`modelID` on every assistant
+  message** (fleet-row label solved).
+- **Event names beyond the fetched types** (1.18.18 live):
+  `permission.asked`, `permission.replied`, `message.part.delta`,
+  `session.diff`, `plugin.added`, `catalog.updated`, `server.heartbeat`.
+- **Catalogs**: `GET /agent` (primaries incl. internal ones — filter
+  `build`/`plan`-style user-facing from `compaction`/`summary`/`title`),
+  `GET /command` (`init`, `review`, `customize-opencode` built-in; feeds
+  `emitPromptOptions`), `GET /config/providers`, `GET /provider/auth`.
+
+**Two findings that reshape OC.3 slightly:**
+
+1. **1.18.18 offers NO Anthropic or Google OAuth** (`GET /provider/auth`
+   lists oauth for openai, github-copilot, gitlab, poe, digitalocean,
+   snowflake-cortex, xai only — presumably dropped after Anthropic's
+   April 2026 harness block). Our blocked rows stay (fail-closed, and
+   older/newer versions may differ) but the common path is unblocked.
+2. **A fresh install ships a working free provider**: "OpenCode Zen"
+   (`id: opencode`, `options.apiKey: "public"`, free models e.g.
+   `laguna-s-2.1-free`). So `agentHasCredentials("opencode")` can be true
+   out of the box — and the Zen provider needs its own policy row (their
+   own gateway, their terms; classify before OC.3 ships, fail-closed
+   until read).
+
+**Still open for OC.0's checkbox** (needs a real connected credential,
+i.e. Kyle): whether a *stored* credential's kind (oauth vs api) is
+readable from the running server for the OC.3 detection path — the jailed
+home had none to observe. Everything else in OC.0 is resolved.

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -192,6 +192,14 @@ The relay gate is untouched: `allowedOverRelay` already refuses
 
 ## SDK vs raw HTTP — recommendation: take `@opencode-ai/sdk`
 
+*(REVERSED at OC.1, 2026-08-13: the adapter drives the surface RAW, zero
+dependencies. The live probe below caught the published types drifting from
+the real server — `permission.asked` vs the types' `permission.updated` —
+which inverts this section's core argument: the generated types are not
+compile-time truth, and the shapes we actually rely on are the OC.0
+captures. Six endpoints + an SSE parse is squarely self-writable.
+opencode-client.ts records the decision at the seam.)*
+
 The dependency test, run explicitly: this is a **vendor's own SDK** (the
 "take it" case), and the sliver argument cuts the other way here — the value
 isn't the fetch wrapper (self-writable in an afternoon), it's the

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -308,6 +308,40 @@ i.e. Kyle): whether a *stored* credential's kind (oauth vs api) is
 readable from the running server for the OC.3 detection path — the jailed
 home had none to observe. Everything else in OC.0 is resolved.
 
+## OC.3 detection probe (2026-08-13) — the residual resolved by FIXTURE
+
+The "needs a real connected credential" residual didn't need one: the
+auth.json FORMAT is known (SDK `Auth` type), so a fixture credential in the
+jailed scratchpad home answers what the server exposes. Findings, all
+against 1.18.18 (`GET /config/providers`, the connected set):
+
+- **Classification needs no auth.json parsing by Mirafold, ever** — the
+  running engine's own catalog distinguishes everything: a stored API key
+  is `source: "api"`, an env key `"env"`, a user-config provider
+  `"config"`, and OAuth logins are `source: "custom"` with the literal
+  marker `options.apiKey === "opencode-oauth-dummy-key"` (Zen: `"public"`).
+- **The catalog leaks the RAW STORED SECRET** (`key: "fixture-key-123"`
+  came back verbatim) — the transport's `providerCatalog()` strips it at
+  the seam; nothing past that method can carry it.
+- **A stored anthropic OAuth credential is ignored wholesale** — the
+  provider never enters the connected set and `/provider/auth` offers no
+  Anthropic/Google OAuth flow. The blocked rows are belt-and-suspenders
+  for other engine versions, not a live path in 1.18.18.
+- `GET /config` exposes the user's own `model` default (absent when unset;
+  the engine's internal fallback pick is unobservable pre-turn) — so a
+  session needs a resolvable pin (OPENCODE_MODEL or config `model`) and
+  refuses with the exact fix named otherwise.
+
+Design landed (provider-policy.ts `classifyOpenCodeProvider` + opencode.ts
+`enforceProviderPolicy`): hello-time detection stays shallow (binary +
+auth.json EXISTENCE, the claude/codex precedent — contents unread), and
+the truthful provider-resolved verdict is enforced at session start from
+the catalog, refusing with human copy. The ChatGPT gray area is
+policy-ALLOWED but session-REFUSED until OC.4 flows the classified kind
+into `Backend` (the relay gate reads `Backend.kind`, and an optimistic
+"api-key" must never overstate a subscription's relay rights). Zen stays
+fail-closed until its terms are read and cited (OC.4/OC.5 gate).
+
 ## OC.2 live leg (2026-08-13) — full loop GREEN through the real adapter
 
 The real `OpenCodeSession` drove a real spawned engine (fake provider, $0):

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -1,0 +1,235 @@
+# OpenCode adapter — feasibility spike
+
+Dated 2026-08-13. Purpose: learn OpenCode's embedding surface before writing a
+fourth adapter, and settle the questions that decide whether it fits the
+`AgentSession` seam: drivability, MCP injection without touching user-owned
+files, permission bridging, and how the provider credential policy applies to
+a multi-provider harness. Sources: opencode.ai docs (server, config, mcp,
+providers, permissions, agents, commands), the published
+`@opencode-ai/sdk@1.18.18` generated types (fetched via jsDelivr), and
+anomalyco/opencode issue #20072. **No live probe ran** — the binary isn't
+installed in this environment — so every "confirm live" flag below is real.
+
+## Verdict: GREEN, with two live-verify gates before implementation starts
+
+OpenCode is drivable as its **own engine** — arguably the cleanest surface of
+the four: a headless HTTP server (`opencode serve`) with an OpenAPI 3.1 spec,
+a typed SSE event stream, native MCP loading, and (unlike the Codex SDK at
+spike time) a **first-class permission round-trip over the API**. Sessions are
+persistent server-side objects with stable ids (→ `resumeId` for free). No
+homegrown loop, no request-path proxy, no shared-code branches.
+
+The two gates that MUST be confirmed live before `opencode.ts` is written:
+
+1. **MCP injection via `OPENCODE_CONFIG_CONTENT` actually loads our render
+   server** (§MCP below — the merge is documented, but issue #20072 shows
+   inline config had at least one quirk in the `mcp` key's handling).
+2. **The permission ask actually surfaces as a `permission.updated` event
+   when driven over the server API** (docs describe the TUI; the types and
+   reply endpoint exist, but the headless flow is undocumented).
+
+## The surface we drive
+
+`opencode serve [--port N] [--hostname H]` — headless HTTP server, default
+`127.0.0.1:4096`. The adapter spawns one per session (or one shared, decided
+at implementation) via the standard `agentBin("OPENCODE_BIN", "opencode")`
+lookup, picks a free port itself (port-0 auto-assign unconfirmed), and sets
+`OPENCODE_SERVER_PASSWORD` to a per-session random secret — the port is
+localhost-bound but otherwise open to any local process, and basic auth is
+built in, so use it.
+
+Endpoints (from the docs + generated SDK client):
+
+- `POST /session` — create; response carries the session `id`.
+- `POST /session/:id/prompt_async` — send a prompt without blocking (the
+  sync `POST /session/:id/message` waits for the whole turn; we stream, so
+  async + events is our shape).
+- `POST /session/:id/abort` — halt the in-flight turn → `interrupt()`.
+- `POST /session/:id/permissions/:permissionID` — answer a permission ask.
+- `GET /event` — SSE stream of typed events (below).
+- `GET /doc` — OpenAPI 3.1 spec; `GET /global/health` — liveness + version.
+- Provider/model/agent/command catalogs are queryable (the SDK exposes
+  them; exact endpoint paths to read off `GET /doc` live).
+
+Prompt body (from the generated types): `parts` (text/file/agent/subtask
+inputs), optional `model: { providerID, modelID }`, optional `agent`
+(build/plan/custom), optional `system`, per-call `tools` enable/disable map.
+Model and agent are **per-prompt**, which makes the fleet-row model label and
+a faithful build/plan toggle straightforward.
+
+## Event → WireMsg mapping (the normalization the adapter implements)
+
+The SSE event union is large (31 types); the ones we consume:
+
+| OpenCode event                              | WireMsg                                             |
+|---------------------------------------------|-----------------------------------------------------|
+| `session.status`                            | `status:thinking` (turn activity)                   |
+| `message.part.updated`, part `step-start`   | `status:thinking`                                   |
+| `message.part.updated`, part `text`         | `text_delta` (parts arrive as growing snapshots — emit the suffix vs. what we already sent, same accrual trick as the Gemini adapter) |
+| `message.part.updated`, part `reasoning`    | `thinking_delta`                                    |
+| `message.part.updated`, tool `pending`/`running` | `status:tool` + `tool_use` (detail via `toolDetail`) |
+| `message.part.updated`, tool `completed`    | `tool_result` (`capOutput`; `title` is a bonus label) |
+| `message.part.updated`, tool `error`        | `tool_result` err=true (`error` text)               |
+| tool part where tool ∈ mirafold MCP         | skip the tool block; paint via `generativeUIMsg`    |
+| `todo.updated`                              | `render` checklist (`TodoItem` shape matches)       |
+| `permission.updated`                        | `permission_request` → answered via the reply endpoint |
+| `message.updated` (assistant msg, token/cost fields) | `usage` (field names to confirm live)      |
+| `session.idle`                              | `turn_end`                                          |
+| `session.error`                             | error notice — engine text, so `notice.source` badges it (shell-voice rule) |
+
+Not consumed (TUI/PTY/LSP/VCS chrome): `tui.*`, `pty.*`, `lsp.*`,
+`vcs.branch.updated`, `file.watcher.updated`, `installation.*`,
+`server.*`, `session.compacted`/`diff`/`created`/`updated`/`deleted`,
+`message.removed`, `message.part.removed`, `permission.replied`,
+`command.executed`, `file.edited` (the tool parts already carry edits).
+
+Every target WireMsg already exists — no protocol change beyond adding
+`"opencode"` to the `AgentName` union (additive; honors ADD-never-reshape).
+
+## Generative UI via MCP — satisfied, via env-var config injection
+
+OpenCode loads MCP servers from its config under the `mcp` key
+(`{"type": "local", "command": [...]}` — subprocess over stdio, exactly what
+`renderMcpCommand()` already packages for Codex and Gemini). The injection
+path that keeps the trust rule intact is **`OPENCODE_CONFIG_CONTENT`**:
+inline JSON config passed in the spawned server's environment, merged
+additively into the user's config chain (documented merge order puts it
+after global and project files; merge combines keys rather than replacing).
+**No file the user owns is read differently, written, or created** — the
+`.gemini/settings.json` failure mode structurally can't recur here.
+
+Caveats, both live-verify items:
+
+- Issue #20072 (closed "not planned") shows `OPENCODE_CONFIG_CONTENT` failing
+  to apply `enabled: false` to MCP entries. Our use is additive (a new server,
+  not disabling one), which is the documented merge behavior — but that issue
+  is proof the inline path has had sharp edges in exactly the `mcp` key.
+  Gate 1: verify our entry loads and its tools appear.
+- The user's own configured MCP servers also load at startup (same issue —
+  there is deliberately no way to suppress them). That's fidelity, not a bug:
+  their agent, their tools. Their tool calls normalize as ordinary
+  `tool_use`/`tool_result`.
+- How OpenCode names MCP tools in tool parts (`mirafold_render_card` vs a
+  server-qualified form) decides the recognition test against
+  `MIRAFOLD_MCP` — confirm the exact prefix live.
+
+## Permissions — a real API round-trip (better than the Codex SDK had)
+
+OpenCode's permission system (`allow`/`ask`/`deny`, per-tool with glob
+patterns, config-set) emits a `Permission` object: `{ id, type, pattern?,
+sessionID, messageID, callID?, title, metadata, time }` — and the reply is
+`POST /session/:id/permissions/:permissionID` with response
+`"once" | "always" | "reject"`.
+
+- Map `permission_request` ← `permission.updated`; `resolvePermission(id,
+  allow)` → `once` / `reject`. **Never send `"always"`** — it persists an
+  approval into the user's own OpenCode state, which is theirs to grant in
+  their own tool, not ours to write through a browser click.
+- `PERMISSION_TIMEOUT_MS` deny-by-default applies unchanged.
+- We set no permission config of our own: the user's `allow/ask/deny` rules
+  ride along untouched (inherit-don't-invent). Whatever asks in their
+  terminal OpenCode asks in Mirafold.
+- Gate 2: confirm the ask actually fires headless (not just in the TUI) and
+  that `abort` cleanly cancels a pending ask.
+
+## Credential policy — the adapter's real design work
+
+OpenCode is a multi-provider harness: 75+ providers, credentials in
+`~/.local/share/opencode/auth.json` via `opencode auth login` (`/connect`),
+typed `oauth` (subscription OAuth: **Anthropic Claude Pro/Max, OpenAI
+ChatGPT, GitHub Copilot, GitLab Duo**, …) or `api` (keys), plus env-var
+credential chains (Bedrock, Vertex). So `CredentialKind` is no longer a
+per-agent fact — it's a fact about the **provider the session's model
+resolves to**:
+
+- anthropic + `oauth` → `subscription` → **blocked** (written prohibition;
+  driving it through OpenCode instead of the Claude binary changes nothing).
+- google + `oauth` → `subscription` → **blocked** (same).
+- openai + `oauth` (ChatGPT) → `subscription` → the **disclosed gray area**,
+  same disclosure copy contract as the codex adapter's CONNECT_HINT.
+- any provider + `api` key / env chain → `api-key` → allowed; relay-eligible.
+- local providers (Ollama, LM Studio) → `local` → anything goes.
+- **any other provider + `oauth`** (Copilot, GitLab Duo, future ones) →
+  treated as `subscription` and **blocked until classified** — the same
+  fail-closed default `allowedOverRelay` uses for unknown kinds. Each gets a
+  cited row in `provider-policy.ts` only when its terms have actually been
+  read (Copilot is the one users will hit first; research it before launch
+  of this adapter, not after a complaint).
+
+Mechanically: `provider-policy.ts` grows a provider-id–keyed classification
+for OpenCode-backed sessions (the one-file rule holds — the matrix stays
+there, the adapter only calls it). `Backend.provider` (added for Codex)
+already carries the chosen provider id. Detection order: prefer asking the
+**running server** (the provider catalog reports each provider's source and
+models; the SDK's `Auth` type distinguishes `oauth`/`api`) over reading
+`auth.json` ourselves — the file is user-owned state, and the API tells us
+what we need without us parsing their credential store. Confirm live that
+the provider catalog actually exposes enough to classify without touching
+`auth.json`; if it doesn't, reading that file needs the same explicit
+consent framing as any user-owned state (trust rule), or we ask the user to
+pick the provider at onboarding and verify against the catalog.
+
+The relay gate is untouched: `allowedOverRelay` already refuses
+`subscription` regardless of which adapter produced it.
+
+## Faithful-skin surface (what an OpenCode user expects to see)
+
+- **Agents**: `build` (default) and `plan` primaries, custom agents from
+  their config; selected per-prompt via the `agent` field. Mirafold surfaces
+  the same toggle (their Tab-cycle, our UI) — catalog queryable from the
+  server.
+- **Commands**: built-ins (`/init`, `/undo`, `/redo`, `/share`, `/help`) +
+  custom commands from their files; feed `emitPromptOptions` if the catalog
+  is exposed over the API (SDK suggests yes — confirm; if not, the
+  optional-feature rule covers absence).
+- **Models**: the provider catalog drives a real cross-provider model picker
+  (their whitelist/blacklist config already applied server-side).
+  `modelName` = the per-prompt `modelID`, known at selection — better than
+  the mid-stream refinement the other adapters need.
+- **Subagents** (`@general`, `@explore`, `@scout`): their invocations arrive
+  as `subtask`/`agent` parts — v1 renders them as ordinary transcript
+  activity; child-session navigation is TUI chrome we don't reproduce.
+
+## SDK vs raw HTTP — recommendation: take `@opencode-ai/sdk`
+
+The dependency test, run explicitly: this is a **vendor's own SDK** (the
+"take it" case), and the sliver argument cuts the other way here — the value
+isn't the fetch wrapper (self-writable in an afternoon), it's the
+**generated types for a 31-variant event union and every request body**,
+regenerated against each server release. OpenCode ships new versions near
+daily; typed drift detection at compile time is accumulated hardening we
+shouldn't hand-roll. Costs, named: one runtime dependency (`@opencode-ai/sdk`,
+a generated fetch client; transitive tree to be checked at install — expect
+small, but verify), tracked against a fast-moving 1.x. Fallback if the tree
+turns out ugly: the raw surface is fully documented (OpenAPI + SSE), so
+dropping the SDK later is mechanical, like `jsonrpc-oneshot` for Codex.
+Note: use `createOpencodeClient` against a server **we** spawn (for env
+control: `OPENCODE_CONFIG_CONTENT`, password, port) — not `createOpencode`,
+which spawns its own.
+
+## Blocking dependencies for the live Done-when (absent in this env)
+
+1. The `opencode` binary (install: `curl -fsSL https://opencode.ai/install |
+   bash`, or `npm i -g opencode-ai`). Not installed here (checked-for but
+   the probe was declined; treat as absent).
+2. A connected provider. **$0 paths exist**: a local Ollama model (kind
+   `local`, no ToS concern — also the cleanest way to exercise Gate 1 and 2),
+   or an existing API key. A subscription OAuth login is NOT needed for the
+   live spike and shouldn't be used for it.
+3. `@opencode-ai/sdk` as a dependency (decision above, confirmed at
+   implementation).
+
+## Wiring notes (the P.1-pattern checklist)
+
+- `AgentName` union + adapter registry (`index.ts` `createSession`),
+  `agentHasCredentials("opencode")` = binary present ∧ ≥1 usable provider.
+- Onboarding card + agents-meta entry (connect hint carries the gray-area
+  disclosure only when the chosen provider needs it).
+- Policy rows in `provider-policy.ts` per the section above.
+- Tests mock-first in all three tiers (fake SSE feed for Tier 1, real spawned
+  server with a mock provider if feasible for Tier 2); live last.
+- MIRAFOLD_MCP recognition per the confirmed tool-name prefix.
+
+Next actions, gated on Kyle: install the binary + connect a $0 provider,
+run the two live gates, lock the event/tool shapes, then phase the adapter
+into PLAN.md. The rest of the adapter can be written offline from the above.

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -48,6 +48,19 @@ class FakeTransport implements OpenCodeTransport {
   ];
   cfgModel: string | undefined = "fake/fake-model";
   sessionsCreated = 0;
+  agents: Awaited<ReturnType<OpenCodeTransport["agentCatalog"]>> = [
+    { name: "build", mode: "primary", description: "The default agent" },
+    { name: "plan", mode: "primary", description: "Plan mode" },
+    { name: "title", mode: "primary", hidden: true },
+    { name: "explore", mode: "subagent" },
+  ];
+  engineCommands: Awaited<ReturnType<OpenCodeTransport["commandCatalog"]>> = [
+    { name: "init", description: "guided AGENTS.md setup" },
+  ];
+  models: Awaited<ReturnType<OpenCodeTransport["modelCatalog"]>> = [
+    { providerID: "fake", modelID: "fake-model", name: "Fake Model" },
+  ];
+  commands: { name: string; args: string; opts: Record<string, unknown> }[] = [];
   async start(cb: (ev: OpenCodeEvent) => void) {
     this.onEvent = cb;
   }
@@ -56,6 +69,18 @@ class FakeTransport implements OpenCodeTransport {
   }
   async configModel() {
     return this.cfgModel;
+  }
+  async agentCatalog() {
+    return this.agents;
+  }
+  async commandCatalog() {
+    return this.engineCommands;
+  }
+  async modelCatalog() {
+    return this.models;
+  }
+  async command(_sessionID: string, name: string, args: string, opts: Record<string, unknown>) {
+    this.commands.push({ name, args, opts });
   }
   async createSession() {
     this.sessionsCreated++;
@@ -532,6 +557,124 @@ test("policy refusals at start: each names its reason and frees the turn", async
     assert.equal(fake.prompts.length, 0, "no prompt reaches a refused provider");
     session.close();
   }
+});
+
+test("/model with no arg paints the picker from allowed providers only", async () => {
+  const { session, fake, msgs, awaitTurnEnd } = makeSession();
+  fake.catalog = [
+    { id: "fake", source: "config" },
+    { id: "deepseek", source: "api" },
+    { id: "opencode", source: "custom", apiKeyOption: "public" }, // Zen — refused, so never offered
+  ];
+  fake.models = [
+    { providerID: "fake", modelID: "fake-model" },
+    { providerID: "deepseek", modelID: "deepseek-v4" },
+    { providerID: "opencode", modelID: "laguna-s-2.1-free" },
+  ];
+  session.pushPrompt("/model");
+  await awaitTurnEnd();
+  const picker = msgs.find((m) => m.type === "picker");
+  assert.deepEqual(
+    picker?.rows.map((r: { label: string }) => r.label),
+    ["fake/fake-model", "deepseek/deepseek-v4"],
+  );
+  assert.equal(picker?.rows.find((r: { current?: boolean }) => r.current)?.label, "fake/fake-model");
+  session.close();
+});
+
+test("/model switches to an allowed provider; a blocked pick refuses and keeps the pin", async () => {
+  const { session, fake, msgs, feed, awaitTurnEnd } = makeSession();
+  fake.catalog = [
+    { id: "fake", source: "config" },
+    { id: "deepseek", source: "api" },
+    { id: "opencode", source: "custom", apiKeyOption: "public" },
+  ];
+  session.pushPrompt("/model deepseek/deepseek-v4");
+  await awaitTurnEnd();
+  assert.ok(msgs.some((m) => m.type === "text_delta" && /Model set to deepseek/.test(m.text)));
+  assert.equal(session.modelName, "deepseek-v4");
+
+  session.pushPrompt("/model opencode/laguna-s-2.1-free");
+  await awaitTurnEnd(2);
+  assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /Zen/);
+  assert.equal(session.modelName, "deepseek-v4", "blocked pick must not move the pin");
+
+  session.pushPrompt("hi");
+  await waitFor(() => fake.prompts.length === 1, "prompt");
+  assert.deepEqual(fake.prompts[0]?.["model"], { providerID: "deepseek", modelID: "deepseek-v4" });
+  feed(idle());
+  await awaitTurnEnd(3);
+  session.close();
+});
+
+test("/agent paints user-facing primaries only; a pick rides subsequent prompts", async () => {
+  const { session, fake, msgs, feed, awaitTurnEnd } = makeSession();
+  session.pushPrompt("/agent");
+  await awaitTurnEnd();
+  const picker = msgs.find((m) => m.type === "picker");
+  assert.deepEqual(
+    picker?.rows.map((r: { label: string }) => r.label),
+    ["build", "plan"],
+    "hidden primaries and subagents never offered",
+  );
+  assert.equal(picker?.rows.find((r: { current?: boolean }) => r.current)?.label, "build");
+
+  session.pushPrompt("/agent plan");
+  await awaitTurnEnd(2);
+  assert.ok(msgs.some((m) => m.type === "text_delta" && /Agent set to plan/.test(m.text)));
+  session.pushPrompt("hi");
+  await waitFor(() => fake.prompts.length === 1, "prompt");
+  assert.equal(fake.prompts[0]?.["agent"], "plan");
+  feed(idle());
+  await awaitTurnEnd(3);
+  session.close();
+});
+
+test("an engine command routes to the engine's dispatcher with pin and agent", async () => {
+  const { session, fake, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("warm up"); // learns the engine command catalog
+  feed(idle());
+  await awaitTurnEnd();
+  session.pushPrompt("/agent plan");
+  await awaitTurnEnd(2);
+  session.pushPrompt("/init focus on tests");
+  await waitFor(() => fake.commands.length === 1, "engine command dispatch");
+  assert.deepEqual(fake.commands[0], {
+    name: "init",
+    args: "focus on tests",
+    opts: { model: "fake/fake-model", agent: "plan" },
+  });
+  feed(idle());
+  await awaitTurnEnd(3);
+  assert.equal(fake.prompts.length, 1, "the command never rides as prompt text");
+  session.close();
+});
+
+test("prompt options: our re-skins immediately, the engine catalog behind them", async () => {
+  const { session, fake, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("warm up");
+  feed(idle());
+  await awaitTurnEnd();
+  session.refreshPromptOptions();
+  await waitFor(
+    () =>
+      msgs.some(
+        (m) => m.type === "prompt_options" && m.options.some((o: { value: string }) => o.value === "/init"),
+      ),
+    "engine catalog options",
+  );
+  const options = msgs.filter((m) => m.type === "prompt_options").at(-1)?.options as {
+    value: string;
+    source?: string;
+  }[];
+  assert.deepEqual(
+    options.map((o) => o.value),
+    ["/model", "/agent", "/init"],
+  );
+  assert.equal(options.find((o) => o.value === "/init")?.source, "opencode");
+  assert.equal(options.find((o) => o.value === "/model")?.source, undefined, "our re-skin, no badge");
+  assert.equal(fake.commands.length, 0);
+  session.close();
 });
 
 test("an allowed stored-key provider runs; the refusal latch retries after a fix", async () => {

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -532,18 +532,6 @@ test("policy refusals at start: each names its reason and frees the turn", async
       catalog: [{ id: "github-copilot", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }],
       expect: /API key/,
     },
-    // the openai gray area: allowed by policy, refused until OC.4 wires kind
-    {
-      model: "openai/gpt-5.5",
-      catalog: [{ id: "openai", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }],
-      expect: /ChatGPT login .* isn't wired up/,
-    },
-    // the built-in Zen gateway — terms unread, fail-closed
-    {
-      model: "opencode/big-pickle",
-      catalog: [{ id: "opencode", source: "custom", apiKeyOption: "public" }],
-      expect: /Zen/,
-    },
   ];
   for (const c of cases) {
     const { session, fake, msgs, awaitTurnEnd } = makeSession({ model: c.model });
@@ -564,19 +552,21 @@ test("/model with no arg paints the picker from allowed providers only", async (
   fake.catalog = [
     { id: "fake", source: "config" },
     { id: "deepseek", source: "api" },
-    { id: "opencode", source: "custom", apiKeyOption: "public" }, // Zen — refused, so never offered
+    { id: "opencode", source: "custom", apiKeyOption: "public" }, // Zen — open (2026-08-13), so offered
+    { id: "github-copilot", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }, // blocked — never offered
   ];
   fake.models = [
     { providerID: "fake", modelID: "fake-model" },
     { providerID: "deepseek", modelID: "deepseek-v4" },
     { providerID: "opencode", modelID: "laguna-s-2.1-free" },
+    { providerID: "github-copilot", modelID: "gpt-5" },
   ];
   session.pushPrompt("/model");
   await awaitTurnEnd();
   const picker = msgs.find((m) => m.type === "picker");
   assert.deepEqual(
     picker?.rows.map((r: { label: string }) => r.label),
-    ["fake/fake-model", "deepseek/deepseek-v4"],
+    ["fake/fake-model", "deepseek/deepseek-v4", "opencode/laguna-s-2.1-free"],
   );
   assert.equal(picker?.rows.find((r: { current?: boolean }) => r.current)?.label, "fake/fake-model");
   session.close();
@@ -587,16 +577,16 @@ test("/model switches to an allowed provider; a blocked pick refuses and keeps t
   fake.catalog = [
     { id: "fake", source: "config" },
     { id: "deepseek", source: "api" },
-    { id: "opencode", source: "custom", apiKeyOption: "public" },
+    { id: "github-copilot", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" },
   ];
   session.pushPrompt("/model deepseek/deepseek-v4");
   await awaitTurnEnd();
   assert.ok(msgs.some((m) => m.type === "text_delta" && /Model set to deepseek/.test(m.text)));
   assert.equal(session.modelName, "deepseek-v4");
 
-  session.pushPrompt("/model opencode/laguna-s-2.1-free");
+  session.pushPrompt("/model github-copilot/gpt-5");
   await awaitTurnEnd(2);
-  assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /Zen/);
+  assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /API key/);
   assert.equal(session.modelName, "deepseek-v4", "blocked pick must not move the pin");
 
   session.pushPrompt("hi");
@@ -674,6 +664,73 @@ test("prompt options: our re-skins immediately, the engine catalog behind them",
   assert.equal(options.find((o) => o.value === "/init")?.source, "opencode");
   assert.equal(options.find((o) => o.value === "/model")?.source, undefined, "our re-skin, no badge");
   assert.equal(fake.commands.length, 0);
+  session.close();
+});
+
+test("OC.4c: gray/gateway providers RUN, publish their true kind, and disclose once", async () => {
+  const cases = [
+    {
+      model: "openai/gpt-5.5",
+      catalog: [
+        { id: "openai", source: "custom" as const, apiKeyOption: "opencode-oauth-dummy-key" },
+      ],
+      kind: "subscription",
+      disclosure: /not clearly\s+permitted .* your account, your\s+call/s,
+    },
+    {
+      model: "opencode/big-pickle",
+      catalog: [{ id: "opencode", source: "custom" as const, apiKeyOption: "public" }],
+      kind: "gateway",
+      disclosure: /improve the model/,
+    },
+  ];
+  for (const c of cases) {
+    const { session, fake, msgs, prompt, feed, awaitTurnEnd } = makeSession({ model: c.model });
+    fake.catalog = c.catalog;
+    const published: { kind: string; provider?: string }[] = [];
+    session.onBackendKind?.((u) => published.push(u));
+    await prompt("hi");
+    feed(idle());
+    await awaitTurnEnd();
+    assert.deepEqual(published, [{ kind: c.kind, provider: c.catalog[0].id }]);
+    const notices = msgs.filter((m) => m.type === "notice");
+    assert.equal(notices.length, 1, "the disclosure rides exactly once");
+    assert.match(notices[0].text, c.disclosure);
+    assert.equal(notices[0].source, undefined, "Mirafold-composed — no engine badge");
+    // A second turn must not re-disclose.
+    await prompt("again");
+    feed(idle());
+    await awaitTurnEnd(2);
+    assert.equal(msgs.filter((m) => m.type === "notice").length, 1);
+    session.close();
+  }
+});
+
+test("OC.4c: an api-key provider publishes api-key; a /model switch re-publishes", async () => {
+  const { session, fake, msgs, prompt, feed, awaitTurnEnd } = makeSession({
+    model: "deepseek/deepseek-v4",
+  });
+  fake.catalog = [
+    { id: "deepseek", source: "api" },
+    { id: "opencode", source: "custom", apiKeyOption: "public" },
+  ];
+  fake.models = [
+    { providerID: "deepseek", modelID: "deepseek-v4" },
+    { providerID: "opencode", modelID: "big-pickle" },
+  ];
+  const published: { kind: string; provider?: string }[] = [];
+  session.onBackendKind?.((u) => published.push(u));
+  await prompt("hi");
+  feed(idle());
+  await awaitTurnEnd();
+  assert.deepEqual(published, [{ kind: "api-key", provider: "deepseek" }]);
+  session.pushPrompt("/model opencode/big-pickle");
+  await awaitTurnEnd(2);
+  assert.deepEqual(published.at(-1), { kind: "gateway", provider: "opencode" });
+  assert.ok(
+    msgs.some((m) => m.type === "notice" && /improve the model/.test(m.text)),
+    "the switch to Zen carries its disclosure",
+  );
   session.close();
 });
 

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -41,10 +41,24 @@ class FakeTransport implements OpenCodeTransport {
   existing = new Set<string>();
   failPrompt?: Error;
   configContent?: Record<string, unknown>;
+  // OC.3 classification inputs — defaults let a pinless session resolve the
+  // user's config default onto an allowed BYO provider.
+  catalog: Awaited<ReturnType<OpenCodeTransport["providerCatalog"]>> = [
+    { id: "fake", source: "config" },
+  ];
+  cfgModel: string | undefined = "fake/fake-model";
+  sessionsCreated = 0;
   async start(cb: (ev: OpenCodeEvent) => void) {
     this.onEvent = cb;
   }
+  async providerCatalog() {
+    return this.catalog;
+  }
+  async configModel() {
+    return this.cfgModel;
+  }
   async createSession() {
+    this.sessionsCreated++;
     return { id: SES };
   }
   async sessionExists(id: string) {
@@ -454,21 +468,85 @@ test("a failed prompt surfaces honestly and frees the queue for the next turn", 
   session.close();
 });
 
-test("a model pin is provider/model per prompt; a bare id pins nothing", async () => {
-  const pinned = makeSession({ model: "opencode/laguna-s-2.1-free" });
+test("a model pin is provider/model per prompt; a bare id falls back to the config default", async () => {
+  const pinned = makeSession({ model: "prov1/laguna-s-2.1-free" });
+  pinned.fake.catalog = [{ id: "prov1", source: "api" }];
   await pinned.prompt("hi");
   assert.deepEqual(pinned.fake.prompts[0]?.["model"], {
-    providerID: "opencode",
+    providerID: "prov1",
     modelID: "laguna-s-2.1-free",
   });
   assert.equal(pinned.session.modelName, "laguna-s-2.1-free");
   pinned.session.close();
 
+  // A bare id can't name a provider — the user's own opencode config default
+  // resolves instead (inherit, never invent), and the prompt pins THAT.
   const bare = makeSession({ model: "laguna-s-2.1-free" });
   await bare.prompt("hi");
-  assert.equal(bare.fake.prompts[0]?.["model"], undefined);
-  assert.equal(bare.session.modelName, undefined);
+  assert.deepEqual(bare.fake.prompts[0]?.["model"], {
+    providerID: "fake",
+    modelID: "fake-model",
+  });
   bare.session.close();
+});
+
+test("policy refusals at start: each names its reason and frees the turn", async () => {
+  const cases: {
+    catalog?: FakeTransport["catalog"];
+    cfgModel?: string;
+    model?: string;
+    expect: RegExp;
+  }[] = [
+    // no pin anywhere
+    { cfgModel: undefined, expect: /no model is pinned/i },
+    // pinned provider not connected
+    { model: "ghost/some-model", expect: /isn't connected in opencode/ },
+    // a non-openai subscription OAuth — fail-closed
+    {
+      model: "github-copilot/gpt-5",
+      catalog: [{ id: "github-copilot", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }],
+      expect: /API key/,
+    },
+    // the openai gray area: allowed by policy, refused until OC.4 wires kind
+    {
+      model: "openai/gpt-5.5",
+      catalog: [{ id: "openai", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }],
+      expect: /ChatGPT login .* isn't wired up/,
+    },
+    // the built-in Zen gateway — terms unread, fail-closed
+    {
+      model: "opencode/big-pickle",
+      catalog: [{ id: "opencode", source: "custom", apiKeyOption: "public" }],
+      expect: /Zen/,
+    },
+  ];
+  for (const c of cases) {
+    const { session, fake, msgs, awaitTurnEnd } = makeSession({ model: c.model });
+    if (c.catalog) fake.catalog = c.catalog;
+    fake.cfgModel = "cfgModel" in c ? c.cfgModel : fake.cfgModel;
+    session.pushPrompt("hi");
+    await waitFor(() => msgs.some((m) => m.type === "error"), `refusal for ${c.expect}`);
+    await awaitTurnEnd();
+    assert.match(msgs.find((m) => m.type === "error")?.message ?? "", c.expect);
+    assert.equal(fake.sessionsCreated, 0, "no engine session before the policy gate");
+    assert.equal(fake.prompts.length, 0, "no prompt reaches a refused provider");
+    session.close();
+  }
+});
+
+test("an allowed stored-key provider runs; the refusal latch retries after a fix", async () => {
+  const { session, fake, msgs, feed, awaitTurnEnd } = makeSession({ model: "deepseek/deepseek-v4" });
+  fake.catalog = []; // not connected yet
+  session.pushPrompt("hi");
+  await waitFor(() => msgs.some((m) => m.type === "error"), "first refusal");
+  await awaitTurnEnd();
+  fake.catalog = [{ id: "deepseek", source: "api" }]; // user connected it
+  session.pushPrompt("hi again");
+  await waitFor(() => fake.prompts.length === 1, "prompt after fix");
+  feed(idle());
+  await awaitTurnEnd(2);
+  assert.deepEqual(fake.prompts[0]?.["model"], { providerID: "deepseek", modelID: "deepseek-v4" });
+  session.close();
 });
 
 test("resume: an existing engine session id is reattached, a dead one recreated", async () => {

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -1,0 +1,493 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdtempSync } from "node:fs";
+import type { WireMsg } from "../protocol";
+import { RENDER_GUIDANCE } from "../render-tools";
+import { OpenCodeSession } from "./opencode";
+import type { OpenCodeEvent, OpenCodeTransport } from "./opencode-client";
+
+// OC.1: the OpenCode event→WireMsg mapping and the turn grammar, on synthetic
+// events whose shapes are the OC.0 live capture (opencode.spike.md) — no
+// engine, no network. The session is real; only the transport is a fake, so
+// the whole worker → runTurn → mapper path runs as shipped.
+
+type Any = WireMsg & Record<string, any>;
+
+const tmp = mkdtempSync(path.join(os.tmpdir(), "mcp-opencode-test-"));
+const SES = "ses_test";
+
+const waitFor = (cond: () => boolean, what: string, timeoutMs = 5_000) =>
+  new Promise<void>((resolve, reject) => {
+    const t0 = Date.now();
+    const poll = setInterval(() => {
+      if (cond()) {
+        clearInterval(poll);
+        resolve();
+      } else if (Date.now() - t0 > timeoutMs) {
+        clearInterval(poll);
+        reject(new Error(`timed out waiting for ${what}`));
+      }
+    }, 5);
+  });
+
+class FakeTransport implements OpenCodeTransport {
+  onEvent: (ev: OpenCodeEvent) => void = () => {};
+  prompts: Record<string, unknown>[] = [];
+  aborts = 0;
+  replies: { permissionID: string; response: string }[] = [];
+  closed = false;
+  existing = new Set<string>();
+  failPrompt?: Error;
+  configContent?: Record<string, unknown>;
+  async start(cb: (ev: OpenCodeEvent) => void) {
+    this.onEvent = cb;
+  }
+  async createSession() {
+    return { id: SES };
+  }
+  async sessionExists(id: string) {
+    return this.existing.has(id);
+  }
+  async prompt(_sessionID: string, body: Record<string, unknown>) {
+    if (this.failPrompt) throw this.failPrompt;
+    this.prompts.push(body);
+  }
+  async abort(_sessionID: string) {
+    this.aborts++;
+  }
+  async replyPermission(_sessionID: string, permissionID: string, response: "once" | "reject") {
+    this.replies.push({ permissionID, response });
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+const ev = (type: string, properties: Record<string, unknown>): OpenCodeEvent => ({
+  type,
+  properties,
+});
+const snap = (part: Record<string, unknown>) =>
+  ev("message.part.updated", {
+    sessionID: SES,
+    part: { sessionID: SES, messageID: "m1", id: "p1", ...part },
+  });
+const delta = (partID: string, text: string) =>
+  ev("message.part.delta", { sessionID: SES, messageID: "m1", partID, field: "text", delta: text });
+const idle = () => ev("session.idle", { sessionID: SES });
+const asked = (id = "per1") =>
+  ev("permission.asked", {
+    id,
+    sessionID: SES,
+    permission: "bash",
+    patterns: ["echo hi"],
+    metadata: { command: "echo hi" },
+    always: ["echo *"],
+    tool: { messageID: "m1", callID: "c1" },
+  });
+const assistant = (
+  id: string,
+  tokens: { input: number; output: number; reasoning?: number },
+  modelID = "fake-model",
+  cost = 0,
+) =>
+  ev("message.updated", {
+    sessionID: SES,
+    info: {
+      id,
+      role: "assistant",
+      sessionID: SES,
+      modelID,
+      cost,
+      tokens: { reasoning: 0, cache: { read: 0, write: 0 }, ...tokens },
+    },
+  });
+
+function makeSession(opts: Partial<ConstructorParameters<typeof OpenCodeSession>[0]> = {}) {
+  const fake = new FakeTransport();
+  const session = new OpenCodeSession({
+    workspaceDir: tmp,
+    makeTransport: (config) => {
+      fake.configContent = config;
+      return fake;
+    },
+    ...opts,
+  });
+  const msgs: Any[] = [];
+  session.onMessage((m) => msgs.push(m as Any));
+  const turnEnds = () => msgs.filter((m) => m.type === "turn_end").length;
+  const prompt = async (text: string) => {
+    const before = fake.prompts.length;
+    session.pushPrompt(text);
+    await waitFor(() => fake.prompts.length > before, "prompt to reach transport");
+  };
+  const awaitTurnEnd = (count = 1) => waitFor(() => turnEnds() >= count, `turn_end #${count}`);
+  const feed = (...events: OpenCodeEvent[]) => events.forEach((e) => fake.onEvent(e));
+  return { session, fake, msgs, prompt, feed, awaitTurnEnd };
+}
+
+test("text streams as deltas; the final snapshot never duplicates", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    snap({ type: "text", text: "" }),
+    delta("p1", "hel"),
+    delta("p1", "lo"),
+    snap({ type: "text", text: "hello" }), // full-text snapshot after deltas
+    idle(),
+  );
+  await awaitTurnEnd();
+  const texts = msgs.filter((m) => m.type === "text_delta").map((m) => m.text);
+  assert.deepEqual(texts, ["hel", "lo"]);
+  session.close();
+});
+
+test("a buffered part (snapshot only, no deltas) still emits its text", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(snap({ type: "text", text: "all at once" }), idle());
+  await awaitTurnEnd();
+  assert.deepEqual(
+    msgs.filter((m) => m.type === "text_delta").map((m) => m.text),
+    ["all at once"],
+  );
+  session.close();
+});
+
+test("reasoning parts become thinking_delta behind a thinking status", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    snap({ type: "reasoning", text: "", id: "r1" }),
+    delta("r1", "pondering"),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.equal(msgs.find((m) => m.type === "status")?.state, "thinking");
+  assert.deepEqual(
+    msgs.filter((m) => m.type === "thinking_delta").map((m) => m.text),
+    ["pondering"],
+  );
+  session.close();
+});
+
+test("tool lifecycle: running announces, completed resolves, output is capped", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  const input = { command: "echo hi", description: "d" };
+  feed(
+    snap({ type: "tool", id: "t1", tool: "bash", callID: "c1", state: { status: "running", input } }),
+    snap({
+      type: "tool",
+      id: "t1",
+      tool: "bash",
+      callID: "c1",
+      state: { status: "completed", input, output: "x".repeat(70_000), title: "echo hi" },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  const use = msgs.find((m) => m.type === "tool_use");
+  assert.equal(use?.name, "bash");
+  assert.equal(use?.detail, "echo hi");
+  assert.equal(use?.id, "t1");
+  assert.deepEqual(use?.input, input);
+  assert.equal(msgs.find((m) => m.type === "status" && m.state === "tool")?.label, "bash");
+  const result = msgs.find((m) => m.type === "tool_result");
+  assert.equal(result?.id, "t1");
+  assert.ok((result?.truncatedBytes ?? 0) > 0, "long output reports its elided bytes");
+  session.close();
+});
+
+test("tool error resolves as an isError result; completed-first still announces", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    // completed arrives with no prior running snapshot — announce then resolve
+    snap({
+      type: "tool",
+      id: "t1",
+      tool: "webfetch",
+      state: { status: "error", input: { url: "https://x" }, error: "boom" },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.equal(msgs.find((m) => m.type === "tool_use")?.name, "webfetch");
+  const result = msgs.find((m) => m.type === "tool_result");
+  assert.equal(result?.isError, true);
+  assert.equal(result?.output, "boom");
+  session.close();
+});
+
+test("a mirafold render call paints the component, no raw tool block", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    snap({
+      type: "tool",
+      id: "t1",
+      tool: "mirafold_render_card",
+      state: {
+        status: "completed",
+        input: { title: "Hi", body: "b" },
+        output: "Rendered card (id: 0a1b2c3d-0000-0000-0000-000000000000)",
+      },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  const render = msgs.find((m) => m.type === "render");
+  assert.equal(render?.component, "card");
+  assert.equal(render?.id, "0a1b2c3d-0000-0000-0000-000000000000");
+  assert.deepEqual(render?.props, { title: "Hi", body: "b" });
+  assert.equal(msgs.some((m) => m.type === "tool_use" || m.type === "tool_result"), false);
+  session.close();
+});
+
+test("mirafold emit_artifact paints an artifact", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    snap({
+      type: "tool",
+      id: "t1",
+      tool: "mirafold_emit_artifact",
+      state: {
+        status: "completed",
+        input: { html: "<b>x</b>", title: "T" },
+        output: "Rendered artifact (id: 0a1b2c3d-0000-0000-0000-00000000ffff)",
+      },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  const artifact = msgs.find((m) => m.type === "artifact");
+  assert.equal(artifact?.html, "<b>x</b>");
+  assert.equal(artifact?.title, "T");
+  session.close();
+});
+
+test("a mirafold call without a recognizable ack falls back to the tool record", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    snap({
+      type: "tool",
+      id: "t1",
+      tool: "mirafold_render_card",
+      state: { status: "error", input: { title: "Hi" }, error: "invalid props" },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.equal(msgs.some((m) => m.type === "render"), false);
+  assert.equal(msgs.find((m) => m.type === "tool_use")?.name, "mirafold_render_card");
+  const result = msgs.find((m) => m.type === "tool_result");
+  assert.equal(result?.isError, true);
+  assert.equal(result?.output, "invalid props");
+  session.close();
+});
+
+test("permission ask bridges to the bar; allow replies `once` and resolves", async () => {
+  const { session, fake, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(asked());
+  await waitFor(() => msgs.some((m) => m.type === "permission_request"), "ask");
+  const request = msgs.find((m) => m.type === "permission_request");
+  assert.equal(request?.tool, "bash");
+  assert.equal(request?.detail, "echo hi");
+  session.resolvePermission("per1", true);
+  await waitFor(() => fake.replies.length === 1, "engine reply");
+  assert.deepEqual(fake.replies[0], { permissionID: "per1", response: "once" });
+  const resolved = msgs.find((m) => m.type === "permission_resolved");
+  assert.deepEqual({ id: resolved?.id, allow: resolved?.allow }, { id: "per1", allow: true });
+  feed(idle());
+  await awaitTurnEnd();
+  session.close();
+});
+
+test("deny replies `reject`; a second answer for the same ask is a no-op", async () => {
+  const { session, fake, msgs, prompt, feed } = makeSession();
+  await prompt("hi");
+  feed(asked());
+  await waitFor(() => msgs.some((m) => m.type === "permission_request"), "ask");
+  session.resolvePermission("per1", false);
+  session.resolvePermission("per1", true); // stale — must not reach the engine
+  await waitFor(() => fake.replies.length === 1, "engine reply");
+  assert.deepEqual(fake.replies[0], { permissionID: "per1", response: "reject" });
+  assert.equal(msgs.filter((m) => m.type === "permission_resolved").length, 1);
+  session.close();
+});
+
+test("an unanswered ask auto-denies on the timeout", async () => {
+  const { session, fake, msgs, prompt, feed } = makeSession({ permissionTimeoutMs: 30 });
+  await prompt("hi");
+  feed(asked());
+  await waitFor(() => fake.replies.length === 1, "timeout reply");
+  assert.equal(fake.replies[0]?.response, "reject");
+  assert.equal(msgs.find((m) => m.type === "permission_resolved")?.allow, false);
+  session.close();
+});
+
+test("a reply observed on the stream (another client) resolves without an engine echo", async () => {
+  const { session, fake, msgs, prompt, feed } = makeSession();
+  await prompt("hi");
+  feed(asked());
+  await waitFor(() => msgs.some((m) => m.type === "permission_request"), "ask");
+  feed(ev("permission.replied", { sessionID: SES, requestID: "per1", reply: "once" }));
+  await waitFor(() => msgs.some((m) => m.type === "permission_resolved"), "resolution");
+  assert.equal(fake.replies.length, 0, "no reply sent back at the engine");
+  assert.equal(msgs.find((m) => m.type === "permission_resolved")?.allow, true);
+  session.close();
+});
+
+test("subagent child-session events are skipped whole", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    ev("message.part.updated", {
+      sessionID: "ses_child",
+      part: { sessionID: "ses_child", messageID: "m9", id: "p9", type: "text", text: "child text" },
+    }),
+    ev("session.idle", { sessionID: "ses_child" }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.equal(msgs.some((m) => m.type === "text_delta"), false);
+  assert.equal(msgs.filter((m) => m.type === "turn_end").length, 1);
+  session.close();
+});
+
+test("usage sums the turn's assistant messages and rides just before turn_end", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    assistant("a1", { input: 11, output: 0 }, "laguna-s-2.1", 0.01),
+    assistant("a2", { input: 20, output: 5 }, "laguna-s-2.1", 0.02),
+    idle(),
+  );
+  await awaitTurnEnd();
+  const usage = msgs.find((m) => m.type === "usage");
+  assert.deepEqual(
+    { model: usage?.model, input: usage?.inputTokens, output: usage?.outputTokens },
+    { model: "laguna-s-2.1", input: 31, output: 5 },
+  );
+  assert.ok(Math.abs((usage?.costUsd ?? 0) - 0.03) < 1e-9);
+  assert.equal(session.modelName, "laguna-s-2.1", "modelName refined from the engine");
+  assert.ok(
+    msgs.findIndex((m) => m.type === "usage") < msgs.findIndex((m) => m.type === "turn_end"),
+  );
+  session.close();
+});
+
+test("session.error surfaces and ends the turn exactly once", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    ev("session.error", { sessionID: SES, error: { name: "ProviderError", data: { message: "no key" } } }),
+    idle(), // late idle after the error must not double-end
+  );
+  await awaitTurnEnd();
+  assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /no key/);
+  assert.equal(msgs.filter((m) => m.type === "turn_end").length, 1);
+  session.close();
+});
+
+test("render guidance rides the first accepted turn only", async () => {
+  const { session, fake, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("first");
+  feed(idle());
+  await awaitTurnEnd();
+  await prompt("second");
+  feed(idle());
+  await awaitTurnEnd(2);
+  const text = (p: Record<string, unknown>) =>
+    (p["parts"] as { text: string }[])[0]?.text ?? "";
+  assert.ok(text(fake.prompts[0]).startsWith(RENDER_GUIDANCE));
+  assert.ok(text(fake.prompts[0]).endsWith("first"));
+  assert.equal(text(fake.prompts[1]), "second");
+  session.close();
+});
+
+test("a failed prompt surfaces honestly and frees the queue for the next turn", async () => {
+  const { session, fake, msgs, feed, awaitTurnEnd } = makeSession();
+  fake.failPrompt = new Error("HTTP 500: kaput");
+  session.pushPrompt("first");
+  await waitFor(() => msgs.some((m) => m.type === "error"), "error");
+  await awaitTurnEnd();
+  assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /kaput/);
+  fake.failPrompt = undefined;
+  session.pushPrompt("second");
+  await waitFor(() => fake.prompts.length === 1, "second prompt");
+  feed(idle());
+  await awaitTurnEnd(2);
+  session.close();
+});
+
+test("a model pin is provider/model per prompt; a bare id pins nothing", async () => {
+  const pinned = makeSession({ model: "opencode/laguna-s-2.1-free" });
+  await pinned.prompt("hi");
+  assert.deepEqual(pinned.fake.prompts[0]?.["model"], {
+    providerID: "opencode",
+    modelID: "laguna-s-2.1-free",
+  });
+  assert.equal(pinned.session.modelName, "laguna-s-2.1-free");
+  pinned.session.close();
+
+  const bare = makeSession({ model: "laguna-s-2.1-free" });
+  await bare.prompt("hi");
+  assert.equal(bare.fake.prompts[0]?.["model"], undefined);
+  assert.equal(bare.session.modelName, undefined);
+  bare.session.close();
+});
+
+test("resume: an existing engine session id is reattached, a dead one recreated", async () => {
+  const alive = makeSession({ resumeId: SES });
+  alive.fake.existing.add(SES);
+  const seen: string[] = [];
+  alive.session.onResumeId((id) => seen.push(id));
+  await alive.prompt("hi");
+  assert.equal(alive.session.resumeId, SES);
+  alive.session.close();
+
+  const dead = makeSession({ resumeId: "ses_gone" });
+  await dead.prompt("hi");
+  assert.equal(dead.session.resumeId, SES, "fresh engine session replaces the dead id");
+  dead.session.close();
+  assert.ok(seen.includes(SES));
+});
+
+test("interrupt aborts the engine turn and denies the pending ask", async () => {
+  const { session, fake, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(asked());
+  await waitFor(() => msgs.some((m) => m.type === "permission_request"), "ask");
+  session.interrupt();
+  await waitFor(() => fake.aborts === 1, "abort");
+  assert.equal(fake.replies[0]?.response, "reject");
+  assert.equal(msgs.find((m) => m.type === "permission_resolved")?.allow, false);
+  feed(idle()); // the engine's own idle after abort ends the turn
+  await awaitTurnEnd();
+  session.close();
+});
+
+test("close releases an in-flight turn and shuts the transport", async () => {
+  const { session, fake, msgs, prompt } = makeSession();
+  await prompt("hi");
+  session.close();
+  await waitFor(() => fake.closed, "transport closed");
+  // turn_end is not emitted post-close (no listeners should hear a ghost);
+  // the internal latch is released so the worker exits.
+  assert.equal(msgs.some((m) => m.type === "turn_end"), false);
+});
+
+test("the render MCP injects additively through config content", () => {
+  const { session, fake } = makeSession();
+  const mcp = (fake.configContent?.["mcp"] ?? {}) as Record<string, Record<string, unknown>>;
+  assert.equal(mcp["mirafold"]?.["type"], "local");
+  assert.ok(Array.isArray(mcp["mirafold"]?.["command"]));
+  session.close();
+});

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -344,6 +344,33 @@ test("a reply observed on the stream (another client) resolves without an engine
   session.close();
 });
 
+test("the user message's own echoed parts never replay as output", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("hi");
+  feed(
+    // The stream announces the user message, then echoes its parts —
+    // observed live (OC.2): snapshot AND delta forms both appear.
+    ev("message.updated", { sessionID: SES, info: { id: "mu", role: "user", sessionID: SES } }),
+    ev("message.part.updated", {
+      sessionID: SES,
+      part: { sessionID: SES, messageID: "mu", id: "pu", type: "text", text: "guidance + hi" },
+    }),
+    ev("message.part.delta", { sessionID: SES, messageID: "mu", partID: "pu", field: "text", delta: "more" }),
+    assistant("ma", { input: 1, output: 1 }),
+    ev("message.part.updated", {
+      sessionID: SES,
+      part: { sessionID: SES, messageID: "ma", id: "pa", type: "text", text: "real reply" },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.deepEqual(
+    msgs.filter((m) => m.type === "text_delta").map((m) => m.text),
+    ["real reply"],
+  );
+  session.close();
+});
+
 test("subagent child-session events are skipped whole", async () => {
   const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
   await prompt("hi");

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -3,7 +3,7 @@ import { mkdirSync } from "node:fs";
 import type { WireMsg } from "../protocol";
 import { RENDER_GUIDANCE } from "../render-tools";
 import { envInt } from "../env";
-import { classifyOpenCodeProvider } from "../provider-policy";
+import { classifyOpenCodeProvider, type CredentialKind } from "../provider-policy";
 import { agentBin, errText, PERMISSION_TIMEOUT_MS, type AgentSession } from "./types";
 import { AsyncQueue, CLOSE } from "./async-queue";
 import { ResumeIdState } from "./resume-id";
@@ -59,6 +59,10 @@ export class OpenCodeSession implements AgentSession {
   // The engine's command catalog, learned at start — routes `/name` inputs
   // to the engine's dispatcher and feeds the prompt-options catalog.
   private engineCommands: OpenCodeCommandEntry[] = [];
+  // OC.4c: the classified backend kind, published to the registry once the
+  // provider verdict lands (and re-published on a /model provider switch).
+  private kindListeners = new Set<(u: { kind: CredentialKind; provider?: string }) => void>();
+  private lastKind?: { kind: CredentialKind; provider?: string };
   private permissionTimeoutMs: number;
   private pendingPermissions = new Map<string, ReturnType<typeof setTimeout>>();
   // Per-turn end latch: exactly one turn_end per prompt (idle, error,
@@ -77,6 +81,16 @@ export class OpenCodeSession implements AgentSession {
 
   onResumeId(cb: (id: string) => void) {
     this.resumeIdState.onChange(cb);
+  }
+
+  onBackendKind(cb: (update: { kind: CredentialKind; provider?: string }) => void) {
+    this.kindListeners.add(cb);
+    if (this.lastKind) cb(this.lastKind);
+  }
+
+  private publishKind(kind: CredentialKind, provider: string) {
+    this.lastKind = { kind, provider };
+    for (const cb of this.kindListeners) cb(this.lastKind);
   }
 
   // `makeTransport` and `permissionTimeoutMs` are test seams.
@@ -210,19 +224,24 @@ export class OpenCodeSession implements AgentSession {
       throw new Error(
         "no model is pinned for this OpenCode session — set OPENCODE_MODEL=<provider>/<model> " +
           "(or `model` in your opencode config) so Mirafold knows which provider will run; " +
-          "the provider determines whether the session may run at all",
+          "the provider determines whether the session may run at all. The built-in free " +
+          "models work too, e.g. OPENCODE_MODEL=opencode/big-pickle",
       );
     }
-    const reason = await this.pinRefusalReason(pin);
+    const reason = await this.adoptPin(pin);
     if (reason) throw new Error(reason);
-    this.modelPin = pin;
-    this.modelLabel ??= pin.modelID;
   }
 
-  /** Why `pin` may not run, or undefined when it may — the shared verdict
-   *  behind session start and a `/model` switch (a switch must never reach a
-   *  provider the start gate would have refused). */
-  private async pinRefusalReason(pin: {
+  // Providers whose gray-area disclosure already ran this session — the
+  // notice states standing terms, so it rides once per provider, not per turn.
+  private disclosedProviders = new Set<string>();
+
+  /** Classify `pin`, and on an allowed verdict make it THIS session's pin:
+   *  publish the truthful kind to the registry (OC.4c — the relay gate's
+   *  input) and emit the gray-area disclosure when the provider carries one.
+   *  Returns the refusal reason instead when the pin may not run — the
+   *  shared verdict behind session start and a `/model` switch. */
+  private async adoptPin(pin: {
     providerID: string;
     modelID: string;
   }): Promise<string | undefined> {
@@ -235,17 +254,14 @@ export class OpenCodeSession implements AgentSession {
     }
     const verdict = classifyOpenCodeProvider(entry);
     if (!verdict.allowed) return verdict.reason ?? "provider refused by policy";
-    if (verdict.kind === "subscription") {
-      // The ChatGPT gray area needs the classified kind to flow into the
-      // session's Backend before it may run (the relay gate reads
-      // Backend.kind, and this session was resolved optimistically as
-      // api-key) — that wiring plus the required disclosure is PLAN OC.4b.
-      // Until then the gray path refuses honestly rather than run under a
-      // kind that would overstate its relay rights.
-      return (
-        "a ChatGPT login through OpenCode isn't wired up in Mirafold yet — " +
-        "connect OpenAI (or another provider) with an API key in opencode to run this session"
-      );
+    this.modelPin = pin;
+    this.modelLabel = pin.modelID;
+    this.publishKind(verdict.kind, pin.providerID);
+    if (verdict.disclosure && !this.disclosedProviders.has(pin.providerID)) {
+      this.disclosedProviders.add(pin.providerID);
+      // Mirafold-composed (no source badge): the disclosed-uncertainty
+      // rule's required disclosure — uncertainty stated, never permission.
+      this.emit({ type: "notice", text: verdict.disclosure });
     }
     return undefined;
   }
@@ -296,14 +312,12 @@ export class OpenCodeSession implements AgentSession {
       emit: (msg) => this.emit(msg),
       listModels: async () => {
         await this.ensureStarted();
+        // Every ALLOWED provider rows here — gray areas included, since
+        // OC.4c flows their true kind to the registry and their disclosure
+        // rides the pick (the picker offers only what a pick can run).
         const allowed = new Set(
           (await this.transport.providerCatalog())
-            .filter((entry) => {
-              const verdict = classifyOpenCodeProvider(entry);
-              // The gray subscription is excluded with the blocked rows: the
-              // picker offers only what a pick can actually run (OC.4b).
-              return verdict.allowed && verdict.kind !== "subscription";
-            })
+            .filter((entry) => classifyOpenCodeProvider(entry).allowed)
             .map((entry) => entry.id),
         );
         return (await this.transport.modelCatalog()).filter((m) => allowed.has(m.providerID));
@@ -315,14 +329,10 @@ export class OpenCodeSession implements AgentSession {
         if (!pin) return "Usage: `/model` to pick, or `/model <provider>/<model>`.";
         try {
           await this.ensureStarted();
-          const reason = await this.pinRefusalReason(pin);
-          if (reason) return reason;
+          return await this.adoptPin(pin);
         } catch (err) {
           return errText(err);
         }
-        this.modelPin = pin;
-        this.modelLabel = pin.modelID;
-        return undefined;
       },
     });
   }

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from "node:fs";
 import type { WireMsg } from "../protocol";
 import { RENDER_GUIDANCE } from "../render-tools";
 import { envInt } from "../env";
+import { classifyOpenCodeProvider } from "../provider-policy";
 import { agentBin, errText, PERMISSION_TIMEOUT_MS, type AgentSession } from "./types";
 import { AsyncQueue, CLOSE } from "./async-queue";
 import { ResumeIdState } from "./resume-id";
@@ -163,10 +164,12 @@ export class OpenCodeSession implements AgentSession {
   }
 
   /** Spawn/attach lazily on the first turn; a failure resets the latch so a
-   *  later prompt retries (the user may have installed the binary meanwhile). */
+   *  later prompt retries (the user may have installed the binary, connected
+   *  a provider, or pinned a model meanwhile). */
   private ensureStarted(): Promise<void> {
     this.started ??= (async () => {
       await this.transport.start((ev) => this.handleEvent(ev));
+      await this.enforceProviderPolicy();
       if (this.wantedResumeId && (await this.transport.sessionExists(this.wantedResumeId))) {
         this.sessionID = this.wantedResumeId;
       } else {
@@ -178,6 +181,45 @@ export class OpenCodeSession implements AgentSession {
       this.started = undefined;
       throw err;
     });
+  }
+
+  /** The R.4i gate, provider-resolved (PLAN OC.3): every turn of this session
+   *  runs on the pinned provider (we set `model` on each prompt), so the pin
+   *  is what the policy judges — classified from the running engine's own
+   *  catalog, never from the user's auth.json. Refusals throw; the message
+   *  travels the honest per-turn error path and names the fix. */
+  private async enforceProviderPolicy(): Promise<void> {
+    const pin = this.modelPin ?? parseModelPin(await this.transport.configModel());
+    if (!pin) {
+      throw new Error(
+        "no model is pinned for this OpenCode session — set OPENCODE_MODEL=<provider>/<model> " +
+          "(or `model` in your opencode config) so Mirafold knows which provider will run; " +
+          "the provider determines whether the session may run at all",
+      );
+    }
+    const entry = (await this.transport.providerCatalog()).find((p) => p.id === pin.providerID);
+    if (!entry) {
+      throw new Error(
+        `provider "${pin.providerID}" isn't connected in opencode — connect it with ` +
+          "`opencode auth login` (or declare it in your opencode config), then prompt again",
+      );
+    }
+    const verdict = classifyOpenCodeProvider(entry);
+    if (!verdict.allowed) throw new Error(verdict.reason ?? "provider refused by policy");
+    if (verdict.kind === "subscription") {
+      // The ChatGPT gray area needs the classified kind to flow into the
+      // session's Backend before it may run (the relay gate reads
+      // Backend.kind, and this session was resolved optimistically as
+      // api-key) — that wiring plus the required disclosure is PLAN OC.4.
+      // Until then the gray path refuses honestly rather than run under a
+      // kind that would overstate its relay rights.
+      throw new Error(
+        "a ChatGPT login through OpenCode isn't wired up in Mirafold yet — " +
+          "connect OpenAI (or another provider) with an API key in opencode to run this session",
+      );
+    }
+    this.modelPin = pin;
+    this.modelLabel ??= pin.modelID;
   }
 
   /** Serial queue: turns apply in prompt order, one at a time. */
@@ -270,9 +312,10 @@ export class OpenCodeSession implements AgentSession {
 
 /** A configured model pin. OpenCode addresses models as `provider/model`
  *  (the id itself may contain further slashes); a bare value can't name a
- *  provider, so it pins nothing and the engine's own default runs —
- *  inherit, never invent. */
-function parseModelPin(model?: string): { providerID: string; modelID: string } | undefined {
+ *  provider, so it pins nothing and the user's own config default is
+ *  resolved instead — inherit, never invent. Exported for the registry's
+ *  `Backend.provider` resolution. */
+export function parseModelPin(model?: string): { providerID: string; modelID: string } | undefined {
   if (!model) return undefined;
   const slash = model.indexOf("/");
   if (slash <= 0 || slash === model.length - 1) return undefined;

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -10,10 +10,17 @@ import { ResumeIdState } from "./resume-id";
 import { renderMcpCommand, MIRAFOLD_MCP } from "./render-mcp-cmd";
 import {
   OpenCodeServerProcess,
+  type OpenCodeCommandEntry,
   type OpenCodeEvent,
   type OpenCodeTransport,
 } from "./opencode-client";
 import { OpenCodeEventMapper } from "./opencode-events";
+import {
+  OPENCODE_DEFAULT_AGENT,
+  refreshOpenCodePromptOptions,
+  runOpenCodeAgentCommand,
+  runOpenCodeModelCommand,
+} from "./opencode-commands";
 
 // An aborted turn normally ends via the engine's own `session.idle`; this is
 // the honest fallback if that event never comes, so an interrupt can't wedge
@@ -46,6 +53,12 @@ export class OpenCodeSession implements AgentSession {
   private closed = false;
   private firstTurn = true;
   private modelLabel?: string;
+  // The picked OpenCode agent (build/plan/custom primary); unset = the
+  // engine's own default rides (no `agent` field on prompts).
+  private currentAgent?: string;
+  // The engine's command catalog, learned at start — routes `/name` inputs
+  // to the engine's dispatcher and feeds the prompt-options catalog.
+  private engineCommands: OpenCodeCommandEntry[] = [];
   private permissionTimeoutMs: number;
   private pendingPermissions = new Map<string, ReturnType<typeof setTimeout>>();
   // Per-turn end latch: exactly one turn_end per prompt (idle, error,
@@ -176,6 +189,9 @@ export class OpenCodeSession implements AgentSession {
         this.sessionID = (await this.transport.createSession()).id;
       }
       this.resumeIdState.publish(this.sessionID);
+      // Non-fatal fidelity: without the catalog, `/name` inputs simply reach
+      // the model as prompt text and the options list shows only our rows.
+      this.engineCommands = await this.transport.commandCatalog().catch(() => []);
     })();
     return this.started.catch((err) => {
       this.started = undefined;
@@ -197,37 +213,154 @@ export class OpenCodeSession implements AgentSession {
           "the provider determines whether the session may run at all",
       );
     }
-    const entry = (await this.transport.providerCatalog()).find((p) => p.id === pin.providerID);
-    if (!entry) {
-      throw new Error(
-        `provider "${pin.providerID}" isn't connected in opencode — connect it with ` +
-          "`opencode auth login` (or declare it in your opencode config), then prompt again",
-      );
-    }
-    const verdict = classifyOpenCodeProvider(entry);
-    if (!verdict.allowed) throw new Error(verdict.reason ?? "provider refused by policy");
-    if (verdict.kind === "subscription") {
-      // The ChatGPT gray area needs the classified kind to flow into the
-      // session's Backend before it may run (the relay gate reads
-      // Backend.kind, and this session was resolved optimistically as
-      // api-key) — that wiring plus the required disclosure is PLAN OC.4.
-      // Until then the gray path refuses honestly rather than run under a
-      // kind that would overstate its relay rights.
-      throw new Error(
-        "a ChatGPT login through OpenCode isn't wired up in Mirafold yet — " +
-          "connect OpenAI (or another provider) with an API key in opencode to run this session",
-      );
-    }
+    const reason = await this.pinRefusalReason(pin);
+    if (reason) throw new Error(reason);
     this.modelPin = pin;
     this.modelLabel ??= pin.modelID;
   }
 
-  /** Serial queue: turns apply in prompt order, one at a time. */
+  /** Why `pin` may not run, or undefined when it may — the shared verdict
+   *  behind session start and a `/model` switch (a switch must never reach a
+   *  provider the start gate would have refused). */
+  private async pinRefusalReason(pin: {
+    providerID: string;
+    modelID: string;
+  }): Promise<string | undefined> {
+    const entry = (await this.transport.providerCatalog()).find((p) => p.id === pin.providerID);
+    if (!entry) {
+      return (
+        `provider "${pin.providerID}" isn't connected in opencode — connect it with ` +
+        "`opencode auth login` (or declare it in your opencode config), then prompt again"
+      );
+    }
+    const verdict = classifyOpenCodeProvider(entry);
+    if (!verdict.allowed) return verdict.reason ?? "provider refused by policy";
+    if (verdict.kind === "subscription") {
+      // The ChatGPT gray area needs the classified kind to flow into the
+      // session's Backend before it may run (the relay gate reads
+      // Backend.kind, and this session was resolved optimistically as
+      // api-key) — that wiring plus the required disclosure is PLAN OC.4b.
+      // Until then the gray path refuses honestly rather than run under a
+      // kind that would overstate its relay rights.
+      return (
+        "a ChatGPT login through OpenCode isn't wired up in Mirafold yet — " +
+        "connect OpenAI (or another provider) with an API key in opencode to run this session"
+      );
+    }
+    return undefined;
+  }
+
+  refreshPromptOptions() {
+    refreshOpenCodePromptOptions({
+      emit: (msg) => this.emit(msg),
+      isClosed: () => this.closed,
+      listCommands: async () => {
+        await this.ensureStarted();
+        return this.engineCommands;
+      },
+    });
+  }
+
+  /** Serial queue: command switches and engine turns apply in prompt order. */
   private async worker() {
     while (!this.closed) {
       const item = await this.queue.next();
       if (item === CLOSE) return;
-      await this.runTurn(item);
+      const trimmed = item.trim();
+      if (trimmed === "/model" || trimmed.startsWith("/model ")) {
+        await this.runModelCommand(trimmed.slice("/model".length).trim());
+      } else if (trimmed === "/agent" || trimmed.startsWith("/agent ")) {
+        await this.runAgentCommand(trimmed.slice("/agent".length).trim());
+      } else {
+        const engine = this.matchEngineCommand(trimmed);
+        if (engine) await this.runEngineCommand(engine.name, engine.args);
+        else await this.runTurn(item);
+      }
+    }
+  }
+
+  /** `/name [args]` for a name in the engine's own catalog. Known only once
+   *  the engine started — a cold session's very first input routes as prompt
+   *  text instead (rare; the model still sees exactly what was typed). */
+  private matchEngineCommand(trimmed: string): { name: string; args: string } | undefined {
+    const match = /^\/([\w:-]+)(?:\s+([^]*))?$/.exec(trimmed);
+    if (!match) return undefined;
+    const name = match[1];
+    if (!this.engineCommands.some((c) => c.name === name)) return undefined;
+    return { name, args: (match[2] ?? "").trim() };
+  }
+
+  private async runModelCommand(arg: string) {
+    await runOpenCodeModelCommand({
+      arg,
+      emit: (msg) => this.emit(msg),
+      listModels: async () => {
+        await this.ensureStarted();
+        const allowed = new Set(
+          (await this.transport.providerCatalog())
+            .filter((entry) => {
+              const verdict = classifyOpenCodeProvider(entry);
+              // The gray subscription is excluded with the blocked rows: the
+              // picker offers only what a pick can actually run (OC.4b).
+              return verdict.allowed && verdict.kind !== "subscription";
+            })
+            .map((entry) => entry.id),
+        );
+        return (await this.transport.modelCatalog()).filter((m) => allowed.has(m.providerID));
+      },
+      isCurrent: (providerID, modelID) =>
+        this.modelPin?.providerID === providerID && this.modelPin?.modelID === modelID,
+      setModel: async (id) => {
+        const pin = parseModelPin(id);
+        if (!pin) return "Usage: `/model` to pick, or `/model <provider>/<model>`.";
+        try {
+          await this.ensureStarted();
+          const reason = await this.pinRefusalReason(pin);
+          if (reason) return reason;
+        } catch (err) {
+          return errText(err);
+        }
+        this.modelPin = pin;
+        this.modelLabel = pin.modelID;
+        return undefined;
+      },
+    });
+  }
+
+  private async runAgentCommand(arg: string) {
+    await runOpenCodeAgentCommand({
+      arg,
+      emit: (msg) => this.emit(msg),
+      listAgents: async () => {
+        await this.ensureStarted();
+        return this.transport.agentCatalog();
+      },
+      currentAgent: this.currentAgent ?? OPENCODE_DEFAULT_AGENT,
+      setAgent: (name) => {
+        this.currentAgent = name;
+      },
+    });
+  }
+
+  /** An engine command runs as a full turn: same envelope, same event flow —
+   *  the engine's own dispatcher does the work (`/init`, custom commands). */
+  private async runEngineCommand(name: string, args: string) {
+    this.turnToken += 1;
+    this.turnActive = true;
+    this.mapper.startTurn();
+    const done = new Promise<void>((resolve) => {
+      this.turnDone = resolve;
+    });
+    try {
+      await this.ensureStarted();
+      await this.transport.command(this.sessionID as string, name, args, {
+        ...(this.modelPin ? { model: `${this.modelPin.providerID}/${this.modelPin.modelID}` } : {}),
+        ...(this.currentAgent ? { agent: this.currentAgent } : {}),
+      });
+      await done;
+    } catch (err) {
+      if (!this.closed) this.emit({ type: "error", message: errText(err) });
+      this.endTurn();
     }
   }
 
@@ -244,6 +377,7 @@ export class OpenCodeSession implements AgentSession {
       await this.transport.prompt(this.sessionID as string, {
         parts: [{ type: "text", text: prompt }],
         ...(this.modelPin ? { model: this.modelPin } : {}),
+        ...(this.currentAgent ? { agent: this.currentAgent } : {}),
       });
       // Flipped only once the engine ACCEPTED the prompt: flipping before the
       // await burns the guidance on a failed first turn and every later turn

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -1,0 +1,285 @@
+import path from "node:path";
+import { mkdirSync } from "node:fs";
+import type { WireMsg } from "../protocol";
+import { RENDER_GUIDANCE } from "../render-tools";
+import { envInt } from "../env";
+import { agentBin, errText, PERMISSION_TIMEOUT_MS, type AgentSession } from "./types";
+import { AsyncQueue, CLOSE } from "./async-queue";
+import { ResumeIdState } from "./resume-id";
+import { renderMcpCommand, MIRAFOLD_MCP } from "./render-mcp-cmd";
+import {
+  OpenCodeServerProcess,
+  type OpenCodeEvent,
+  type OpenCodeTransport,
+} from "./opencode-client";
+import { OpenCodeEventMapper } from "./opencode-events";
+
+// An aborted turn normally ends via the engine's own `session.idle`; this is
+// the honest fallback if that event never comes, so an interrupt can't wedge
+// the serial prompt queue forever.
+const INTERRUPT_GRACE_MS = envInt("MIRAFOLD_OPENCODE_INTERRUPT_GRACE_MS", 5_000);
+
+/**
+ * The OpenCode adapter: the opencode engine driven through its own
+ * `opencode serve` HTTP + SSE surface (raw, no SDK — see opencode-client.ts),
+ * one server per session, project-scoped by the session's cwd.
+ *
+ * Faithful-skin posture: we pass only Mirafold's genuine concerns — the
+ * working directory and, when configured, a `provider/model` pin per prompt.
+ * The user's own OpenCode config (their MCP servers, permission rules,
+ * custom agents) loads untouched; the render MCP arrives additively via
+ * OPENCODE_CONFIG_CONTENT, never by writing a file they own. Permission asks
+ * bridge to the shell's bar and are answered `once`/`reject` — never
+ * `always`, which would persist an approval into their own OpenCode state.
+ */
+export class OpenCodeSession implements AgentSession {
+  private queue = new AsyncQueue<string | typeof CLOSE>();
+  private listeners = new Set<(msg: WireMsg) => void>();
+  private workspaceDir: string;
+  private transport: OpenCodeTransport;
+  private mapper: OpenCodeEventMapper;
+  private resumeIdState: ResumeIdState;
+  private sessionID?: string;
+  private wantedResumeId?: string;
+  private started?: Promise<void>;
+  private closed = false;
+  private firstTurn = true;
+  private modelLabel?: string;
+  private permissionTimeoutMs: number;
+  private pendingPermissions = new Map<string, ReturnType<typeof setTimeout>>();
+  // Per-turn end latch: exactly one turn_end per prompt (idle, error,
+  // interrupt fallback, or close — whichever comes first).
+  private turnActive = false;
+  private turnDone?: () => void;
+  private turnToken = 0;
+
+  get modelName(): string | undefined {
+    return this.modelLabel;
+  }
+
+  get resumeId(): string | undefined {
+    return this.resumeIdState.value;
+  }
+
+  onResumeId(cb: (id: string) => void) {
+    this.resumeIdState.onChange(cb);
+  }
+
+  // `makeTransport` and `permissionTimeoutMs` are test seams.
+  constructor(opts: {
+    workspaceDir: string;
+    model?: string;
+    resumeId?: string;
+    makeTransport?: (config: Record<string, unknown>) => OpenCodeTransport;
+    permissionTimeoutMs?: number;
+  }) {
+    const workspaceDir = path.resolve(opts.workspaceDir);
+    mkdirSync(workspaceDir, { recursive: true });
+    this.workspaceDir = workspaceDir;
+    this.modelLabel = modelIdOf(opts.model);
+    this.wantedResumeId = opts.resumeId;
+    this.resumeIdState = new ResumeIdState(opts.resumeId);
+    this.permissionTimeoutMs = opts.permissionTimeoutMs ?? PERMISSION_TIMEOUT_MS;
+    this.modelPin = parseModelPin(opts.model);
+    const render = renderMcpCommand();
+    const configContent = {
+      mcp: {
+        [MIRAFOLD_MCP]: {
+          type: "local",
+          command: [render.command, ...render.args],
+          enabled: true,
+        },
+      },
+    };
+    this.transport =
+      opts.makeTransport?.(configContent) ??
+      new OpenCodeServerProcess({
+        bin: agentBin("OPENCODE_BIN", "opencode"),
+        cwd: workspaceDir,
+        configContent,
+      });
+    this.mapper = new OpenCodeEventMapper({
+      emit: (msg) => this.emit(msg),
+      workspaceDir,
+      isOurs: (id) => this.sessionID !== undefined && id === this.sessionID,
+      learnModel: (modelID) => {
+        this.modelLabel = modelID;
+      },
+      onPermissionAsked: (ask) => this.onPermissionAsked(ask),
+      onPermissionReplied: (requestID, reply) => this.onPermissionReplied(requestID, reply),
+      endTurn: () => this.endTurn(),
+    });
+    void this.worker();
+  }
+
+  private modelPin?: { providerID: string; modelID: string };
+
+  pushPrompt(text: string) {
+    if (!this.closed) this.queue.push(text);
+  }
+
+  onMessage(cb: (msg: WireMsg) => void) {
+    this.listeners.add(cb);
+  }
+
+  interrupt() {
+    if (!this.turnActive) return;
+    const token = this.turnToken;
+    this.denyPendingPermissions();
+    const fallback = () => {
+      if (this.turnActive && this.turnToken === token) this.endTurn();
+    };
+    if (this.sessionID) {
+      void this.transport
+        .abort(this.sessionID)
+        .catch(() => fallback())
+        .then(() => setTimeout(fallback, INTERRUPT_GRACE_MS));
+    } else {
+      fallback();
+    }
+  }
+
+  resolvePermission(id: string, allow: boolean) {
+    const timer = this.pendingPermissions.get(id);
+    if (timer === undefined) return; // stale/unknown — already resolved
+    this.resolvePermissionInternal(id, allow, timer, true);
+  }
+
+  close() {
+    if (this.closed) return;
+    this.closed = true;
+    this.denyPendingPermissions();
+    this.endTurn(); // release a worker awaiting an in-flight turn
+    this.transport.close();
+    this.queue.push(CLOSE);
+  }
+
+  private emit(msg: WireMsg) {
+    for (const cb of this.listeners) cb(msg);
+  }
+
+  private handleEvent(ev: OpenCodeEvent) {
+    if (!this.closed) this.mapper.handle(ev);
+  }
+
+  /** Spawn/attach lazily on the first turn; a failure resets the latch so a
+   *  later prompt retries (the user may have installed the binary meanwhile). */
+  private ensureStarted(): Promise<void> {
+    this.started ??= (async () => {
+      await this.transport.start((ev) => this.handleEvent(ev));
+      if (this.wantedResumeId && (await this.transport.sessionExists(this.wantedResumeId))) {
+        this.sessionID = this.wantedResumeId;
+      } else {
+        this.sessionID = (await this.transport.createSession()).id;
+      }
+      this.resumeIdState.publish(this.sessionID);
+    })();
+    return this.started.catch((err) => {
+      this.started = undefined;
+      throw err;
+    });
+  }
+
+  /** Serial queue: turns apply in prompt order, one at a time. */
+  private async worker() {
+    while (!this.closed) {
+      const item = await this.queue.next();
+      if (item === CLOSE) return;
+      await this.runTurn(item);
+    }
+  }
+
+  private async runTurn(text: string) {
+    this.turnToken += 1;
+    this.turnActive = true;
+    this.mapper.startTurn();
+    const done = new Promise<void>((resolve) => {
+      this.turnDone = resolve;
+    });
+    try {
+      await this.ensureStarted();
+      const prompt = this.firstTurn ? `${RENDER_GUIDANCE}\n\n---\n\n${text}` : text;
+      await this.transport.prompt(this.sessionID as string, {
+        parts: [{ type: "text", text: prompt }],
+        ...(this.modelPin ? { model: this.modelPin } : {}),
+      });
+      // Flipped only once the engine ACCEPTED the prompt: flipping before the
+      // await burns the guidance on a failed first turn and every later turn
+      // runs bare (the codex adapter's 2026-07-29 lesson, inherited).
+      this.firstTurn = false;
+      await done;
+    } catch (err) {
+      if (!this.closed) this.emit({ type: "error", message: errText(err) });
+      this.endTurn();
+    }
+  }
+
+  private endTurn() {
+    if (!this.turnActive) return;
+    this.turnActive = false;
+    this.mapper.endTurn();
+    if (!this.closed) this.emit({ type: "turn_end" });
+    this.turnDone?.();
+    this.turnDone = undefined;
+  }
+
+  private onPermissionAsked(ask: { id: string; permission: string; detail: string }) {
+    if (this.closed || this.pendingPermissions.has(ask.id)) return;
+    // Deny-by-default: an unanswered ask must not pin the turn open forever.
+    const timer = setTimeout(() => {
+      const pending = this.pendingPermissions.get(ask.id);
+      if (pending !== undefined) this.resolvePermissionInternal(ask.id, false, pending, true);
+    }, this.permissionTimeoutMs);
+    this.pendingPermissions.set(ask.id, timer);
+    this.emit({ type: "permission_request", tool: ask.permission, detail: ask.detail, id: ask.id });
+  }
+
+  /** protocol.ts contract: permission_request MUST resolve visibly on EVERY
+   *  path — browser answer, timeout, external reply, interrupt, close. */
+  private resolvePermissionInternal(
+    id: string,
+    allow: boolean,
+    timer: ReturnType<typeof setTimeout>,
+    replyToEngine: boolean,
+  ) {
+    clearTimeout(timer);
+    this.pendingPermissions.delete(id);
+    if (replyToEngine && this.sessionID) {
+      void this.transport
+        .replyPermission(this.sessionID, id, allow ? "once" : "reject")
+        .catch((err) => {
+          if (!this.closed)
+            this.emit({ type: "error", message: `permission reply failed: ${errText(err)}` });
+        });
+    }
+    if (!this.closed) this.emit({ type: "permission_resolved", id, allow });
+  }
+
+  /** The stream reported a reply we didn't send (another attached client). */
+  private onPermissionReplied(requestID: string, reply: string) {
+    const timer = this.pendingPermissions.get(requestID);
+    if (timer === undefined) return; // our own echo — already resolved
+    this.resolvePermissionInternal(requestID, reply !== "reject", timer, false);
+  }
+
+  private denyPendingPermissions() {
+    for (const [id, timer] of [...this.pendingPermissions])
+      this.resolvePermissionInternal(id, false, timer, true);
+  }
+}
+
+/** A configured model pin. OpenCode addresses models as `provider/model`
+ *  (the id itself may contain further slashes); a bare value can't name a
+ *  provider, so it pins nothing and the engine's own default runs —
+ *  inherit, never invent. */
+function parseModelPin(model?: string): { providerID: string; modelID: string } | undefined {
+  if (!model) return undefined;
+  const slash = model.indexOf("/");
+  if (slash <= 0 || slash === model.length - 1) return undefined;
+  return { providerID: model.slice(0, slash), modelID: model.slice(slash + 1) };
+}
+
+/** The label half of a pin, for `modelName` before the engine reports. */
+function modelIdOf(model?: string): string | undefined {
+  return parseModelPin(model)?.modelID;
+}

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -61,6 +61,12 @@ export interface AgentSession {
    * identity at the readiness boundary instead of guessing from a later
    * unrelated wire event. */
   onResumeId?(cb: (id: string) => void): void;
+  /** OC.4c: an adapter whose hello-time credential kind is OPTIMISTIC
+   * (OpenCode — the provider-resolved truth needs the running engine)
+   * publishes the classified kind here at session start. The registry
+   * updates its entry so the relay gate judges truth; until the first
+   * publish such entries are `kindPending` and refuse remote actions. */
+  onBackendKind?(cb: (update: { kind: CredentialKind; provider?: string }) => void): void;
   /** Re-read and emit the provider's pre-submit command/skill catalog. */
   refreshPromptOptions?(): void;
   close(): void;

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -16,7 +16,7 @@
  * since Phase P.4 — the browser picks which agent a session runs at onboarding,
  * so the name is part of the shared contract (adapters/types.ts re-exports it).
  */
-export type AgentName = "claude-code" | "codex" | "gemini-cli";
+export type AgentName = "claude-code" | "codex" | "gemini-cli" | "opencode";
 
 /** One provider-owned completion shown by the trusted prompt shell before a
  * prompt is submitted. `value` includes its trigger (`/model`, `$audit`), so

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -403,7 +403,9 @@ export type AgentInfo = {
   agent: AgentName;
   live: boolean;
   blocked?: boolean;
-  kind?: "api-key" | "subscription" | "local";
+  // "gateway" added 2026-08-13 (OpenCode Zen) — additive: an older bundle
+  // shows its generic fallback label for an unknown kind, nothing breaks.
+  kind?: "api-key" | "subscription" | "local" | "gateway";
   detail?: string;
   backends?: AgentBackend[];
 };
@@ -422,7 +424,7 @@ export type AgentInfo = {
  * the browser never infers this privacy claim from a hostname prefix.
  */
 export type AgentBackend = {
-  kind: "api-key" | "subscription" | "local";
+  kind: "api-key" | "subscription" | "local" | "gateway";
   usable: boolean;
   blocked?: boolean;
   detail?: string;
@@ -452,7 +454,7 @@ export type AgentBackend = {
  *  is the picked catalog entry. Labels and opaque identifiers only — never a
  *  configured URL or credential. */
 export type BackendChoice = {
-  kind: "api-key" | "subscription" | "local";
+  kind: "api-key" | "subscription" | "local" | "gateway";
   endpoint?: string;
   backendId?: string;
   provider?: string;

--- a/server/provider-policy.test.ts
+++ b/server/provider-policy.test.ts
@@ -4,6 +4,7 @@ import {
   allowedLocally,
   allowedOverRelay,
   classifyOpenCodeProvider,
+  relayGateRefusal,
   type OpenCodeProviderEntry,
 } from "./provider-policy";
 
@@ -56,10 +57,32 @@ test("anthropic/google oauth are refused naming the written terms", () => {
   }
 });
 
-test("the built-in Zen gateway fails closed until its terms are read", () => {
+test("the Zen gateway is open (Kyle 2026-08-13): gateway kind, local-only, disclosed", () => {
   const v = classifyOpenCodeProvider(entry({ id: "opencode", source: "custom", apiKeyOption: "public" }));
-  assert.equal(v.allowed, false);
-  assert.match(v.reason ?? "", /Zen/);
+  assert.deepEqual({ kind: v.kind, allowed: v.allowed }, { kind: "gateway", allowed: true });
+  // The disclosure must state uncertainty AND the training caveat, and must
+  // never read as permission.
+  assert.match(v.disclosure ?? "", /don't\s+clearly address/);
+  assert.match(v.disclosure ?? "", /improve the model/);
+  assert.match(v.disclosure ?? "", /never run over the relay/);
+  assert.equal(allowedLocally("opencode", "gateway"), true);
+  assert.equal(allowedOverRelay("gateway"), false, "gateway never relay-eligible");
+});
+
+test("the openai gray verdict carries its uncertainty disclosure", () => {
+  const v = classifyOpenCodeProvider(
+    entry({ id: "openai", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }),
+  );
+  assert.match(v.disclosure ?? "", /not clearly\s+permitted/);
+  assert.match(v.disclosure ?? "", /your account, your\s+call/);
+});
+
+test("relayGateRefusal: pending refuses outright; kinds refuse per the allow-list", () => {
+  assert.match(relayGateRefusal({ kind: "api-key", kindPending: true }) ?? "", /still verifying/);
+  assert.equal(relayGateRefusal({ kind: "api-key" }), undefined);
+  assert.equal(relayGateRefusal({ kind: "local" }), undefined);
+  assert.match(relayGateRefusal({ kind: "subscription" }) ?? "", /subscription login/);
+  assert.match(relayGateRefusal({ kind: "gateway" }) ?? "", /free-gateway/);
 });
 
 test("an unrecognized custom shape is refused, never guessed", () => {

--- a/server/provider-policy.test.ts
+++ b/server/provider-policy.test.ts
@@ -1,58 +1,78 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import type { AgentName } from "./protocol";
-import { allowedLocally, allowedOverRelay, type CredentialKind } from "./provider-policy";
+import {
+  allowedLocally,
+  allowedOverRelay,
+  classifyOpenCodeProvider,
+  type OpenCodeProviderEntry,
+} from "./provider-policy";
 
-// The whole matrix, cell by cell. This is the single source of truth for
-// which credential runs where — if a provider's terms change, this test is the
-// first thing that must change with it (R.4i).
+// OC.3: the provider-keyed OpenCode matrix. Shapes are the 1.18.18 catalog
+// facts captured with stored-credential fixtures (opencode.spike.md).
 
-const AGENTS: AgentName[] = ["claude-code", "codex", "gemini-cli"];
-const KINDS: CredentialKind[] = ["api-key", "subscription", "local", "none"];
+const entry = (over: Partial<OpenCodeProviderEntry>): OpenCodeProviderEntry => ({
+  id: "p",
+  source: "api",
+  ...over,
+});
 
-test("LOCAL use: api-key and local endpoints always run; none never does", () => {
-  for (const agent of AGENTS) {
-    assert.equal(allowedLocally(agent, "api-key"), true, `${agent} api-key`);
-    assert.equal(allowedLocally(agent, "local"), true, `${agent} local`);
-    assert.equal(allowedLocally(agent, "none"), false, `${agent} none`);
+test("a stored api key and an env key are api-key, allowed", () => {
+  for (const source of ["api", "env"] as const) {
+    const v = classifyOpenCodeProvider(entry({ id: "deepseek", source }));
+    assert.deepEqual({ kind: v.kind, allowed: v.allowed }, { kind: "api-key", allowed: true });
   }
 });
 
-test("LOCAL subscription: written bans honored; codex allowed as a DISCLOSED gray area", () => {
-  // Anthropic + Google prohibit it in writing → refused outright. OpenAI has
-  // no written permission either way but a visibly permissive posture, so the
-  // disclosed-uncertainty rule (K.3 amendment, 2026-07-15) allows it locally —
-  // the codex CONNECT_HINT must carry the uncertainty disclosure (asserted in
-  // web/src/agents-meta.test.ts), and the relay still refuses it below.
-  assert.equal(allowedLocally("codex", "subscription"), true, "disclosed-uncertainty rule");
-  assert.equal(allowedLocally("claude-code", "subscription"), false, "Anthropic ToS ban");
-  assert.equal(allowedLocally("gemini-cli", "subscription"), false, "Gemini ToS ban / tier cutoff");
+test("a user-config provider is BYO local, allowed", () => {
+  const v = classifyOpenCodeProvider(entry({ id: "ollama", source: "config" }));
+  assert.deepEqual({ kind: v.kind, allowed: v.allowed }, { kind: "local", allowed: true });
 });
 
-test("RELAY: the terms gate refuses subscription only — api-key, local, demo pass", () => {
-  for (const agent of AGENTS) {
-    assert.equal(allowedOverRelay("api-key"), true);
-    assert.equal(allowedOverRelay("local"), true);
-    assert.equal(allowedOverRelay("none"), true, "a credential-less demo has no provider/ToS");
-    // The key rule: even OpenAI's subscription — fine locally — is refused over
-    // the paid relay (charging for remote access trips the reselling clauses).
-    assert.equal(allowedOverRelay("subscription"), false, `${agent} subscription over relay`);
+test("openai oauth is the one allowed subscription (the disclosed gray area)", () => {
+  const v = classifyOpenCodeProvider(
+    entry({ id: "openai", source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }),
+  );
+  assert.deepEqual({ kind: v.kind, allowed: v.allowed }, { kind: "subscription", allowed: true });
+});
+
+test("every other oauth is refused with its reason — including ones never classified", () => {
+  for (const id of ["github-copilot", "gitlab", "poe", "some-future-provider"]) {
+    const v = classifyOpenCodeProvider(
+      entry({ id, source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }),
+    );
+    assert.equal(v.kind, "subscription");
+    assert.equal(v.allowed, false, `${id} must fail closed`);
+    assert.match(v.reason ?? "", /API key/);
   }
 });
 
-test("RELAY: the gate is an allow-list — an unrecognized kind fails CLOSED (refused)", () => {
-  // The gate guards a legal/reselling line, so a credential kind added in the
-  // future must default to REFUSED, not allowed. Cast past the closed union to
-  // prove the allow-list keeps an unknown kind off the relay.
-  assert.equal(allowedOverRelay("some-future-kind" as CredentialKind), false);
-  assert.equal(allowedOverRelay("" as CredentialKind), false);
+test("anthropic/google oauth are refused naming the written terms", () => {
+  for (const id of ["anthropic", "google"]) {
+    const v = classifyOpenCodeProvider(
+      entry({ id, source: "custom", apiKeyOption: "opencode-oauth-dummy-key" }),
+    );
+    assert.equal(v.allowed, false);
+    assert.match(v.reason ?? "", /written terms/);
+  }
 });
 
-test("every kind resolves to a boolean for every agent (no unreachable cell)", () => {
-  for (const agent of AGENTS) {
-    for (const kind of KINDS) {
-      assert.equal(typeof allowedLocally(agent, kind), "boolean");
-      assert.equal(typeof allowedOverRelay(kind), "boolean");
-    }
-  }
+test("the built-in Zen gateway fails closed until its terms are read", () => {
+  const v = classifyOpenCodeProvider(entry({ id: "opencode", source: "custom", apiKeyOption: "public" }));
+  assert.equal(v.allowed, false);
+  assert.match(v.reason ?? "", /Zen/);
+});
+
+test("an unrecognized custom shape is refused, never guessed", () => {
+  const v = classifyOpenCodeProvider(entry({ id: "mystery", source: "custom" }));
+  assert.deepEqual({ kind: v.kind, allowed: v.allowed }, { kind: "none", allowed: false });
+  assert.match(v.reason ?? "", /doesn't recognize/);
+});
+
+test("agent-level opencode subscription stays fail-closed; relay gate unchanged", () => {
+  // Without a provider resolution the agent-level answer is NO (the map's
+  // fail-closed row) — the gray area only opens through the classified path.
+  assert.equal(allowedLocally("opencode", "subscription"), false);
+  assert.equal(allowedLocally("opencode", "api-key"), true);
+  assert.equal(allowedOverRelay("subscription"), false);
+  assert.equal(allowedOverRelay("api-key"), true);
 });

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -82,7 +82,13 @@ import type { AgentName } from "./protocol";
 // API-key-only = the user pays the provider directly for metered use and we sell
 // only transport — the defensible line.
 
-export type CredentialKind = "api-key" | "subscription" | "local" | "none";
+// "gateway" (added 2026-08-13, OC.4c/Zen): a vendor-hosted gateway the
+// harness itself is credentialed for (OpenCode Zen's free models — no user
+// account at all). Allowed locally as a disclosed gray area (Kyle's call,
+// 2026-08-13 — see the Zen row below); NEVER relay-eligible: the allow-list
+// in allowedOverRelay was designed so a new kind defaults to refused, and
+// gateway deliberately stays off it.
+export type CredentialKind = "api-key" | "subscription" | "local" | "gateway" | "none";
 
 // Whether a SUBSCRIPTION may drive a third-party app for free LOCAL use.
 // Anthropic + Google: NO, prohibited in writing. OpenAI: YES as a disclosed
@@ -153,6 +159,10 @@ export type OpenCodeProviderVerdict = {
   allowed: boolean;
   /** Human copy for a refusal — shown down the create-error path. */
   reason?: string;
+  /** The disclosed-uncertainty rule's required disclosure for an ALLOWED
+   *  gray-area provider — Mirafold-composed (no source badge), emitted once
+   *  at session start. States uncertainty, never permission. */
+  disclosure?: string;
 };
 
 /** Classify one connected OpenCode provider. Fail-closed: any shape this
@@ -176,7 +186,14 @@ export function classifyOpenCodeProvider(entry: OpenCodeProviderEntry): OpenCode
           kind: "subscription",
           allowed: ok,
           ...(ok
-            ? {}
+            ? {
+                // The codex CONNECT_HINT contract, session-time edition:
+                // uncertainty stated, never permission (K.3, 2026-07-15).
+                disclosure:
+                  "This session runs on your ChatGPT login through opencode — not clearly " +
+                  "permitted by OpenAI's terms, tolerated in practice; your account, your " +
+                  "call. It will never run over the relay.",
+              }
             : {
                 reason:
                   `the "${entry.id}" login in opencode is a subscription OAuth, which ` +
@@ -193,18 +210,19 @@ export function classifyOpenCodeProvider(entry: OpenCodeProviderEntry): OpenCode
         // Services for your own internal use, and not on behalf of or for
         // the benefit of any third party" (local personal use reads clean;
         // the paid relay would not); free models "during free periods" may
-        // use collected data to improve the models (a disclosure the user
-        // would need to see). This is the disclosed-uncertainty rule's exact
-        // shape, but opening a NEW provider under that rule is Kyle's call
-        // (the codex precedent, 2026-07-15), not a session's — so the row
-        // stays CLOSED until he makes it. If opened: local-only (never the
-        // relay), with the training-data caveat shown.
+        // use collected data to improve the models (disclosed below).
+        // OPENED by Kyle 2026-08-13 ("open Zen") under the
+        // disclosed-uncertainty rule: local-only — kind "gateway" is not
+        // relay-eligible (allowedOverRelay's allow-list) — with the
+        // uncertainty AND the training-data caveat stated to the user.
         return {
-          kind: "api-key",
-          allowed: false,
-          reason:
-            "the built-in OpenCode Zen free models aren't enabled in Mirafold yet — " +
-            "connect a provider API key in opencode (`opencode auth login`) to run OpenCode here",
+          kind: "gateway",
+          allowed: true,
+          disclosure:
+            "This session runs on OpenCode Zen's free models. opencode's terms don't " +
+            "clearly address third-party apps like Mirafold (our reading: fine for your " +
+            "own local use — your call), and free-period models may use prompts to " +
+            "improve the model. Local only — it will never run over the relay.",
         };
       }
       return {
@@ -224,6 +242,10 @@ export function allowedLocally(agent: AgentName, kind: CredentialKind): boolean 
     case "api-key":
     case "local":
       return true;
+    case "gateway":
+      // Only OpenCode has a gateway path (Zen, opened 2026-08-13 — the row
+      // above carries the citation and disclosure).
+      return agent === "opencode";
     case "subscription":
       return SUBSCRIPTION_LOCAL_OK[agent];
   }
@@ -247,4 +269,32 @@ export function allowedLocally(agent: AgentName, kind: CredentialKind): boolean 
  */
 export function allowedOverRelay(kind: CredentialKind): boolean {
   return kind === "api-key" || kind === "local" || kind === "none";
+}
+
+/**
+ * The relay gate's whole verdict for a session entry, pending-awareness
+ * included (OC.4c). An OpenCode session's hello-time kind is OPTIMISTIC —
+ * the truthful, provider-resolved kind only arrives once the engine starts
+ * and the session publishes it (adapters/opencode.ts) — so until then a
+ * remote viewport is refused outright: without this, a relay prompt racing
+ * the first classification could drive a subscription/gateway session under
+ * the optimistic "api-key". Returns the human refusal, or undefined when the
+ * remote action may proceed.
+ */
+export function relayGateRefusal(entry: {
+  kind: CredentialKind;
+  kindPending?: boolean;
+}): string | undefined {
+  if (entry.kindPending)
+    return (
+      "This session is still verifying which credential backs it — try again in a " +
+      "moment, or drive it from the machine it runs on."
+    );
+  if (!allowedOverRelay(entry.kind))
+    return (
+      "This session runs on a " +
+      (entry.kind === "gateway" ? "free-gateway backing" : "subscription login") +
+      ", which can't be used over the relay. Use an API key to drive an agent remotely."
+    );
+  return undefined;
 }

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -93,6 +93,12 @@ const SUBSCRIPTION_LOCAL_OK: Record<AgentName, boolean> = {
   "claude-code": false,
   "gemini-cli": false,
   codex: true,
+  // OpenCode is a multi-provider harness: whether a subscription OAuth may
+  // drive it locally is a fact about the UNDERLYING provider, not the agent
+  // (anthropic/google → prohibited in writing; openai → the disclosed gray
+  // area; copilot and others → unread, so blocked). Until PLAN OC.3 lands the
+  // provider-keyed classification here, the agent-level answer fails closed.
+  opencode: false,
 };
 
 /** May a session with this credential run for LOCAL (free) use? */

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -186,8 +186,19 @@ export function classifyOpenCodeProvider(entry: OpenCodeProviderEntry): OpenCode
         };
       }
       if (entry.id === "opencode" && entry.apiKeyOption === OPENCODE_ZEN_MARKER) {
-        // The built-in free Zen gateway. Its terms of use haven't been read
-        // and cited yet (OC.4/OC.5 gate) — fail closed until they are.
+        // The built-in free Zen gateway — TERMS READ 2026-08-13 (OC.4b,
+        // opencode.ai/legal/terms-of-service + opencode.ai/docs/zen):
+        // no prohibition on third-party harnesses (the server API we drive
+        // is opencode's own documented programmatic surface); "only use the
+        // Services for your own internal use, and not on behalf of or for
+        // the benefit of any third party" (local personal use reads clean;
+        // the paid relay would not); free models "during free periods" may
+        // use collected data to improve the models (a disclosure the user
+        // would need to see). This is the disclosed-uncertainty rule's exact
+        // shape, but opening a NEW provider under that rule is Kyle's call
+        // (the codex precedent, 2026-07-15), not a session's — so the row
+        // stays CLOSED until he makes it. If opened: local-only (never the
+        // relay), with the training-data caveat shown.
         return {
           kind: "api-key",
           allowed: false,

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -101,6 +101,110 @@ const SUBSCRIPTION_LOCAL_OK: Record<AgentName, boolean> = {
   opencode: false,
 };
 
+// ---------------------------------------------------------------------------
+// OpenCode: the provider-keyed half of the matrix (PLAN OC.3, 2026-08-13).
+// OpenCode is a multi-provider harness, so the credential question is asked
+// per UNDERLYING provider, answered from the RUNNING ENGINE's own catalog
+// (`GET /config/providers`) — never by parsing the user's auth.json (their
+// file; the server tells us what we need). Verified against opencode 1.18.18
+// with stored-credential fixtures (opencode.spike.md, OC.3 probe):
+//   - a stored API key surfaces as `source: "api"` (an env-var key as "env");
+//   - a ChatGPT OAuth login surfaces as `source: "custom"` with the literal
+//     marker `options.apiKey === "opencode-oauth-dummy-key"`;
+//   - the built-in free "OpenCode Zen" gateway is `source: "custom"` with
+//     `options.apiKey === "public"`;
+//   - a user-config provider (Ollama, OpenRouter, …) is `source: "config"`;
+//   - a stored ANTHROPIC oauth credential is IGNORED WHOLESALE — the
+//     provider never enters the connected set, and /provider/auth offers no
+//     Anthropic (or Google) OAuth flow at all. The blocked rows below are
+//     belt-and-suspenders for other engine versions, not a live path.
+// The oauth marker string is version-specific; classification fails closed
+// on anything unrecognized, so engine drift degrades to "refused with a
+// reason", never to "waved through" (same posture as allowedOverRelay).
+
+/** One row of the engine's provider catalog, pre-stripped by the transport —
+ *  the catalog exposes RAW STORED SECRETS (`key`), which must never travel
+ *  past that seam, so this shape deliberately cannot carry them. */
+export type OpenCodeProviderEntry = {
+  id: string;
+  source: "env" | "config" | "custom" | "api";
+  /** The catalog's `options.apiKey` — a MARKER, not a secret ("public",
+   *  "opencode-oauth-dummy-key"); real keys ride `key`, which is stripped. */
+  apiKeyOption?: string;
+};
+
+const OPENCODE_OAUTH_MARKER = "opencode-oauth-dummy-key";
+const OPENCODE_ZEN_MARKER = "public";
+
+// Which providers' subscription OAuth may drive OpenCode locally. Only
+// OpenAI qualifies (the same disclosed-uncertainty call as the codex
+// adapter's ChatGPT login — uncertain terms, permissive posture, minimal
+// exposure). Everything else — GitHub Copilot, GitLab Duo, Poe,
+// DigitalOcean, Snowflake, xAI, and whatever a future version adds — stays
+// false until its terms have actually been read and cited here.
+const OPENCODE_SUBSCRIPTION_LOCAL_OK: Record<string, boolean | undefined> = {
+  openai: true,
+  anthropic: false, // written prohibition; also not even offered by 1.18.18
+  google: false, // written prohibition; same
+};
+
+export type OpenCodeProviderVerdict = {
+  kind: CredentialKind;
+  allowed: boolean;
+  /** Human copy for a refusal — shown down the create-error path. */
+  reason?: string;
+};
+
+/** Classify one connected OpenCode provider. Fail-closed: any shape this
+ *  version of the matrix doesn't recognize is refused with its reason. */
+export function classifyOpenCodeProvider(entry: OpenCodeProviderEntry): OpenCodeProviderVerdict {
+  switch (entry.source) {
+    case "api":
+    case "env":
+      // The user's own metered key (stored via `opencode auth login` or an
+      // environment variable) — the fully supported path, relay-eligible.
+      return { kind: "api-key", allowed: true };
+    case "config":
+      // A provider the user declared in their own opencode config (Ollama,
+      // OpenRouter, …): they pointed the engine elsewhere — BYO, like a
+      // codex config.toml provider.
+      return { kind: "local", allowed: true };
+    case "custom": {
+      if (entry.apiKeyOption === OPENCODE_OAUTH_MARKER) {
+        const ok = OPENCODE_SUBSCRIPTION_LOCAL_OK[entry.id] ?? false;
+        return {
+          kind: "subscription",
+          allowed: ok,
+          ...(ok
+            ? {}
+            : {
+                reason:
+                  `the "${entry.id}" login in opencode is a subscription OAuth, which ` +
+                  `can't drive a third-party app${entry.id === "anthropic" || entry.id === "google" ? " (provider's written terms)" : " (terms unread — refused until they are)"} — ` +
+                  `connect ${entry.id} with an API key in opencode instead`,
+              }),
+        };
+      }
+      if (entry.id === "opencode" && entry.apiKeyOption === OPENCODE_ZEN_MARKER) {
+        // The built-in free Zen gateway. Its terms of use haven't been read
+        // and cited yet (OC.4/OC.5 gate) — fail closed until they are.
+        return {
+          kind: "api-key",
+          allowed: false,
+          reason:
+            "the built-in OpenCode Zen free models aren't enabled in Mirafold yet — " +
+            "connect a provider API key in opencode (`opencode auth login`) to run OpenCode here",
+        };
+      }
+      return {
+        kind: "none",
+        allowed: false,
+        reason: `provider "${entry.id}" has a credential shape Mirafold doesn't recognize — refused rather than guessed`,
+      };
+    }
+  }
+}
+
 /** May a session with this credential run for LOCAL (free) use? */
 export function allowedLocally(agent: AgentName, kind: CredentialKind): boolean {
   switch (kind) {

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -15,7 +15,7 @@ import {
   resolveChosenBackend,
   type Backend,
 } from "../adapters";
-import { allowedOverRelay } from "../provider-policy";
+import { relayGateRefusal } from "../provider-policy";
 import { probeLocalServers } from "../local-models";
 import { createLogger } from "../log";
 import { VERSION } from "../version";
@@ -31,12 +31,9 @@ import { folderPickerAvailable } from "../folder-picker";
 // cached answer instead of re-probing localhost.
 const REFRESH_MIN_INTERVAL_MS = envInt("REFRESH_MIN_INTERVAL_MS", 1_000);
 
-// What a remote (relay) connection is told when a cockpit act would drive a
-// subscription-backed session (M.2) — the same reasoning as the attach gate's
-// refusal (R.4i), phrased for an action instead of an attach.
-const RELAY_GATE_REFUSAL =
-  "This session runs on a subscription login, which can't be driven over the relay. " +
-  "Use an API key to drive an agent remotely.";
+// The relay refusal copy now lives with the rule (provider-policy.ts
+// relayGateRefusal, OC.4c) so the attach gate, cockpit acts, and uploads say
+// the same words about the same verdict — pending-kind included.
 
 // Agents the browser is allowed to name at onboarding (P.4). A create message
 // naming anything else falls back to the daemon default rather than erroring.
@@ -139,14 +136,16 @@ export function openConnection(
     // creates too — 2026-07-29 bughunt. The important case this gate closes
     // is a phone attaching to a subscription session a local tab started.)
     // (R.4i)
-    if (remote && !allowedOverRelay(e.kind)) {
+    const relayRefusal = remote ? relayGateRefusal(e) : undefined;
+    if (relayRefusal) {
       viewport({
         type: "refused",
         reason: "subscription-relay",
-        message:
-          "This session runs on a subscription login, which can't be used over the relay. Use an API key to drive an agent remotely.",
+        message: relayRefusal,
       });
-      log.info(`refused remote viewport → session ${e.id} (${e.kind})`);
+      log.info(
+        `refused remote viewport → session ${e.id} (${e.kind}${e.kindPending ? ", pending" : ""})`,
+      );
       return false;
     }
     if (entry) registry.detach(entry, viewport);
@@ -232,8 +231,9 @@ export function openConnection(
       sendError(`no such session: ${sessionId}`);
       return undefined;
     }
-    if (drivesModel && remote && !allowedOverRelay(target.kind)) {
-      sendError(RELAY_GATE_REFUSAL);
+    const actRefusal = drivesModel && remote ? relayGateRefusal(target) : undefined;
+    if (actRefusal) {
+      sendError(actRefusal);
       // `open()` may just have lazily revived a dormant engine. A refused
       // remote act owns no viewport, so return that engine to the ordinary
       // idle-unload path instead of leaving it warm indefinitely.

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -163,6 +163,12 @@ export type SessionEntry = {
   // The credential kind behind this session — read by the relay gate in
   // connection.ts to refuse a subscription-backed session over the paid relay (R.4i).
   kind: CredentialKind;
+  // OC.4c: true while `kind` is the hello-time OPTIMISTIC answer for an
+  // adapter that can only classify truthfully once its engine starts
+  // (OpenCode). The relay gate refuses remote actions outright until the
+  // session's onBackendKind publish clears it — provider-policy.ts
+  // relayGateRefusal.
+  kindPending?: boolean;
   // Exact server-side backend selection, persisted so recovery cannot silently
   // move the conversation to a different credential/provider/model server.
   // A configured endpoint URL can itself be sensitive; it never rides the wire.
@@ -385,6 +391,22 @@ export class SessionRegistry {
     entry.session.onResumeId?.(() => {
       if (this.entries.get(entry.id) === entry) this.checkpoint(entry);
     });
+    // OC.4c: an adapter with an optimistic hello-time kind publishes the
+    // truthful one once its engine classifies the pinned provider. Until
+    // then the entry is kindPending and the relay gate refuses remote
+    // actions (provider-policy.ts relayGateRefusal). The truthful kind is
+    // checkpointed so recovery starts from it — and re-verifies anyway.
+    if (entry.session.onBackendKind) {
+      entry.kindPending = true;
+      entry.session.onBackendKind((update) => {
+        if (this.entries.get(entry.id) !== entry) return;
+        entry.kind = update.kind;
+        entry.kindPending = false;
+        entry.backend.kind = update.kind;
+        if (update.provider) entry.backend.provider = update.provider;
+        this.checkpoint(entry);
+      });
+    }
     entry.session.refreshPromptOptions?.();
     this.checkpoint(entry);
     this.notifyWatchers();

--- a/server/sessions/upload-handlers.ts
+++ b/server/sessions/upload-handlers.ts
@@ -15,7 +15,7 @@ import os from "node:os";
 import path from "node:path";
 import type { ClientMsg, WireMsg } from "../protocol";
 import type { SessionEntry } from "./registry";
-import { allowedOverRelay } from "../provider-policy";
+import { relayGateRefusal } from "../provider-policy";
 import { envInt } from "../env";
 import { CLIENT_ID_RE } from "./fs-handlers";
 import { createLogger } from "../log";
@@ -38,11 +38,8 @@ export const FILE_UPLOAD_MAX_CHUNK_BYTES = envInt("FILE_UPLOAD_MAX_CHUNK_BYTES",
 // abort) — reap it so its memory isn't held for the connection's life.
 export const FILE_UPLOAD_STALL_MS = envInt("FILE_UPLOAD_STALL_MS", 30_000);
 
-// Same wording as the prompt/cockpit relay gate (R.4i): an upload is model
-// input staging, so it follows the same rule.
-const UPLOAD_RELAY_REFUSAL =
-  "This session runs on a subscription login, which can't be used over the relay. " +
-  "Use an API key to drive an agent remotely.";
+// An upload is model input staging, so it follows the prompt/cockpit relay
+// gate exactly — one verdict, one wording (provider-policy.ts, OC.4c).
 
 /** Path-free, control-free, bounded display name; never empty. */
 export function safeUploadName(raw: unknown): string {
@@ -144,8 +141,9 @@ export function createUploadHandlers({ viewport, getEntry, remote }: UploadDeps)
         fail(msg.id, "no session attached");
         return;
       }
-      if (remote && !allowedOverRelay(entry.kind)) {
-        fail(msg.id, UPLOAD_RELAY_REFUSAL);
+      const relayRefusal = remote ? relayGateRefusal(entry) : undefined;
+      if (relayRefusal) {
+        fail(msg.id, relayRefusal);
         return;
       }
       if (active.has(msg.id)) {

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -381,13 +381,20 @@ test("the agent picker flexes to the window — no internal scrollbar through th
   // are mostly ready (same recipe as the R.4k test below), swept through the
   // squeeze ramp's lower band, where pre-fix EVERY height here scrolled.
   const token = "e2e-squeeze-9c2f";
-  // All three rows ready (one-line details, no paragraph hints) — display
-  // only, nothing is clicked, so no engine ever spawns.
+  // All four rows ready (one-line details, no paragraph hints) — display
+  // only, nothing is clicked, so no engine ever spawns. OpenCode's readiness
+  // is an existence probe (binary + auth.json), so a stand-in binary and an
+  // empty stored-credential file are enough to get the short row.
+  const opencodeData = mkdtempSync(path.join(os.tmpdir(), "mirafold-squeeze-ocd-"));
+  mkdirSync(path.join(opencodeData, "opencode"));
+  writeFileSync(path.join(opencodeData, "opencode", "auth.json"), "{}");
   const d2 = await startDaemon({
     MIRAFOLD_TOKEN: token,
     ANTHROPIC_BASE_URL: "http://localhost:11434",
     OPENAI_API_KEY: "e2e-not-a-real-key",
     GEMINI_API_KEY: "e2e-not-a-real-key",
+    OPENCODE_BIN: "/bin/true", // display-only: never spawned
+    XDG_DATA_HOME: opencodeData,
   });
   const page2 = await browser.newPage();
   try {
@@ -521,7 +528,14 @@ test("onboarding → a full mock turn renders in the DOM", async () => {
   // Every credential-less row carries its one-line fix on the picker
   // itself (the harness forces all three agents credential-less) (R.4b).
   await page.waitForSelector(".onb-agent-hint");
-  assert.equal(await page.locator(".onb-agent-hint").count(), 3);
+  // One hint per offerable agent (the harness forces every agent
+  // credential-less) — four since the OpenCode adapter (PLAN OC.4b).
+  assert.equal(await page.locator(".onb-agent-hint").count(), 4);
+  const opencodeRowText = await page
+    .locator(".onb-agent", { hasText: "OpenCode" })
+    .innerText();
+  assert.match(opencodeRowText, /opencode auth login/);
+  assert.match(opencodeRowText, /OPENCODE_MODEL/);
   const claudeRow = page.locator(".onb-agent", { hasText: "Claude Code" });
   assert.match(await claudeRow.innerText(), /ANTHROPIC_API_KEY|`claude`/);
   // Disclosed-uncertainty rule (K.3 amendment, 2026-07-15): the Codex row

--- a/web/src/agents-meta.ts
+++ b/web/src/agents-meta.ts
@@ -28,7 +28,7 @@ export const CONNECT_HINT: Record<AgentName, string> = {
   "gemini-cli":
     "set GEMINI_API_KEY (free key at aistudio.google.com/apikey) — Gemini has no local path",
   opencode:
-    "install opencode (opencode.ai), connect a provider with an API key via `opencode auth login` — or declare a local/BYO provider (Ollama, OpenRouter, …) in your opencode config — then set OPENCODE_MODEL=<provider>/<model>. Subscription logins (ChatGPT, Copilot) and the built-in free Zen models aren't usable here yet",
+    "install opencode (opencode.ai) — its built-in free Zen models then work out of the box (set OPENCODE_MODEL=<provider>/<model>, e.g. opencode/big-pickle; free-period prompts may train the models). Or connect a provider API key via `opencode auth login`, or declare a local/BYO provider (Ollama, OpenRouter, …) in your opencode config. A ChatGPT login works too — not clearly permitted by OpenAI's terms, tolerated in practice; your account, your call. Other subscription logins (Copilot, …) aren't usable",
 };
 
 // The hint for a BLOCKED agent — a prohibited subscription credential is
@@ -85,7 +85,13 @@ export function blockedHint(agent: string): string | undefined {
  *  "OpenAI API key" — ChatGPT is their SUBSCRIPTION brand and they keep the
  *  two apart, which is why the subscription labels below don't match these
  *  one-for-one. That asymmetry is theirs, and inheriting it is the point. */
-export function backendLabel(agent: string, kind: "api-key" | "subscription" | "local"): string {
+export function backendLabel(
+  agent: string,
+  kind: "api-key" | "subscription" | "local" | "gateway",
+): string {
+  // OpenCode Zen (2026-08-13): the engine's built-in free gateway — no user
+  // account behind it, so neither "API key" nor "subscription" is honest.
+  if (kind === "gateway") return "OpenCode Zen (free models)";
   if (kind === "api-key") {
     if (agent === "codex") return "OpenAI API key";
     if (agent === "claude-code") return "Claude API key";
@@ -118,7 +124,7 @@ export function localBackendLabel(agent: string, detail: string | undefined): st
  *  routes name the backing identically. */
 export function backingLine(
   agent: string,
-  kind: "api-key" | "subscription" | "local" | undefined,
+  kind: "api-key" | "subscription" | "local" | "gateway" | undefined,
   detail: string | undefined,
 ): string | undefined {
   if (!kind) return detail;

--- a/web/src/agents-meta.ts
+++ b/web/src/agents-meta.ts
@@ -9,6 +9,7 @@ export const LABEL: Record<AgentName, string> = {
   "claude-code": "Claude Code",
   codex: "Codex",
   "gemini-cli": "Gemini CLI",
+  opencode: "OpenCode",
 };
 
 // R.4i/R.4k: the hint for a NO-credentials agent — the one action that makes it
@@ -26,6 +27,9 @@ export const CONNECT_HINT: Record<AgentName, string> = {
     "run `codex login` (ChatGPT subscription — not clearly permitted by OpenAI's terms, tolerated in practice; your account, your call) or set OPENAI_API_KEY (platform.openai.com/api-keys) — or point Codex at a local model (Ollama/LM Studio/vLLM) or any OpenAI-compatible provider (e.g. OpenRouter) via ~/.codex/config.toml (recipe: docs/local-models.md)",
   "gemini-cli":
     "set GEMINI_API_KEY (free key at aistudio.google.com/apikey) — Gemini has no local path",
+  // Placeholder until PLAN OC.4 writes the real onboarding surface (the
+  // agent isn't offered before then — not in ADAPTER_AGENTS).
+  opencode: "install opencode (opencode.ai) and connect a provider with `opencode auth login`",
 };
 
 // The hint for a BLOCKED agent — a prohibited subscription credential is

--- a/web/src/agents-meta.ts
+++ b/web/src/agents-meta.ts
@@ -27,9 +27,8 @@ export const CONNECT_HINT: Record<AgentName, string> = {
     "run `codex login` (ChatGPT subscription — not clearly permitted by OpenAI's terms, tolerated in practice; your account, your call) or set OPENAI_API_KEY (platform.openai.com/api-keys) — or point Codex at a local model (Ollama/LM Studio/vLLM) or any OpenAI-compatible provider (e.g. OpenRouter) via ~/.codex/config.toml (recipe: docs/local-models.md)",
   "gemini-cli":
     "set GEMINI_API_KEY (free key at aistudio.google.com/apikey) — Gemini has no local path",
-  // Placeholder until PLAN OC.4 writes the real onboarding surface (the
-  // agent isn't offered before then — not in ADAPTER_AGENTS).
-  opencode: "install opencode (opencode.ai) and connect a provider with `opencode auth login`",
+  opencode:
+    "install opencode (opencode.ai), connect a provider with an API key via `opencode auth login` — or declare a local/BYO provider (Ollama, OpenRouter, …) in your opencode config — then set OPENCODE_MODEL=<provider>/<model>. Subscription logins (ChatGPT, Copilot) and the built-in free Zen models aren't usable here yet",
 };
 
 // The hint for a BLOCKED agent — a prohibited subscription credential is
@@ -91,6 +90,10 @@ export function backendLabel(agent: string, kind: "api-key" | "subscription" | "
     if (agent === "codex") return "OpenAI API key";
     if (agent === "claude-code") return "Claude API key";
     if (agent === "gemini-cli") return "Gemini API key";
+    // OpenCode's row backs onto whichever provider credential its own auth
+    // store holds — no single vendor name exists until the session resolves
+    // the pinned provider (OC.3), so the row names the mechanism.
+    if (agent === "opencode") return "API key (via opencode)";
     return "API key";
   }
   if (kind === "local") return "local endpoint";

--- a/web/src/components/PromptBox.tsx
+++ b/web/src/components/PromptBox.tsx
@@ -29,6 +29,8 @@ function promptSourceLabel(option: PromptOption): string | undefined {
       return option.kind === "skill" ? "Codex skill" : "Codex command";
     case "gemini-cli":
       return "Gemini CLI command";
+    case "opencode":
+      return "OpenCode command";
     case "mirafold":
       return "Mirafold demo";
     default:

--- a/web/src/styles/12-dialogs.css
+++ b/web/src/styles/12-dialogs.css
@@ -29,7 +29,11 @@
   background: var(--overlay);
   backdrop-filter: blur(3px);
   padding: calc(12px + var(--onb-squeeze) * 0.75) 24px; /* 12→24px */
-  --onb-squeeze: clamp(0px, calc(9.1vh - 66px), 16px);
+  /* Intercept moved 66→70 when the FOURTH agent row landed (OC.4b): the
+     floor now arrives ~44px of window earlier, buying the compression the
+     extra row needs through the 730–760px band. Tall-window chrome (the
+     16px cap) is untouched. */
+  --onb-squeeze: clamp(0px, calc(9.1vh - 70px), 16px);
 }
 
 .onb-card {
@@ -147,7 +151,7 @@
 .onb-list {
   display: flex;
   flex-direction: column;
-  gap: calc(7px + var(--onb-squeeze) * 0.1875); /* 7→10px */
+  gap: calc(5px + var(--onb-squeeze) * 0.3125); /* 5→10px */
 }
 
 .onb-connecting {
@@ -161,8 +165,8 @@
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  gap: calc(3px + var(--onb-squeeze) * 0.25); /* 3→7px */
-  padding: calc(10px + var(--onb-squeeze) * 0.4375) calc(14px + var(--onb-squeeze) * 0.3125); /* 10→17px / 14→19px */
+  gap: calc(2px + var(--onb-squeeze) * 0.3125); /* 2→7px */
+  padding: calc(8px + var(--onb-squeeze) * 0.5625) calc(14px + var(--onb-squeeze) * 0.3125); /* 8→17px / 14→19px */
   background: var(--surface-2);
   border: 1px solid var(--border-mid);
   border-radius: 9px;


### PR DESCRIPTION
The most popular open-source terminal agent becomes Mirafold's fourth adapter, spike to live confirmation in one arc (PLAN Phase OC, all steps checked).

## What ships
- **Core adapter** (`server/adapters/opencode.ts` + events + client): one `opencode serve` per session driven raw over its documented HTTP+SSE surface (no SDK — the live probe caught the published types drifting from the real server; shapes come from captured ground truth). Streaming deltas, tool lifecycle, todo checklist, usage, resume via engine session ids.
- **Generative UI + permissions**: the render MCP injects additively via `OPENCODE_CONFIG_CONTENT` — no user-owned file is ever touched; `permission.asked` bridges to the shell bar, answered `once`/`reject` (never `always`), deny-by-default timeout, external replies honored.
- **Provider-keyed credential policy** (`provider-policy.ts`): classified from the running engine's own catalog (never by parsing auth.json; the catalog's raw stored secrets are stripped at the transport seam). Fail-closed for unknown OAuth; ChatGPT gray runs locally with its uncertainty disclosure; **OpenCode Zen opened** (Kyle, 2026-08-13) as a new `gateway` kind — local-only, never relay-eligible, training-data caveat disclosed.
- **Kind-truth relay gating**: sessions publish their classified kind (`onBackendKind`); entries are `kindPending` until then and remote actions refuse outright — closing the race where a relay prompt could slip through under the optimistic hello-kind. One shared `relayGateRefusal` verdict across attach/acts/uploads.
- **Fidelity surface**: `/model` (policy-filtered cross-provider picker), `/agent` (user-facing primaries only), engine commands dispatched via `POST /session/:id/command`, prompt-options catalog; onboarding card with honest copy; the squeeze ramp recalibrated for four agent rows.
- **Tier-4 live test** (`opencode-live.ltest.ts`): the real binary, a scripted loopback provider (no hosted model), jailed HOME/XDG — render, permission round-trip, usage, and resume across an engine restart in ~17s; clean skip where opencode isn't installed.

## Verification
Tier-1 761/761 · Tier-2 152/152 · Tier-3 97/97 · Tier-4 live 1/1 · typecheck clean — plus a live browser session on Zen from a fresh real install, confirmed by Kyle.

Spike doc with all captured shapes and probe evidence: `server/adapters/opencode.spike.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)