### PR TITLE
Gemini gentle sunset — deprecated in-product, removal evidence-gated

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2860,6 +2860,29 @@ gates come first.
   browser session on Zen: "heyyyy it works". Phase OC complete.
   README/ADAPTERS.md refresh rides the wrapup.
 
+## Gemini sunset (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
+
+**Product call.** From the 2026-08-13 market check: Google retired Gemini
+CLI upstream on 2026-06-18 (closed-source Antigravity replaced it; the
+dated citation lives in provider-policy.ts's R.6 note). Kyle's calls, in
+order: sunset rather than migrate (same day, morning), hold while other
+work was in flight, then "do the gemini sunset" (same day, after Phase OC
+merged). Shape: **gentle** — the API-key path still functions under the
+Gemini API ToS, so nothing is removed or hidden; the adapter is deprecated
+honestly. Removal is parked in POST-RELEASE.md, gated on evidence of
+actual breakage, never on a calendar.
+
+- [x] **Deprecation surface** — completed 2026-08-13: additive
+  `AgentInfo.deprecated` (daemon-composed reason; the picker renders it as
+  a suffix on the existing status line — no new element, the squeeze
+  ramp's height budget holds), connect-hint copy updated with the dated
+  retirement, a once-per-session dated notice in the Gemini adapter
+  (Mirafold-composed, lands before the first turn completes), the
+  provider-policy row annotated (policy itself unchanged), and the
+  POST-RELEASE removal entry with its evidence gate. Tier-1 tests: the
+  notice rides once and unbadged; `deprecated` rides the hello for gemini
+  only.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -252,3 +252,13 @@ has a home in this plan, the entry points there instead of duplicating it.
 
 ---
 
+
+- [ ] **Gemini adapter removal** — the second half of the 2026-08-13 gentle
+  sunset (PLAN "Gemini sunset"). Google retired Gemini CLI upstream
+  2026-06-18; the adapter is deprecated in-product (picker suffix, dated
+  session notice) but keeps working while the API-key path does. Remove the
+  adapter — `gemini-cli.ts` + satellites, the `AgentName` member stays wire-
+  reserved — only on EVIDENCE: the archived CLI stops accepting API keys, a
+  Gemini API shutoff, or usage signal that nobody runs it. Never silently;
+  the removal release notes name the date and the alternative (OpenCode
+  drives Gemini-family models via BYO providers).

--- a/server/adapters/codex-binding.ts
+++ b/server/adapters/codex-binding.ts
@@ -95,7 +95,11 @@ export function createCodexRuntimeBinding(options: {
 
   // Drive the user's installed Codex when present so the terminal and SDK
   // share one engine version; machines without it retain the SDK fallback.
-  const installedCodex = installedAgentBin("MIRAFOLD_CODEX_BIN", "codex");
+  // An explicit override is SPAWN intent and rides verbatim — even missing,
+  // so the first turn ENOENTs honestly (the detection/spawn split of
+  // types.ts, 2026-08-13); only the unset case consults installation lookup.
+  const installedCodex =
+    process.env.MIRAFOLD_CODEX_BIN || installedAgentBin("MIRAFOLD_CODEX_BIN", "codex");
   const codex = (options.makeCodex ?? ((codexOptions: CodexOptions) => new Codex(codexOptions)))({
     ...(installedCodex ? { codexPathOverride: installedCodex } : {}),
     ...(kind === "api-key" && process.env.OPENAI_API_KEY

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -113,6 +113,25 @@ test("recovery and discovery: Gemini resumes the saved id and advertises only it
   delete process.env.FAKE_ARGS_LOG;
 });
 
+test("the sunset notice rides the first turn once — dated, ours, then never again", async () => {
+  const { s, msgs, awaitTurnEnd } = makeSession();
+  s.pushPrompt("hello");
+  await awaitTurnEnd();
+  s.pushPrompt("again");
+  await awaitTurnEnd(2);
+  const notices = msgs.filter(
+    (m) => m.type === "notice" && /retired Gemini CLI upstream on 2026-06-18/.test(m.text),
+  );
+  assert.equal(notices.length, 1, "once per session, not per turn");
+  assert.equal(notices[0].source, undefined, "Mirafold-composed — no engine badge");
+  assert.match(notices[0].text, /deprecated/);
+  assert.ok(
+    msgs.findIndex((m) => m.type === "notice") < msgs.findIndex((m) => m.type === "turn_end"),
+    "the notice lands before the first turn completes",
+  );
+  s.close();
+});
+
 test("a pre-existing settings.json — broken or valid — is untouched at construction; a turn is what earns consent to merge it", async () => {
   // Unparseable: construction touches NOTHING. Only once a turn actually runs
   // (this workspace is pre-trusted, under `tmp`) does the rewrite+backup happen.

--- a/server/adapters/gemini-cli.ts
+++ b/server/adapters/gemini-cli.ts
@@ -379,7 +379,23 @@ export class GeminiCliSession implements AgentSession {
     return this.spawnTurn(text);
   }
 
+  // Gemini sunset (2026-08-13): one dated, Mirafold-composed line per
+  // session. Google retired Gemini CLI upstream on 2026-06-18 (the R.6 note
+  // in provider-policy.ts); the API-key path still functions, so the adapter
+  // keeps working — deprecated honestly rather than removed or hidden.
+  private sunsetNoticed = false;
+
   private spawnTurn(text: string): Promise<void> {
+    if (!this.sunsetNoticed) {
+      this.sunsetNoticed = true;
+      this.emit({
+        type: "notice",
+        text:
+          "Google retired Gemini CLI upstream on 2026-06-18 (Antigravity replaced it). " +
+          "Your Gemini API key keeps working here for now, but this adapter is " +
+          "deprecated and will be removed in a future release.",
+      });
+    }
     return new Promise((resolve) => {
       // V.2: the headless stream-json surface has no system-prompt/instructions
       // hook (unlike Claude's `systemPrompt.append`), so RENDER_GUIDANCE rides

--- a/server/adapters/index.test.ts
+++ b/server/adapters/index.test.ts
@@ -187,6 +187,10 @@ test("a live agent advertises the kind behind it", () => {
       assert.equal(gemini.live, true);
       assert.equal(gemini.kind, "api-key");
       assert.equal(gemini.detail, undefined); // no model override — the kind stands alone
+      // Gemini sunset (2026-08-13): deprecated rides the hello — live or not,
+      // and no other agent carries it.
+      assert.match(gemini.deprecated ?? "", /retired upstream/);
+      assert.ok(availableAgents().every((a) => a.agent === "gemini-cli" || !a.deprecated));
     });
     withEnv({ CLAUDE_CONFIG_DIR: empty, ANTHROPIC_BASE_URL: "http://localhost:11434" }, () => {
       assert.equal(claude().kind, "local");

--- a/server/adapters/index.ts
+++ b/server/adapters/index.ts
@@ -439,6 +439,10 @@ export function availableAgents(): AgentInfo[] {
     return {
       agent,
       live,
+      // Gemini sunset (Kyle, 2026-08-13): Google retired Gemini CLI upstream
+      // on 2026-06-18 (provider-policy.ts R.6 note). The adapter keeps
+      // working while API keys do — deprecated, visible, never hidden.
+      ...(agent === "gemini-cli" ? { deprecated: "retired upstream" } : {}),
       ...(kind === "subscription" && !live ? { blocked: true } : {}),
       // The KIND rides as a fact; the client owns its wording (agents-meta's
       // backendLabel), so the one-click row and the second step say the same

--- a/server/adapters/types.test.ts
+++ b/server/adapters/types.test.ts
@@ -29,11 +29,25 @@ function executable(file: string): void {
   if (process.platform !== "win32") chmodSync(file, 0o755);
 }
 
-test("installedAgentBin honors the explicit operator override", () => {
+test("installedAgentBin honors the operator override — but a missing file is not an install", () => {
   const key = "MIRAFOLD_TEST_AGENT_BIN";
+  // Absolute + missing: NOT detected as installed (no "ready" card for a
+  // binary that can only ENOENT) — yet the spawn path keeps the operator's
+  // explicit choice so the first turn fails honestly. This split is also how
+  // the harnesses force an agent absent on machines that really have it.
   withEnv({ [key]: "/operator/chosen/agent" }, () => {
-    assert.equal(installedAgentBin(key, "agent"), "/operator/chosen/agent");
+    assert.equal(installedAgentBin(key, "agent"), undefined);
     assert.equal(agentBin(key, "agent"), "/operator/chosen/agent");
+  });
+  // Absolute + present: both agree.
+  withEnv({ [key]: process.execPath }, () => {
+    assert.equal(installedAgentBin(key, "agent"), process.execPath);
+    assert.equal(agentBin(key, "agent"), process.execPath);
+  });
+  // A bare name can't be stat'ed — trusted as-is (resolved at spawn time).
+  withEnv({ [key]: "custom-agent" }, () => {
+    assert.equal(installedAgentBin(key, "agent"), "custom-agent");
+    assert.equal(agentBin(key, "agent"), "custom-agent");
   });
 });
 

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { existsSync } from "node:fs";
 import type { AgentName, PromptOption, WireMsg } from "../protocol";
 import type { CredentialKind } from "../provider-policy";
 import { locateTrustedExecutable } from "../security/executable-trust";
@@ -6,25 +7,35 @@ import { locateTrustedExecutable } from "../security/executable-trust";
 export type { AgentName } from "../protocol";
 import { envInt } from "../env";
 
-/** Resolve an agent executable that is actually installed outside an SDK.
- *  The env override is explicit operator intent, so return it even when it is
- *  a bare name or currently missing (the eventual spawn then fails honestly).
- *  Otherwise mirror normal command lookup: beside node first (global npm/nvm
- *  installs), then filtered PATH. Project files, relative entries, and npm's
- *  injected node_modules bins are never agent identity. `undefined` lets an
- *  SDK retain its bundled fallback. */
+/** Resolve an agent executable that is actually INSTALLED outside an SDK —
+ *  the detection question ("show this agent as ready?"). An env override is
+ *  explicit operator intent, but an override pointing at a missing file is
+ *  not an installation: advertising "ready" for it would sell a first turn
+ *  that can only ENOENT (revised 2026-08-13, Gemini-sunset sitting — it is
+ *  also how the test harnesses force OpenCode absent on machines that have
+ *  it installed for real). A bare-name override can't be stat'ed and stays
+ *  trusted as-is. Without an override: normal command lookup — beside node
+ *  first (global npm/nvm installs), then filtered PATH. Project files,
+ *  relative entries, and npm's injected node_modules bins are never agent
+ *  identity. `undefined` lets an SDK retain its bundled fallback. */
 export function installedAgentBin(envVar: string, name: string): string | undefined {
   const override = process.env[envVar];
-  if (override) return override;
+  if (override) {
+    if (!path.isAbsolute(override)) return override;
+    return existsSync(override) ? override : undefined;
+  }
   return locateTrustedExecutable(name, {
     directories: [path.dirname(process.execPath)],
   });
 }
 
-/** Resolve which `name`d agent binary to spawn. Non-SDK adapters need a
- *  command even when lookup misses so their first turn can surface ENOENT. */
+/** Resolve which `name`d agent binary to SPAWN. Distinct from detection: the
+ *  operator's explicit override is honored verbatim even when missing, and
+ *  non-SDK adapters need a command even when lookup misses — either way the
+ *  first turn surfaces ENOENT honestly instead of silently running something
+ *  the operator didn't name. */
 export function agentBin(envVar: string, name: string): string {
-  return installedAgentBin(envVar, name) ?? name;
+  return process.env[envVar] || installedAgentBin(envVar, name) || name;
 }
 
 /** The human-readable message of an unknown catch value. */

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -408,6 +408,11 @@ export type AgentInfo = {
   kind?: "api-key" | "subscription" | "local" | "gateway";
   detail?: string;
   backends?: AgentBackend[];
+  // Additive (2026-08-13, Gemini sunset): a short daemon-composed reason why
+  // this agent is deprecated — the vendor retired it upstream. The picker
+  // shows it beside the status; the agent still works while its credentials
+  // do (gentle sunset, not removal). Absent = not deprecated.
+  deprecated?: string;
 };
 
 /**

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -37,7 +37,10 @@ import type { AgentName } from "./protocol";
 //     google-gemini/gemini-cli discussion #28017, posted by a maintainer;
 //     Antigravity CLI announced as the successor — adapter impact tracked as
 //     an R.6 check). API-key use continues under the Gemini API ToS. Already
-//     API-key-only in our detection.
+//     API-key-only in our detection. 2026-08-13: the adapter is DEPRECATED
+//     in-product (Kyle's gentle-sunset call — picker suffix + dated session
+//     notice; removal parked in POST-RELEASE.md, gated on evidence of actual
+//     breakage). This policy row is unchanged by the sunset.
 //   OpenAI (codex), closed: allowed for free LOCAL use **as a disclosed
 //     gray area** (Kyle's call, 2026-07-15, amending the same-day fail-closed
 //     flip — see the disclosed-uncertainty rule below). K.3's re-verification

--- a/server/testing/itest-harness.ts
+++ b/server/testing/itest-harness.ts
@@ -42,6 +42,12 @@ export const SCRUBBED_CREDENTIAL_ENV = {
   GEMINI_API_KEY: "",
   GOOGLE_API_KEY: "",
   CODEX_HOME: path.join(ROOT, "itest-no-codex-home"), // no auth.json here
+  // OpenCode detects LIVE from the binary alone (the Zen gateway, OC.4c), so
+  // a dev machine with opencode installed would flip the card ready and a
+  // careless click could spawn a real engine. An absolute-but-missing
+  // override reads as NOT installed (types.ts installedAgentBin) — the mock
+  // stays forced everywhere, like the credential scrubs above.
+  OPENCODE_BIN: path.join(ROOT, "itest-no-opencode", "opencode"),
   MIRAFOLD_LOG_FILE: "", // never write the real flight-recorder file from tests
   MIRAFOLD_SESSION_DIR: path.join(os.tmpdir(), `mirafold-itest-${process.pid}`),
   // R.4b made a `claude` subscription login count as live credentials —

--- a/web/src/agents-meta.ts
+++ b/web/src/agents-meta.ts
@@ -26,7 +26,7 @@ export const CONNECT_HINT: Record<AgentName, string> = {
   codex:
     "run `codex login` (ChatGPT subscription — not clearly permitted by OpenAI's terms, tolerated in practice; your account, your call) or set OPENAI_API_KEY (platform.openai.com/api-keys) — or point Codex at a local model (Ollama/LM Studio/vLLM) or any OpenAI-compatible provider (e.g. OpenRouter) via ~/.codex/config.toml (recipe: docs/local-models.md)",
   "gemini-cli":
-    "set GEMINI_API_KEY (free key at aistudio.google.com/apikey) — Gemini has no local path",
+    "set GEMINI_API_KEY (aistudio.google.com/apikey) — note Google retired Gemini CLI upstream on 2026-06-18; existing API keys still work here, but this adapter is deprecated",
   opencode:
     "install opencode (opencode.ai) — its built-in free Zen models then work out of the box (set OPENCODE_MODEL=<provider>/<model>, e.g. opencode/big-pickle; free-period prompts may train the models). Or connect a provider API key via `opencode auth login`, or declare a local/BYO provider (Ollama, OpenRouter, …) in your opencode config. A ChatGPT login works too — not clearly permitted by OpenAI's terms, tolerated in practice; your account, your call. Other subscription logins (Copilot, …) aren't usable",
 };

--- a/web/src/components/Onboarding.tsx
+++ b/web/src/components/Onboarding.tsx
@@ -348,17 +348,18 @@ export function Onboarding({
             <div className="onb-connecting">connecting…</div>
           ) : (
             agents.map((row) => {
-              const { agent, live, blocked, kind, detail } = row;
+              const { agent, live, blocked, kind, detail, deprecated } = row;
               // Three states. live → ready. blocked → a prohibited
               // subscription is present; say so and name the API-key fix (still
               // clickable — it runs the demo, like any non-live agent). none →
               // no credentials · demo (R.4i).
               const hint = blocked ? blockedHint(agent) : !live ? connectHint(agent) : undefined;
-              const statusText = live
-                ? "ready"
-                : blocked
-                  ? "subscription not supported"
-                  : "no credentials · demo";
+              // A deprecated agent stays fully usable — the suffix rides the
+              // existing status line (no new element: the squeeze ramp's
+              // height budget is calibrated to these rows).
+              const statusText =
+                (live ? "ready" : blocked ? "subscription not supported" : "no credentials · demo") +
+                (deprecated ? ` · ${deprecated}` : "");
               const statusClass = live ? "onb-live" : blocked ? "onb-blocked" : "onb-demo";
               const backing = backingLine(agent, kind, detail);
               return (


### PR DESCRIPTION
Google retired Gemini CLI upstream on 2026-06-18 (Antigravity replaced it; dated citation in `provider-policy.ts`). The API-key path still works under the Gemini API ToS, so this is the **gentle** sunset: deprecated honestly everywhere the agent shows, removed nowhere.

## What changes
- **`AgentInfo.deprecated`** (additive): the daemon composes the reason; the picker renders it as a suffix on the existing status line ("ready · retired upstream") — no new element, so the onboarding squeeze budget holds.
- **Connect hint** carries the dated retirement story for credential-less machines.
- **One dated session notice** (Mirafold-composed, no engine badge) lands before the first turn completes: keys keep working for now, the adapter is deprecated.
- **Removal parked** in POST-RELEASE.md behind an evidence gate (the CLI actually breaking, an API shutoff, usage signal) — never a calendar.

## Plus a real harness hole this work exposed
Since Zen opened, OpenCode detects live from the binary alone — so a dev machine with opencode globally installed flipped the e2e picker card to ready (a 26-test cascade), and a stray click could have spawned a real engine from a test. Fixed at the root: `types.ts` now splits **detection** from **spawn intent** (an absolute-but-missing override is not an installation, while spawn keeps the operator's explicit path for honest ENOENT), the itest harness scrubs `OPENCODE_BIN` alongside the credential scrubs, and codex-binding keeps its override verbatim per the same split.

## Verification
Tier-1 762/762 · Tier-2 152/152 · Tier-3 97/97 · typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)