### PR TITLE
Remote CREATE of OpenCode sessions — classify-before-create (Phase RC)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2883,6 +2883,70 @@ actual breakage, never on a calendar.
   notice rides once and unbadged; `deprecated` rides the hello for gemini
   only.
 
+## Phase RC — Remote CREATE of OpenCode sessions (opened 2026-08-13; Kyle-directed)
+
+**Why.** OC.4c's fail-closed design verifies an OpenCode session's credential
+kind at its first turn: until the engine classifies the pinned provider, the
+registry entry is `kindPending` and the relay gate refuses every remote
+action. Consequence (recorded in POST-RELEASE.md 2026-08-13, promoted here
+the same day at Kyle's direction): a remote viewport can ATTACH to an
+OpenCode session only after a first local turn — it can never CREATE one.
+Supporting remote creation means classifying BEFORE admitting the creator:
+spawn the engine, read the provider catalog, judge the pin, and only then
+attach the remote viewport. The gate itself does not change; only WHEN the
+truth arrives does.
+
+- [x] **RC.1 — the adapter seam.** — completed 2026-08-13. `AgentSession` gains optional
+  `verifyBackendKind?(): Promise<void>`: resolve once the truthful kind has
+  been published via `onBackendKind`, reject with the honest reason when it
+  cannot be (no binary, no pin, provider not connected, policy refusal).
+  OpenCode implements it as `ensureStarted()` — the full lazy-start path
+  (engine + policy + engine session), whose failure already resets the outer
+  latch so a later local prompt retries. No other adapter implements it:
+  their hello-time kind is already truthful.
+- [x] **RC.2 — the create path awaits truth.** — completed 2026-08-13
+  (`attachOrReapClassified`; timeout env `VERIFY_KIND_TIMEOUT_MS`, 30s
+  default). In `connection.ts`, a REMOTE
+  create (and the attach-path fallback create) of an entry that is
+  `kindPending` with a `verifyBackendKind` seam awaits classification —
+  bounded (30s) — BEFORE `attachTo` judges the relay gate. Local creates are
+  untouched: still synchronous, still lazy. On success the existing gate
+  judges the now-truthful kind (an ineligible provider still refuses with
+  the existing honest copy). On failure/timeout: the error goes to the
+  viewport and the minted session is REAPED (`registry.end`) — the
+  no-viewport leak rule from the 2026-07-29 bughunt applies unchanged. The
+  async detour catches its own errors (index.ts has no try/catch around
+  `handleMessage`).
+- [x] **RC.3 — the races.** — completed 2026-08-13 (d landed as a comment
+  correction only: the user-facing copy was already honest for the attach
+  path, and remote creates no longer surface it). (a) Viewport disconnects mid-classify → on
+  settle, a closed connection with a viewport-less entry reaps it. (b) A
+  second create/attach on the same connection while one classification is in
+  flight → refused honestly ("still verifying the previous create"); one
+  pending create per connection. (c) Entry torn down mid-classify → the
+  settle path checks `entries.get(id) === entry` before acting, like every
+  onBackendKind consumer. (d) `relayGateRefusal`'s `kindPending` copy stays
+  honest for BOTH paths now that remote creates verify inline: the
+  "run its first turn from its own machine" sentence describes only the
+  attach-to-existing case.
+- [x] **RC.4 — tests** — completed 2026-08-13: 7 connection-grain tests in
+  `server/sessions/remote-create.test.ts` (own process so the verify
+  timeout pins via env before module load; a registry session-factory test
+  seam injects the fake classifying session) + 2 adapter-grain in
+  `opencode.test.ts` (`verifyBackendKind` resolves after publish / rejects
+  honestly and stays retryable). Tiers 803/152/97 green. Original scope
+  (Tier 2 grain, `makeTransport` seam; no real engine):
+  Remote create allowed (kind publishes api-key → viewport attaches); remote
+  create policy-refused (subscription pin → refusal + entry reaped, no
+  MAX_SESSIONS leak); classify failure (engine start throws → honest error +
+  reap); timeout (kind never publishes → bounded refusal + reap); disconnect
+  mid-classify (no leak); local create unaffected (no await, still lazy).
+  The existing remote-attach regressions stay green.
+
+**Done when.** A relay viewport can create a fresh OpenCode session pinned to
+an allowed provider and drive it immediately; a subscription/Zen pin is
+refused at create with the honest reason and leaks nothing; all tiers green.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/POST-RELEASE.md
+++ b/POST-RELEASE.md
@@ -263,7 +263,8 @@ has a home in this plan, the entry points there instead of duplicating it.
   the removal release notes name the date and the alternative (OpenCode
   drives Gemini-family models via BYO providers).
 
-- [ ] **Remote CREATE of an OpenCode session** — today a relay viewport can
+- [x] **Remote CREATE of an OpenCode session** — PROMOTED to PLAN.md Phase RC
+  (2026-08-13, Kyle-directed) — today a relay viewport can
   only ATTACH to an OpenCode session after its first local turn classifies
   the credential (`kindPending` refuses remote actions until the publish —
   the fail-closed OC.4c design; the refusal copy says so honestly since the

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -1066,3 +1066,23 @@ test("AUDIT: an oversized engine command catalog is capped to what a checkpoint 
   assert.ok(cmds.length <= 500, `advertised commands capped, saw ${cmds.length}`);
   session.close();
 });
+
+test("RC: verifyBackendKind resolves only after the truthful kind published", async () => {
+  const { session } = makeSession({ model: "fake/fake-model" });
+  const published: { kind: string }[] = [];
+  session.onBackendKind?.((u) => published.push(u));
+  await session.verifyBackendKind?.();
+  assert.deepEqual(published, [{ kind: "local", provider: "fake" }]);
+  session.close();
+});
+
+test("RC: verifyBackendKind rejects with the honest reason and stays retryable", async () => {
+  const { session, fake } = makeSession({ model: "missing/nope" });
+  await assert.rejects(session.verifyBackendKind!(), /isn't connected in opencode/);
+  // The same honest failure repeats (latch reset), and a fixed catalog recovers.
+  await assert.rejects(session.verifyBackendKind!(), /isn't connected in opencode/);
+  fake.catalog = [{ id: "missing", source: "config" }];
+  await session.verifyBackendKind!();
+  assert.equal(fake.sessionsCreated, 1, "recovered into a real engine session");
+  session.close();
+});

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -113,6 +113,13 @@ export class OpenCodeSession implements AgentSession {
     if (this.lastKind) cb(this.lastKind);
   }
 
+  /** Phase RC: the full lazy-start path — engine + policy + engine session —
+   *  which publishes the truthful kind on the way (adoptPin). A failure has
+   *  already reset the started latch, so a later local prompt retries. */
+  verifyBackendKind(): Promise<void> {
+    return this.ensureStarted();
+  }
+
   private publishKind(kind: CredentialKind, provider: string) {
     this.lastKind = { kind, provider };
     for (const cb of this.kindListeners) cb(this.lastKind);

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -78,6 +78,14 @@ export interface AgentSession {
    * updates its entry so the relay gate judges truth; until the first
    * publish such entries are `kindPending` and refuse remote actions. */
   onBackendKind?(cb: (update: { kind: CredentialKind; provider?: string }) => void): void;
+  /** Phase RC: classify the backend kind NOW instead of at the first turn —
+   * resolves once the truthful kind has been published via `onBackendKind`,
+   * rejects with the honest user-facing reason when it cannot be (no engine
+   * binary, no pin, provider not connected, policy refusal). Only adapters
+   * whose hello-time kind is optimistic (OpenCode) implement this; the
+   * create path uses it so a remote viewport can create a session without
+   * losing the classification race (classify-before-create). */
+  verifyBackendKind?(): Promise<void>;
   /** Re-read and emit the provider's pre-submit command/skill catalog. */
   refreshPromptOptions?(): void;
   close(): void;

--- a/server/provider-policy.ts
+++ b/server/provider-policy.ts
@@ -300,9 +300,9 @@ export function relayGateRefusal(entry: {
     return (
       // Honest about WHEN it clears: verification runs with the session's
       // first local turn, so a remote viewport racing a fresh session would
-      // wait forever on "a moment" (bughunt 2026-08-13 — remote CREATE of an
-      // OpenCode session can never win this race; supporting it needs
-      // classify-before-create and is parked in POST-RELEASE.md).
+      // wait forever on "a moment" (bughunt 2026-08-13). Reachable only by
+      // ATTACH-to-existing since Phase RC: a remote CREATE classifies inline
+      // (connection.ts attachOrReapClassified) and never surfaces this copy.
       "This session hasn't verified which credential backs it yet — run its " +
       "first turn from its own machine; remote viewports can attach after that."
     );

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -31,6 +31,10 @@ import { folderPickerAvailable } from "../folder-picker";
 // cached answer instead of re-probing localhost.
 const REFRESH_MIN_INTERVAL_MS = envInt("REFRESH_MIN_INTERVAL_MS", 1_000);
 
+// Phase RC: how long a remote create may spend classifying its provider
+// (engine spawn + catalog read) before the creator gets an honest refusal.
+const VERIFY_KIND_TIMEOUT_MS = envInt("VERIFY_KIND_TIMEOUT_MS", 30_000);
+
 // The relay refusal copy now lives with the rule (provider-policy.ts
 // relayGateRefusal, OC.4c) so the attach gate, cockpit acts, and uploads say
 // the same words about the same verdict — pending-kind included.
@@ -181,6 +185,61 @@ export function openConnection(
     if (!attachTo(e, afterSeq, fallback)) registry.end(e.id);
   };
 
+  // Phase RC: classify-before-create. A REMOTE create of an entry whose
+  // credential kind is still optimistic (kindPending + a verifyBackendKind
+  // seam — OpenCode) awaits the truthful classification BEFORE the relay
+  // gate judges the attach, instead of refusing a race the creator can
+  // never win. Local creates keep the lazy path untouched. The async detour
+  // owns its errors (index.ts has no try/catch around handleMessage): a
+  // classify failure or timeout errors the viewport honestly and reaps the
+  // minted no-viewport entry (the 2026-07-29 leak rule); settle re-checks
+  // entry liveness and connection state before acting.
+  let verifyingCreate = false;
+  const attachOrReapClassified = (e: SessionEntry, afterSeq?: number, fallback = false) => {
+    const verify = e.session.verifyBackendKind?.bind(e.session);
+    if (!remote || !e.kindPending || !verify) {
+      attachOrReap(e, afterSeq, fallback);
+      return;
+    }
+    verifyingCreate = true;
+    void (async () => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await Promise.race([
+          verify(),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(
+              () =>
+                reject(
+                  new Error(
+                    "verifying which credential backs this session took too long — " +
+                      "try again, or run its first turn from its own machine",
+                  ),
+                ),
+              VERIFY_KIND_TIMEOUT_MS,
+            );
+            timer.unref();
+          }),
+        ]);
+      } catch (err) {
+        verifyingCreate = false;
+        if (!closed) sendError(errText(err));
+        if (registry.get(e.id) === e && e.viewports.size === 0) registry.end(e.id);
+        return;
+      } finally {
+        clearTimeout(timer);
+      }
+      verifyingCreate = false;
+      if (registry.get(e.id) !== e) return; // torn down mid-classify
+      if (closed) {
+        // The creator left mid-classify; nobody owns the mint.
+        if (e.viewports.size === 0) registry.end(e.id);
+        return;
+      }
+      attachOrReap(e, afterSeq, fallback);
+    })();
+  };
+
   // Advertise which agents this daemon offers + which are live, so the
   // onboarding picker can render before any session exists. No agent assumed (P.4).
   // Also where the daemon was launched — the default cwd for new
@@ -271,6 +330,13 @@ export function openConnection(
         // working somewhere else — the viewport stays unattached and the
         // onboarding card shows the error (Step 4.8).
         noteClientVersion(msg.clientVersion);
+        // Phase RC: one classification in flight per connection — a second
+        // create arriving mid-verify would interleave two mints racing one
+        // `entry` slot.
+        if (verifyingCreate) {
+          sendError("still verifying the previous create — one moment");
+          break;
+        }
         // N.5: the picker's backend choice is validated HERE, against current
         // detection + provider policy — never trusted. A refused choice is a
         // create error (the picker shows it); honoring it only with a valid
@@ -287,7 +353,7 @@ export function openConnection(
           log.info(`create → ${agent} on chosen backend ${describeBackendForLog(backend)}`);
         }
         try {
-          attachOrReap(
+          attachOrReapClassified(
             registry.create({
               cwd: typeof msg.cwd === "string" ? msg.cwd : undefined,
               agent,
@@ -304,6 +370,10 @@ export function openConnection(
         // unknown id (old bookmark / explicit end) gets the historical fresh
         // fallback; a corrupt or unavailable saved session errors in place.
         noteClientVersion(msg.clientVersion);
+        if (verifyingCreate) {
+          sendError("still verifying the previous create — one moment");
+          break;
+        }
         try {
           const existing =
             typeof msg.sessionId === "string" ? registry.open(msg.sessionId) : undefined;
@@ -318,7 +388,7 @@ export function openConnection(
               registry.detach(existing, viewport);
             }
           } else {
-            attachOrReap(registry.create(), afterSeq, typeof msg.sessionId === "string");
+            attachOrReapClassified(registry.create(), afterSeq, typeof msg.sessionId === "string");
           }
         } catch (err) {
           sendError(errText(err));

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -280,6 +280,10 @@ export class SessionRegistry {
     private deltaCoalesceMs: number = DELTA_COALESCE_MS,
     private store?: SessionCheckpointStore,
     private idleTimeoutMs: number = IDLE_TIMEOUT_MS,
+    // Test seam (Phase RC): the classify-before-create flow needs an entry
+    // whose session exposes onBackendKind/verifyBackendKind without spawning
+    // a real engine.
+    private makeSession: typeof createSession = createSession,
   ) {
     if (store) {
       const loaded = store.loadAll();
@@ -312,7 +316,7 @@ export class SessionRegistry {
     const dir = resolveCwd(opts?.cwd);
     // The configured agent becomes a concrete engine at this one seam
     // (Phase P.1). Falls back to the mock when the agent has no credentials.
-    const session: AgentSession = createSession(backend, { cwd: dir });
+    const session: AgentSession = this.makeSession(backend, { cwd: dir });
     const entry: SessionEntry = {
       id,
       cwd: dir,

--- a/server/sessions/remote-create.test.ts
+++ b/server/sessions/remote-create.test.ts
@@ -1,0 +1,177 @@
+// Phase RC: classify-before-create. A remote viewport creating a session
+// whose credential kind is optimistic (kindPending + verifyBackendKind —
+// OpenCode) waits for the truthful classification before the relay gate
+// judges the attach; every failure shape errors honestly and reaps the
+// no-viewport mint. Runs in its own process, so the verify timeout can be
+// pinned via env before connection.ts loads its module constant.
+process.env.VERIFY_KIND_TIMEOUT_MS = "120";
+
+// Static imports would hoist above the env pin; only connection.ts reads it
+// at module load, so it alone arrives dynamically.
+const { openConnection } = await import("./connection");
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { SessionRegistry } from "./registry";
+import { waitFor } from "../testing/wait-for";
+import type { WireMsg } from "../protocol";
+import type { AgentSession, Backend } from "../adapters";
+import type { CredentialKind } from "../provider-policy";
+import type { Connection } from "./connection";
+
+const OC: Backend = { agent: "opencode", kind: "api-key", live: true };
+
+type KindUpdate = { kind: CredentialKind; provider?: string };
+
+/** The RC seam shape: an optimistic session whose truth arrives when the
+ *  test says so, standing in for OpenCodeSession.ensureStarted(). */
+class FakeClassifyingSession implements AgentSession {
+  verifyCalls = 0;
+  closed = false;
+  private kindCb?: (u: KindUpdate) => void;
+  private settle!: { resolve: () => void; reject: (err: Error) => void };
+  private verifyDone: Promise<void>;
+
+  constructor() {
+    this.verifyDone = new Promise((resolve, reject) => {
+      this.settle = { resolve, reject };
+    });
+    this.verifyDone.catch(() => {}); // observed via verifyBackendKind()
+  }
+  publish(update: KindUpdate) {
+    this.kindCb?.(update);
+  }
+  succeed(update: KindUpdate) {
+    this.publish(update);
+    this.settle.resolve();
+  }
+  fail(reason: string) {
+    this.settle.reject(new Error(reason));
+  }
+
+  pushPrompt() {}
+  onMessage() {}
+  interrupt() {}
+  resolvePermission() {}
+  get modelName(): string | undefined {
+    return undefined;
+  }
+  onBackendKind(cb: (u: KindUpdate) => void) {
+    this.kindCb = cb;
+  }
+  verifyBackendKind(): Promise<void> {
+    this.verifyCalls++;
+    return this.verifyDone;
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+function rig() {
+  const sessions: FakeClassifyingSession[] = [];
+  const reg = new SessionRegistry(OC, 0, undefined, undefined, () => {
+    const s = new FakeClassifyingSession();
+    sessions.push(s);
+    return s;
+  });
+  return { reg, sessions };
+}
+
+function conn(reg: SessionRegistry, remote: boolean) {
+  const seen: WireMsg[] = [];
+  const c = openConnection(reg, (m) => seen.push(m), "test", undefined, remote);
+  return { c, seen };
+}
+const send = (c: Connection, msg: unknown) => c.handleMessage(JSON.stringify(msg));
+const of = (seen: WireMsg[], type: string) => seen.filter((m) => m.type === type);
+const errors = (seen: WireMsg[]) =>
+  of(seen, "error").map((m) => (m as { message: string }).message);
+
+test("RC: a LOCAL create stays lazy — no verification, attached while pending", () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, false);
+  send(c, { type: "create", cwd: process.cwd() });
+  assert.equal(of(seen, "session_created").length, 1, "attached immediately");
+  assert.equal(sessions[0].verifyCalls, 0, "classification not forced");
+  const id = (of(seen, "session_created")[0] as { sessionId: string }).sessionId;
+  assert.equal(reg.get(id)?.kindPending, true, "still pending until the first turn");
+  c.close();
+  reg.end(id);
+});
+
+test("RC: a remote create attaches once the truthful kind lands eligible", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  assert.equal(of(seen, "session_created").length, 0, "no attach before the truth");
+  await waitFor(() => sessions[0]?.verifyCalls === 1, "verification to start");
+  sessions[0].succeed({ kind: "api-key", provider: "openai" });
+  await waitFor(() => of(seen, "session_created").length === 1, "post-verify attach");
+  const id = (of(seen, "session_created")[0] as { sessionId: string }).sessionId;
+  assert.equal(reg.get(id)?.kindPending, false, "entry carries the truthful kind");
+  assert.equal(errors(seen).length, 0);
+  c.close();
+  reg.end(id);
+});
+
+test("RC: a remote create whose truth is relay-ineligible is refused and reaped", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  await waitFor(() => sessions[0]?.verifyCalls === 1, "verification to start");
+  sessions[0].succeed({ kind: "gateway", provider: "opencode" });
+  await waitFor(() => of(seen, "refused").length === 1, "the relay gate's refusal");
+  assert.equal(of(seen, "session_created").length, 0, "never attached");
+  await waitFor(() => sessions[0].closed, "the mint reaped");
+  c.close();
+});
+
+test("RC: a classify failure errors the creator honestly and reaps", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  await waitFor(() => sessions[0]?.verifyCalls === 1, "verification to start");
+  sessions[0].fail("no model is pinned for this OpenCode session");
+  await waitFor(() => errors(seen).length === 1, "the honest error");
+  assert.ok(errors(seen)[0].includes("no model is pinned"));
+  assert.equal(of(seen, "session_created").length, 0);
+  await waitFor(() => sessions[0].closed, "the mint reaped");
+  c.close();
+});
+
+test("RC: a verification that never settles times out bounded and reaps", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  await waitFor(() => errors(seen).length === 1, "the timeout refusal", 5_000);
+  assert.ok(errors(seen)[0].includes("took too long"));
+  await waitFor(() => sessions[0].closed, "the mint reaped");
+  c.close();
+});
+
+test("RC: the creator disconnecting mid-classify leaks nothing", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  await waitFor(() => sessions[0]?.verifyCalls === 1, "verification to start");
+  c.close();
+  sessions[0].succeed({ kind: "api-key", provider: "openai" });
+  await waitFor(() => sessions[0].closed, "the ownerless mint reaped");
+  assert.equal(of(seen, "session_created").length, 0, "nothing sent to a dead viewport");
+});
+
+test("RC: a second create mid-verify is refused; the connection recovers after settle", async () => {
+  const { reg, sessions } = rig();
+  const { c, seen } = conn(reg, true);
+  send(c, { type: "create", cwd: process.cwd() });
+  await waitFor(() => sessions[0]?.verifyCalls === 1, "verification to start");
+  send(c, { type: "create", cwd: process.cwd() });
+  assert.ok(errors(seen).some((m) => m.includes("still verifying")));
+  assert.equal(sessions.length, 1, "no second mint while one is in flight");
+  sessions[0].succeed({ kind: "api-key", provider: "openai" });
+  await waitFor(() => of(seen, "session_created").length === 1, "the first create lands");
+  const id = (of(seen, "session_created")[0] as { sessionId: string }).sessionId;
+  c.close();
+  reg.end(id);
+});


### PR DESCRIPTION
Closes the one capability gap OC.4c's fail-closed design left: a relay viewport could only ATTACH to an OpenCode session after its first local turn classified the credential — it could never CREATE one, because a fresh entry sat \`kindPending\` and the relay gate refused the creator every time. Promoted from the POST-RELEASE deferral at Kyle's direction; PLAN.md Phase RC.

- **RC.1** — \`AgentSession.verifyBackendKind?()\`: classify NOW instead of at the first turn. OpenCode implements it as its existing full lazy-start (\`ensureStarted\` publishes the truthful kind via \`adoptPin\` on the way; a failure still resets the latch so a later local prompt retries). No other adapter implements it — their hello-time kind is already truthful.
- **RC.2** — \`connection.ts\` \`attachOrReapClassified\`: a REMOTE create (and the attach-path fallback create) of a \`kindPending\` entry awaits classification — bounded by \`VERIFY_KIND_TIMEOUT_MS\` (30s default) — BEFORE the relay gate judges the attach. Local creates keep the lazy path untouched. Failure/timeout errors the creator honestly and reaps the no-viewport mint (the 2026-07-29 leak rule). An ineligible truth (subscription/Zen) still gets the existing honest gate refusal.
- **RC.3** — races: creator disconnect mid-classify reaps the ownerless mint; a second create mid-verify is refused honestly (one classification in flight per connection); settle re-checks entry liveness; the provider-policy \`kindPending\` comment now marks that copy attach-only.
- **RC.4** — 9 new tests: 7 connection-grain (\`server/sessions/remote-create.test.ts\` — runs in its own process so the verify timeout pins via env before module load; a registry session-factory test seam injects a fake classifying session) + 2 adapter-grain (\`verifyBackendKind\` resolves after publish / rejects honestly and stays retryable).

All tiers green: 803 unit / 152 server / 97 e2e, plus the Tier-4 live OC.5 round-trip against the real engine (verified with a scratchpad opencode install; the dev machine's global install is broken by npm's install-scripts policy — environmental, predates this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)