### PR TITLE
docs: Phase RC completion sync

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2883,7 +2883,7 @@ actual breakage, never on a calendar.
   notice rides once and unbadged; `deprecated` rides the hello for gemini
   only.
 
-## Phase RC — Remote CREATE of OpenCode sessions (opened 2026-08-13; Kyle-directed)
+## Phase RC — Remote CREATE of OpenCode sessions (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
 
 **Why.** OC.4c's fail-closed design verifies an OpenCode session's credential
 kind at its first turn: until the engine classifies the pinned provider, the

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -310,7 +310,13 @@ proven sequence (used for Codex, Gemini, and OpenCode; keep it):
    `AgentSession`. The adapter publishes the classified kind at session start
    (and on a provider switch); the registry adopts it and holds the entry
    `kindPending` until the first publish, so the relay gate refuses remote
-   viewports meanwhile. The relay gate (`provider-policy.ts` `relayGateRefusal`)
+   viewports meanwhile. Pair it with the optional `verifyBackendKind()` seam
+   (Phase RC): classify NOW instead of at the first turn, resolving once the
+   truthful kind has published and rejecting with the honest user-facing
+   reason when it can't. The create path uses it so a REMOTE create of a
+   pending-kind session awaits the truth (bounded, `VERIFY_KIND_TIMEOUT_MS`)
+   instead of losing the classification race; without the seam, remote
+   viewports can only attach after a first local turn. The relay gate (`provider-policy.ts` `relayGateRefusal`)
    is then checked at **drive time on every model-driving path**, not only at
    attach — a mid-session flip to a `subscription`/`gateway` kind must never let
    an already-attached relay viewport keep driving (2026-08-13 audit). If the


### PR DESCRIPTION
Docs-only follow-up to #45 (merged while this sync was being written): PLAN.md's Phase RC header gains its ✅ COMPLETE marker, and ADAPTERS.md §4b (the normative adapter contract) documents the \`verifyBackendKind()\` seam alongside \`onBackendKind\` so the next adapter author sees both halves of the classify-before-create design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)