### PR TITLE
Phase SA — the subagent view: live subagent decks, narration lane, OpenCode mapping

### DIFF
--- a/GLOSSARY.md
+++ b/GLOSSARY.md
@@ -39,6 +39,7 @@ blur the two — that blur is exactly what the security model exists to prevent.
 | *output zone* | the main scroll where the agent's replies and paintings appear | — |
 | *painting* | an agent-authored generative-UI component | "widget" |
 | *deck* | a shell-owned live pane (run deck, preview deck, subagent deck) | "card" |
+| *subagent deck* | the live deck a spawned subagent runs in — calm summary in the output zone, expandable to the subagent's calls and words | "subagent group" |
 | *prompt box* | the input box you type into | "input box" |
 | *pin dock* | where you pin live paintings to keep them in view | — |
 | *status bar* | the strip showing agent → model, session status, usage | — |

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -9944,3 +9944,817 @@ was met live 2026-07-22. Entries verbatim:
   status history → PLAN-ARCHIVE.md.
   - Done when: both reviews pass and R.5's checkout → webhook →
     entitlement-minting build runs against the account.
+
+## Moved 2026-08-14 (post-SA prune — completed bodies)
+
+Verbatim originals of the sections completed 2026-08-12 → 2026-08-14 and
+compressed in PLAN.md on 2026-08-14: the NF and FD step bodies, the
+paintings polish batch, Phase OC, the Gemini sunset, Phase RC, and the
+whole Phase SA record (charter, signed-off decisions, research ledger,
+steps, and the post-phase refactor/bughunt/audit/test-audit records).
+
+### Phase SA — full charter, decisions, research ledger, SA.0–SA.4, and the post-phase refactor/bughunt/audit/test-audit records
+
+## Phase SA — Subagent view (opened + ✅ COMPLETE 2026-08-14; Kyle-directed; plan signed off by Kyle, executed same day)
+
+**Why.** When a session's agent spawns its own subagents, render them as a
+live, legible structure — calm by default, fully expandable — instead of
+dropping their narration and scattering their tool rows. Today the Claude
+Code adapter forwards a subagent's tool calls (nested, T2.4) but drops its
+prose: the SDK never forwards subagent token-level deltas (main-session-only
+stream, confirmed vs docs 2026-08-14), but subagent COMPLETE assistant
+messages — text and thinking blocks tagged `parent_tool_use_id` — do arrive,
+and the adapter skips them (`claude-code.ts` `!parentId` gate). The data is
+in the stream at message grain; Mirafold chooses not to render it — in
+tension with never-hide, sharpest when a stuck subagent explains itself and
+the user never sees it. Framing sharpened by research: the TERMINAL shows
+even less (a panel row — name, elapsed, tokens; no prose, no per-agent tool
+activity — a gap third-party tools visibly fill), so this is not fixing a
+hiding-vs-terminal bug; it is Mirafold being MORE faithful than the terminal
+to what the agent is actually doing.
+A live per-subagent card is also the product thesis made vivid: parallel
+agents shown side by side, which one interleaved terminal column physically
+cannot do. Automatic — the user prompts normally; when the agent fans out,
+this rendering just happens.
+
+**The hard line.** Mirafold DISPLAYS the agent's own coordination — it
+renders what the engine already decided to do. It never spawns or directs
+subagents itself (the homegrown-orchestrator trap, a non-negotiable).
+*Mirafold shows coordination; it never performs it.*
+
+**Decided 2026-08-14 (Kyle signed off on all of these):**
+
+1. **One card per subagent; no invented group container.** Each spawn gets
+   its own live card anchored where its Task row is today. No batch notion,
+   no synthesized group title (shell-voice rule: Mirafold never composes a
+   sentence about the agent's intent). A neutral counted summary line
+   ("3 agents · 2 running") is later polish, not structure.
+2. **Subagent traffic rides the replay ring, per-subagent byte-capped.**
+   A late-attaching viewport sees what a present one saw — dropping it from
+   replay would rebuild the hiding problem for exactly the away user. Cap
+   in the flood-cap spirit; elision marked explicitly (`truncatedBytes`
+   precedent), never silent.
+3. **Wire shape: reuse `text_delta`/`thinking_delta` with optional
+   `parentId`** — the exact additive precedent `tool_use`/`tool_result`
+   set; old clients degrade to today's behavior. No new delta type.
+   **`parentId` is an opaque adapter-chosen handle**: for Claude Code it
+   happens to be the Task tool_use id, but the protocol never promises
+   that; shared code only groups by it, never parses or dereferences it.
+4. **A card must be able to exist without a tool row to anchor to.**
+   Tool-call-spawning engines anchor on (become) the Task row; an engine
+   without one gets a way to announce the spawn (synthetic tool_use-shaped
+   record vs. small additive spawn message — build-time call, requirement
+   named now so the card component is not hard-wired to Task rows).
+5. **Render depth 1 — what the stream surfaces — stated assumption.**
+   (Corrected by research 2026-08-14: engines DO nest — Claude Code to
+   depth 3 by default, but grandchild traffic never reaches the parent
+   stream, only the top-level child's summary returns; OpenCode denies
+   `task` to children by default, though user config can allow nesting,
+   unbounded.) The rule: cards render what the engine surfaces to the
+   session; engine-hidden grandchildren are the ENGINE's choice, not ours.
+   OpenCode parentage resolves transitively (`Session.parentID` is a plain
+   edge), so a configured nesting maps to the nearest stream-visible
+   ancestor's card — documented degradation, not breakage.
+6. **Agent-neutral, proven: OpenCode mapping is IN scope as the final
+   step.** Neutrality is only real once a second adapter maps the lane.
+   Codex is OUT of build scope, with the posture corrected by research
+   2026-08-14: Codex NOW HAS first-class multi-agent (collab tools,
+   default-on since ~2026-02, official docs) — children are full sibling
+   THREADS (own thread id + event stream, `parentThreadId` edges); the
+   parent stream carries spawn/status items (`collabAgentToolCall`,
+   `subAgentActivity`) but never child inner activity, which needs
+   per-thread subscriptions via the app-server protocol — i.e. gated on
+   F.5, and the TS SDK we drive types none of the collab items yet.
+   A Codex SUMMARY-card mapping may be reachable pre-F.5 from untyped
+   collab items; deliberately deferred, revisit at F.5. (Vocabulary trap
+   confirmed: Codex `task_started`/`task_complete` = the whole TURN.)
+   Gemini is sunset.
+7. **Trusted shell:** the card is Mirafold chrome derived from the stream —
+   all subagent prose renders as inert plain text (fleet activity-line
+   precedent), never markdown, never agent-painted HTML.
+8. **Phase shape: mock-first, three beats.** (a) Mock parallel-subagent
+   scenario + summary cards built ENTIRELY from data already on the wire —
+   spawn/finish/tool rows/elapsed/current action all derive from existing
+   `tool_use`/`tool_result` + parentId; zero protocol change; visible win
+   alone. (b) Narration forwarding + the expanded view. (c) The OpenCode
+   mapping. Expanded-view interaction design (the calm/expand balance) is
+   deliberately decided at build time with the mock running.
+
+**Research pass — DONE 2026-08-14 (three agents + local reads). Load-bearing
+findings, beyond the corrections folded into the decisions above:**
+
+- **Claude Code (SDK pin 0.3.201):** subagent narration arrives at MESSAGE
+  grain only (complete assistant messages with `parent_tool_use_id`; deltas
+  are main-session-only per docs). To verify empirically in SA.0: that
+  parent-tagged messages arrive LIVE during the child's run (T2.4's ticking
+  nested rows suggest yes; one doc reading suggested end-of-run) — and that
+  subagent permission asks already route through the parent `canUseTool`.
+  Terminal shows a subagent panel row only (name/elapsed/tokens). Default
+  concurrent-subagent cap 20 — cards must stack legibly at that count.
+- **OpenCode (live OpenAPI capture + engine binary, 1.18.18; NEVER yet
+  exercised live — SA.0 owes the probe):** child sessions ride the SAME
+  global `/event` stream we already consume, tagged with their own
+  `sessionID`; our `isOurs` filter (`opencode.ts:170`, applied across
+  `opencode-events.ts`) drops them whole, per design comment and a pinned
+  test. Spawn = the `task` TOOL part on the parent + `session.created` with
+  `Session.parentID`; the JOIN key parent-task-part → child is
+  `state.metadata.sessionId` (lowercase-d casing, engine inconsistency; the
+  session event alone recovers the parent SESSION, not the Task row). The
+  `subtask` command path converges on the same task tool part — one lane
+  rule covers both. Child gets `todowrite` denied by default — no checklist
+  clobber hazard. **DEFECT FOUND: child-session `permission.asked` events
+  are dropped today — a subagent hitting a permission gate hangs, no UI, no
+  deny timer (`opencode.ts:544` timer only starts for accepted asks).**
+  Reply endpoint for the fix: `POST /permission/{requestID}/reply` (takes
+  only the request id — session-agnostic; our current per-session reply
+  endpoint is marked deprecated in the live spec). Also: child
+  `session.idle` must not end the parent's turn once the lane opens; spike
+  doc's "subtask/agent parts" subagent claim is incomplete — correct it.
+- **Local (registry.ts):** replay ring already double-capped (4000 msgs /
+  32 MB, oldest-first) — riding it is memory-safe; the per-subagent
+  narration cap therefore lives at the ADAPTER (also bounds relay bytes);
+  sizing precedent `TOOL_OUTPUT_CAP_BYTES` 64 KB. **The 33 ms delta
+  coalescer merges on `pending.type === msg.type` only (`registry.ts:589`)
+  — once deltas carry `parentId` the merge key MUST include it**, or parent
+  and child prose concatenate into one message.
+
+**Steps** *(each single-pass; implementation gated on Kyle's explicit
+signoff of the reported plan)*:
+
+- [x] **SA.0 — Live probes + record the truth.** — completed 2026-08-14,
+  both probes credential-free/zero-spend. **OpenCode** (real engine 1.18.18,
+  OC.5-style scripted provider, raw global-stream capture): parent `task`
+  tool part (`pending`) arrives ONE event before child `session.created`;
+  `running` metadata carries the join key
+  (`state.metadata.sessionId`/`parentSessionId`, lowercase d, + `model`;
+  `completed` adds `truncated`); the child `Session` itself carries `agent`,
+  a title from the description, and a ruleset showing `task` denied
+  (depth-1 default confirmed live). Child text/tool/step parts AND
+  token-grain `message.part.delta`s ride the global stream tagged with the
+  child id. Child `permission.asked` arrived (child `sessionID`,
+  `patterns`, `tool.callID`); **the deprecated per-session reply endpoint
+  accepted a reply addressed with the ROOT session id — 200, child
+  unblocked — so it does NOT validate ownership (1.18.18)**; SA.3 still
+  moves to `/permission/{requestID}/reply` (modern, session-agnostic).
+  Child `session.idle` fired BEFORE the parent task part completed and well
+  before parent idle — the parent-turn guard is real. Curated capture:
+  `server/testing/opencode-subagent-fixture.ts`. **Claude Code** (real
+  bundled CLI via SDK 0.3.201, scripted Anthropic endpoint via
+  `ANTHROPIC_BASE_URL`, STREAMING input mirroring the adapter):
+  (a) parent-tagged assistant messages arrive LIVE mid-child-run (child's
+  Bash tool_use yielded before the fake server even served the child's next
+  request), zero parent-tagged `stream_event`s — narration is message-grain,
+  confirmed empirically; (b) **a subagent's gated tool call DOES fire the
+  parent query's `canUseTool`** (proved with a parent-Bash control in the
+  same run) — the existing permission bar already covers subagent tools —
+  but the callback carries NO subagent identifier (extras =
+  suggestions/blockedPath/displayName only), so CC asks stay UNATTRIBUTED
+  on cards this phase, faithful to the terminal. Two design-relevant
+  extras: the spawn tool in 0.3.201 is named **`Agent`** (not `Task`) — the
+  card anchor must key on "the tool_use other messages reference as
+  `parentId`", name-agnostic; and bare `echo` never prompted (the CLI's own
+  safe-command auto-approval — faithful, not a bug). Spike doc's subagent
+  paragraph corrected. Probe scripts: session scratchpad `sa0/`
+  (`probe.mjs`, `cc-probe2.mjs`); recipes summarized above are sufficient
+  to re-derive them.
+- [x] **SA.1 — Mock scenario + summary cards (zero protocol change).** —
+  completed 2026-08-14. `playSubagent` is now a three-spawn parallel
+  fan-out (distinct paces; the second-spawned finishes first). Client:
+  `SubagentCard` in RenderZone (supersedes the T2.4 SubagentGroup) — any
+  tool_use other records reference as `parentId` becomes the card,
+  name-agnostic; calm summary = agent type + spawn description (verbatim,
+  never composed), state dot (pulse honors reduced-motion), tool count,
+  elapsed ticking ONLY while running (client-side stamp — honest under
+  replay, where a settled card shows no stale duration), current action =
+  newest unanswered child, result first-line once done; expandable to the
+  existing nested ToolCallList. Derivation is pure
+  (`web/src/subagent-card.ts`, 7 Tier-1 tests). Cards are fold
+  BOUNDARIES for the settled-activity compaction and their children are
+  invisible to it (omitted, not boundaries — parent-level runs don't
+  split on child traffic). Tier-2 itest updated to the fan-out contract
+  (children tag their own spawn; settle order ≠ spawn order). E2e (app):
+  three cards live at once, independent tick, out-of-order settle, expand/
+  collapse, axe-clean, phone-width stack with no side scroll. Tiers
+  810/152/57(app) green.
+- [x] **SA.2 — The narration lane (wire + Claude Code + expand).** —
+  completed 2026-08-14. Protocol: optional `parentId` on
+  `text_delta`/`thinking_delta`, documented opaque (grouped, never
+  parsed); checkpoint-store strict schemas widened to match (they would
+  have REJECTED the field — caught in-pass). Merge keys gained
+  `parentId` in BOTH coalescers (registry window + client delta-queue) so
+  parallel prose never concatenates across agents. Claude Code adapter:
+  parent-tagged complete-message text/thinking forward as message-grain
+  parented deltas through `SubagentProseBudget` (shared in
+  `adapters/types.ts` for SA.3; `SUBAGENT_TEXT_CAP_BYTES` 64 KB default,
+  one explicit elision marker, byte-safe slice, per-subagent ledger
+  cleared per turn); the F.1 buffered-text dedup rule untouched for the
+  parent; stale stream_event comment corrected. Client: `subtext`
+  entries route to their card BEFORE fold/close logic (child prose can't
+  fold parent thinking), extend-in-place per (parent|variant), closed by
+  that subagent's next tool row — the expansion (`SubagentActivity`)
+  interleaves calls + narration + dim italic reasoning in true stream
+  order, inert plain text (e2e asserts no markdown elements render);
+  Shell keeps subagent prose out of the turn-end announcement and the
+  activity label. Tests: adapter forwarding + wire order, budget
+  semantics (cap marker, per-agent ledgers, U+FFFD safety, reset),
+  registry + delta-queue no-cross-parent merges, e2e narration in the
+  expansion. Tiers 814/152/57(app) green.
+- [x] **SA.3 — The OpenCode mapping (neutrality proven).** — completed
+  2026-08-14. The mapper gained `laneOf`: "root" | spawn-part-id |
+  undefined (unroutable → skipped whole, the pre-lane behavior). Edges
+  from the root task part's `state.metadata` ({sessionId,
+  parentSessionId} — captured shape-wise, not by tool name, so the lane
+  stays name-agnostic) + child `session.created`, resolved transitively —
+  a configured nested grandchild lands on the nearest stream-visible
+  card (tested). Child text/reasoning → parented deltas through the
+  shared `SubagentProseBudget`; child tool parts → parented
+  `tool_use`/`tool_result` (roles tracked for child messages so the task
+  prompt's echo never replays as narration); a child's RENDER call gets
+  the honest tool record, never a painting (cards are calls + prose);
+  child step/status/idle/error never touch root turn state or the
+  activity line. **Defect fixed:** child `permission.asked` surfaces on
+  the shell bar with additive `parentId` on `permission_request`
+  (protocol + store schema + PermBar dim "subagent" chip + announcer
+  suffix), deny timer armed, replies via the modern session-agnostic
+  `POST /permission/{requestID}/reply` (the deprecated per-session
+  endpoint — which the SA.0 probe showed never validated ownership —
+  dropped everywhere). Tests: the SA.0 captured run replayed whole
+  through the shipped session (spawn anchor, parented calls/prose,
+  attributed ask, single turn_end), grandchild transitivity, no-painting
+  rule, unroutable fallback; Tier-4 live extends with a REAL engine
+  fan-out (attributed ask answered through the production bridge, child
+  bash + narration on the lane, parent reply top-level) — green.
+  Tiers 817/152/57(app)/1(live) green.
+- [x] **SA.4 — Docs + glossary.** — completed 2026-08-14. The glossary
+  already NAMED this surface — a *deck* is shell chrome and "card" is its
+  "(was)" column — so SA.4 opened with a vocabulary-compliance rename of
+  SA.1–SA.3's code: `SubagentCard`→`SubagentDeck`,
+  `subagent-card.ts`→`subagent-deck.ts`, CSS `.subagent-card*`→
+  `.subagent-deck*`, comments and e2e selectors converted; all tiers
+  re-verified green after. GLOSSARY gains a dedicated *subagent deck* row
+  (master + all 4 copies, diff-clean; relay/site/desktop copies committed
+  in their repos — docs-only, UNPUSHED, awaiting Kyle). README: the
+  Claude Code subagent-traffic paragraph rewritten to the SA truth
+  (message-grain prose, budget cap, the deck, name-agnostic anchor,
+  canUseTool coverage), `subtext` in the RenderZone entry list, mock
+  hook description updated. ADAPTERS.md: the capability-matrix subagent
+  row rewritten per adapter (incl. the recorded Codex F.5-deferred
+  posture) + a §3 "subagent lane" contract block for the next adapter
+  author (opaque handle, relationship anchor, budget, inert prose,
+  no-painting, ask attribution, depth-1 render rule).
+  Tiers 817/152/57(app) green.
+
+**Post-phase test-audit (2026-08-14, same day; scope: the phase's tests).**
+Ten pins mutation-verified (six fresh mutations — summary recency, budget
+marker, unparented forwarding, lane disable [tripped four tests at once],
+both coalescer merge keys — plus the four bughunt pre-fix proofs); no
+theater and no wrong-target tests found; the e2e label sampling and the
+store-durability poll reviewed as timing-robust. TWO gaps found and
+filled, each mutation-proven: the store's every-frame round-trip test
+predated the lane (a reverted schema widening would have silently stripped
+deck replays — parented text/thinking/ask frames added), and the Tier-2
+fan-out itest never asserted the narration lane over the REAL daemon
+broadcast (parented prose presence + spawn integrity + no cross-parent
+merge added; only e2e covered that path before). One gap named and
+deliberately not filled: the deck component's replayed→no-elapsed wiring
+is pinned at the pure-function level only — the component line is
+one-line wiring whose e2e cost outweighs it; noted here so it's a
+decision, not an oversight.
+
+**Post-phase security audit (2026-08-14, same day; scope: the SA delta +
+its trust boundaries).** ZERO exploitable findings. ONE hardening landed
+(flood-cap parity, pinned): the shared `SubagentProseBudget` had no cap on
+DISTINCT parent ids, so a hostile/looping engine fabricating unlimited
+`parent_tool_use_id` values could grow the ledger without bound within a
+turn — now capped (`MAX_SUBAGENTS_PER_TURN` 2000; past it a NEW subagent's
+prose drops silently, the same degradation as every other per-turn cap;
+OpenCode's parent ids were already bounded by the spawn-part cap, so this
+mainly guards the Claude lane). Verified-clean facts worth keeping: a
+Claude Code SUBAGENT cannot reach the render MCP tools — proved through
+the REAL adapter + shipped in-process MCP server against a scripted
+endpoint (the SDK withholds MCP tools from subagents: 31 child tools, no
+`mcp__mirafold*`), so the no-painting rule holds on BOTH engines (OpenCode
+by our lane code, Claude by the engine itself); subagent prose renders
+inert everywhere (no markdown, no HTML sinks); the deck and the permission
+chip are shell chrome with engine text confined to inert slots; the store's
+`idSchema` bounds a tampered checkpoint's `parentId` at 1 KB; the
+committed fixture carries no secret-shaped strings; alternating parent ids
+cannot defeat the coalescers into unbounded ring growth (count + byte caps
+hold); `laneOf` is cycle-safe (hop cap).
+
+**Post-phase bughunt round 2 (2026-08-14, same day).** Two more found +
+fixed, pins proven failing pre-fix: (1) `zone_reset` cleared every
+streaming ref EXCEPT the new subtext map — a same-page full-replay
+(reconnect) with an open subagent prose run swallowed the replayed
+narration into entry ids that no longer existed (deck came back
+empty-handed); pinned by a resilience e2e that kills+restarts the daemon
+inside the slow-subagent hook's window (new mock hook `delegate slowly`),
+with a store-durability poll so the 250ms checkpoint debounce can't race
+the kill. (2) Child tool traffic steered the ROOT activity line (both
+`tool_use` setting the label and `tool_result` clearing it), contradicting
+the SA.3 design statement the server side already honored — the label now
+ignores parented tool traffic in both directions; pinned by multi-sampled
+label assertions in the SA.1 e2e. Diagnosis bonus, recorded: interior
+frames reach the checkpoint store on a 250ms debounce, so a daemon killed
+inside it loses the un-flushed tail — pre-existing, honest (the turn
+replays as interrupted), not a defect.
+
+**Post-phase bughunt round 1 (2026-08-14, same day).** Two found + fixed with
+pinned regressions (each proven failing pre-fix): a REPLAYED running deck
+ticked a false elapsed (stamp = attach moment, not spawn — now shows no
+elapsed unless the record arrived live), and the OpenCode lane's
+session-edge maps cleared per turn, making a `background: true` child
+unroutable after its spawning turn — its permission ask dropped (the SA.0
+hang, resurrected in a narrower window); the edge maps are now
+session-lifetime (insert-time caps still bound growth). **One deferred,
+LATENT:** a background child streaming ONE text part ACROSS a turn
+boundary would re-emit that part's full text (the per-turn part tracker
+resets, so the next snapshot's suffix restarts at 0) — duplicated prose in
+its deck. Deferred because reachability is unconfirmed (requires the
+engine to spawn background children in stock config, itself unverified)
+AND a proper fix reopens the 2026-08-13 flood-cap design (the part
+trackers are per-turn precisely to stay bounded); revisit if background
+children are ever observed live.
+
+**Done when (phase).** Prompting the mock or a real engine into a parallel
+fan-out yields live per-subagent cards — calm summary, expandable to full
+narration — on desktop and phone, replayed faithfully to a late-attaching
+viewport within caps; Claude Code and OpenCode both map the lane; an
+OpenCode subagent's permission ask no longer hangs; nothing anywhere spawns
+or directs a subagent from Mirafold's side; all tiers green.
+
+
+### Phase RC — why + RC.1–RC.4 bodies + done-when
+
+## Phase RC — Remote CREATE of OpenCode sessions (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
+
+**Why.** OC.4c's fail-closed design verifies an OpenCode session's credential
+kind at its first turn: until the engine classifies the pinned provider, the
+registry entry is `kindPending` and the relay gate refuses every remote
+action. Consequence (recorded in POST-RELEASE.md 2026-08-13, promoted here
+the same day at Kyle's direction): a remote viewport can ATTACH to an
+OpenCode session only after a first local turn — it can never CREATE one.
+Supporting remote creation means classifying BEFORE admitting the creator:
+spawn the engine, read the provider catalog, judge the pin, and only then
+attach the remote viewport. The gate itself does not change; only WHEN the
+truth arrives does.
+
+- [x] **RC.1 — the adapter seam.** — completed 2026-08-13. `AgentSession` gains optional
+  `verifyBackendKind?(): Promise<void>`: resolve once the truthful kind has
+  been published via `onBackendKind`, reject with the honest reason when it
+  cannot be (no binary, no pin, provider not connected, policy refusal).
+  OpenCode implements it as `ensureStarted()` — the full lazy-start path
+  (engine + policy + engine session), whose failure already resets the outer
+  latch so a later local prompt retries. No other adapter implements it:
+  their hello-time kind is already truthful.
+- [x] **RC.2 — the create path awaits truth.** — completed 2026-08-13
+  (`attachOrReapClassified`; timeout env `VERIFY_KIND_TIMEOUT_MS`, 30s
+  default). In `connection.ts`, a REMOTE
+  create (and the attach-path fallback create) of an entry that is
+  `kindPending` with a `verifyBackendKind` seam awaits classification —
+  bounded (30s) — BEFORE `attachTo` judges the relay gate. Local creates are
+  untouched: still synchronous, still lazy. On success the existing gate
+  judges the now-truthful kind (an ineligible provider still refuses with
+  the existing honest copy). On failure/timeout: the error goes to the
+  viewport and the minted session is REAPED (`registry.end`) — the
+  no-viewport leak rule from the 2026-07-29 bughunt applies unchanged. The
+  async detour catches its own errors (index.ts has no try/catch around
+  `handleMessage`).
+- [x] **RC.3 — the races.** — completed 2026-08-13 (d landed as a comment
+  correction only: the user-facing copy was already honest for the attach
+  path, and remote creates no longer surface it). (a) Viewport disconnects mid-classify → on
+  settle, a closed connection with a viewport-less entry reaps it. (b) A
+  second create/attach on the same connection while one classification is in
+  flight → refused honestly ("still verifying the previous create"); one
+  pending create per connection. (c) Entry torn down mid-classify → the
+  settle path checks `entries.get(id) === entry` before acting, like every
+  onBackendKind consumer. (d) `relayGateRefusal`'s `kindPending` copy stays
+  honest for BOTH paths now that remote creates verify inline: the
+  "run its first turn from its own machine" sentence describes only the
+  attach-to-existing case.
+- [x] **RC.4 — tests** — completed 2026-08-13: 7 connection-grain tests in
+  `server/sessions/remote-create.test.ts` (own process so the verify
+  timeout pins via env before module load; a registry session-factory test
+  seam injects the fake classifying session) + 2 adapter-grain in
+  `opencode.test.ts` (`verifyBackendKind` resolves after publish / rejects
+  honestly and stays retryable). Tiers 803/152/97 green. Original scope
+  (Tier 2 grain, `makeTransport` seam; no real engine):
+  Remote create allowed (kind publishes api-key → viewport attaches); remote
+  create policy-refused (subscription pin → refusal + entry reaped, no
+  MAX_SESSIONS leak); classify failure (engine start throws → honest error +
+  reap); timeout (kind never publishes → bounded refusal + reap); disconnect
+  mid-classify (no leak); local create unaffected (no await, still lazy).
+  The existing remote-attach regressions stay green.
+
+**Done when.** A relay viewport can create a fresh OpenCode session pinned to
+an allowed provider and drive it immediately; a subscription/Zen pin is
+refused at create with the honest reason and leaks nothing; all tiers green.
+
+
+### Gemini sunset — product call + deprecation-surface body
+
+## Gemini sunset (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
+
+**Product call.** From the 2026-08-13 market check: Google retired Gemini
+CLI upstream on 2026-06-18 (closed-source Antigravity replaced it; the
+dated citation lives in provider-policy.ts's R.6 note). Kyle's calls, in
+order: sunset rather than migrate (same day, morning), hold while other
+work was in flight, then "do the gemini sunset" (same day, after Phase OC
+merged). Shape: **gentle** — the API-key path still functions under the
+Gemini API ToS, so nothing is removed or hidden; the adapter is deprecated
+honestly. Removal is parked in POST-RELEASE.md, gated on evidence of
+actual breakage, never on a calendar.
+
+- [x] **Deprecation surface** — completed 2026-08-13: additive
+  `AgentInfo.deprecated` (daemon-composed reason; the picker renders it as
+  a suffix on the existing status line — no new element, the squeeze
+  ramp's height budget holds), connect-hint copy updated with the dated
+  retirement, a once-per-session dated notice in the Gemini adapter
+  (Mirafold-composed, lands before the first turn completes), the
+  provider-policy row annotated (policy itself unchanged), and the
+  POST-RELEASE removal entry with its evidence gate. Tier-1 tests: the
+  notice rides once and unbadged; `deprecated` rides the hello for gemini
+  only.
+
+
+### Phase OC — OC.0–OC.5 full bodies
+
+## Phase OC — OpenCode adapter (opened 2026-08-13; Kyle-directed)
+
+**Product call.** Kyle, from a 2026-08-13 market check: OpenCode (~195k
+GitHub stars) is now the dominant open-source terminal agent — the largest
+user population Mirafold doesn't cover — and becomes the fourth adapter.
+(Same check surfaced that Gemini CLI was retired upstream 2026-06-18,
+replaced by the closed-source Antigravity CLI; Gemini-adapter sunset is
+agreed but explicitly deferred — NOT part of this phase.) The feasibility
+spike is **`server/adapters/opencode.spike.md`** (verdict GREEN): the
+event→`WireMsg` table, the `OPENCODE_CONFIG_CONTENT` MCP-injection path,
+the permission reply round-trip, and the provider-keyed credential-policy
+design all live there — the steps below execute that doc, and its two live
+gates come first.
+
+- [x] **Step OC.0 — Live gates + shape capture** — completed 2026-08-13,
+  same day, $0 and credential-free: scratchpad-local `opencode-ai@1.18.18`
+  with HOME jailed; Gate 1 PASSED (`OPENCODE_CONFIG_CONTENT` alone
+  connected the render MCP; tools advertise as `mirafold_render_*`), Gate 2
+  PASSED via a fake OpenAI-compatible provider (ask event is
+  **`permission.asked`** — published SDK types drift — reply `once` ran the
+  tool through to `session.idle`). Streaming is a true delta channel
+  (`message.part.delta`), usage + `modelID` ride each assistant message.
+  Bonuses: 1.18.18 offers no Anthropic/Google OAuth at all, and a fresh
+  install ships the free "OpenCode Zen" provider (needs its own OC.3
+  policy row). One residual folded into OC.3: confirm a stored
+  credential's oauth-vs-api kind is server-readable (needs a real
+  connected credential). Full appendix in the spike doc. — **Goal:** de-risk the
+  two spike gates and lock real shapes before adapter code exists.
+  **Build:** run `opencode serve` (scratchpad-local install is fine; no
+  global mutation) and confirm: (1) `OPENCODE_CONFIG_CONTENT` loads the
+  mirafold render MCP and its tools appear (exact tool-name prefix
+  captured); (2) a permission ask surfaces as `permission.updated` headless
+  and the reply endpoint resolves it; plus capture the provider catalog's
+  auth exposure (oauth-vs-api visible without reading `auth.json`?), the
+  streaming part-update granularity, and usage field names. A $0 provider
+  (Ollama or an existing API key) is needed for gate 2 only. **Done when:**
+  the spike doc's "confirm live" flags are each resolved GREEN/RED with
+  captured payloads appended to the doc.
+- [x] **Step OC.1 — Core adapter + Tier-1** — completed 2026-08-13:
+  `opencode.ts` (session: lazy spawn-with-retry latch, serial queue,
+  first-turn guidance flipped only after prompt acceptance, permission
+  bridge with deny-by-default timeout + external-reply handling +
+  interrupt grace fallback) + `opencode-events.ts` (mapper: delta/snapshot
+  text accrual, tool lifecycle, mirafold `render_*` recognition with
+  honest fallback, todo checklist, per-turn usage summing) +
+  `opencode-client.ts` (raw HTTP+SSE transport — the spike's SDK
+  recommendation REVERSED with the reason recorded there: live shapes
+  beat drifting generated types). 22 Tier-1 tests on captured shapes;
+  full Tier-1 suite 746/746; typecheck green. `AgentName` grew additively
+  (policy row fails closed, agent not in ADAPTER_AGENTS, so nothing is
+  offered before OC.3/OC.4). — **Goal:** an OpenCode session
+  behind the `AgentSession` seam, mock-verified. **Build:**
+  `server/adapters/opencode.ts` — spawn `opencode serve` on a free port
+  with a per-session `OPENCODE_SERVER_PASSWORD`, create the session, prompt
+  via `prompt_async` with the pinned `model`, normalize the SSE stream per
+  the spike table (text/reasoning accrual → deltas, tool parts →
+  `tool_use`/`tool_result` with `capOutput`, `todo.updated` → checklist,
+  `session.idle` → `turn_end`, `session.error` → sourced notice),
+  `interrupt()` → abort, `resumeId` = session id. SDK-vs-raw call finalized
+  at install per the spike. **Files:** `server/adapters/opencode.ts`
+  (+ `.test.ts` with a fake SSE feed), `server/protocol.ts` (`AgentName` +
+  fixtures — additive only). **Done when:** Tier-1 drives the full table
+  through a fake event feed; `yarn typecheck` green.
+- [x] **Step OC.2 — Render MCP + permission bridge** — completed
+  2026-08-13. The Tier-1 half had landed inside OC.1; this step ran the
+  live leg, $0 and credential-free (real `OpenCodeSession` → real spawned
+  engine → fake provider): **a card painted end-to-end** through the real
+  render-mcp stub, and **a permission ask round-tripped live** (ask → bar
+  shape → `once` → bash ran). It caught and fixed two adapter bugs
+  (health-poll wedge on pre-ready connections — per-attempt abort is
+  load-bearing; user-message parts echoing as text_delta — roles now
+  tracked, +1 test) and characterized one upstream engine behavior,
+  documented not gated: a cold server's first model call carries zero
+  tools; the engine self-recovers same-turn (spike appendix has the full
+  probe evidence). Suite 747/747, typecheck green. — **Goal:** generative
+  UI and the permission bar, faithfully. **Build:** inject
+  `renderMcpCommand()` under `MIRAFOLD_MCP` via `OPENCODE_CONFIG_CONTENT`
+  (additive merge; user config untouched); recognize mirafold tool parts by
+  the OC.0-confirmed prefix → `generativeUIMsg` (skip the raw tool block);
+  `permission.updated` → `permission_request`, `resolvePermission` → reply
+  `once`/`reject` (**never `always`** — that writes the user's own approval
+  state), `PERMISSION_TIMEOUT_MS` deny-by-default. **Done when:** Tier-1
+  proves render-call recognition + both permission outcomes + timeout; a
+  live render paints end-to-end.
+- [x] **Step OC.3 — Credential policy + registry wiring** — completed
+  2026-08-13, including the "needs a real credential" residual — resolved
+  with auth.json FIXTURES in the jailed probe home (no real credential
+  needed): the engine's own catalog distinguishes every kind (`source`
+  api/env/config/custom + the `opencode-oauth-dummy-key` OAuth marker), it
+  leaks raw stored secrets (stripped at the transport seam, never past
+  it), and 1.18.18 ignores a stored anthropic OAuth wholesale. Landed:
+  `classifyOpenCodeProvider` matrix in provider-policy.ts (fail-closed:
+  unknown OAuth, Zen-pending-terms, unrecognized shapes all refuse with
+  human copy), session-start enforcement in opencode.ts (pin resolved
+  from OPENCODE_MODEL or the user's config `model`; refusals precede any
+  engine session), shallow hello detection in index.ts (binary +
+  auth.json existence — contents unread), `Backend.provider` from the
+  pin. ChatGPT gray: policy-allowed, session-refused until OC.4 flows
+  classified kind into Backend (relay-gate truth). 8 policy tests + 3
+  session tests; suite 752/752; typecheck green. — **Goal:** the
+  policy matrix applied provider-aware, fail-closed. **Build:**
+  `provider-policy.ts` gains the OpenCode provider classification
+  (anthropic/google oauth → blocked; openai oauth → disclosed gray area;
+  api-key/env → `api-key`; local → `local`; **unclassified oauth →
+  blocked**), detection per the OC.0-confirmed path (server catalog
+  preferred; `auth.json` only with explicit consent); model pinned
+  per-prompt so the session provider is the one Mirafold set; registry:
+  `createSession` case, `agentHasCredentials("opencode")`, `Backend.provider`
+  carries the pick. Relay gate unchanged (already refuses `subscription`).
+  **Done when:** Tier-1 covers every matrix row incl. the fail-closed
+  default; blocked/gray states render their correct copy.
+- [x] **Step OC.4 — In-session fidelity surface** — completed 2026-08-13
+  (the original OC.4 split in two; the onboarding half is OC.4b below):
+  `opencode-commands.ts` on the codex picker pattern — `/model` paints the
+  cross-provider catalog (policy-filtered: only providers a pick can
+  actually run; a typed blocked pick refuses with its reason and keeps the
+  pin), `/agent` paints user-facing primaries only (`hidden` internals and
+  subagents excluded; pick rides every subsequent prompt), the engine's
+  own command catalog routes `/name` inputs to `POST /session/:id/command`
+  (the engine's real dispatcher, with pin + agent) and feeds
+  `emitPromptOptions` behind our two re-skins (engine rows badged
+  `source: "opencode"`). 6 new Tier-1 tests; suite 757/757; typecheck
+  green. — **Goal:** what an OpenCode user expects in-session.
+- [x] **Step OC.4b — Offerable + Zen terms citation** — completed
+  2026-08-13 (the kind-into-Backend half split to OC.4c; live onboarding
+  proof folds into OC.5): `opencode` joined ADAPTER_AGENTS +
+  `defaultAgent`; one shallow `backendOptions` api-key row (existence
+  probe; the provider-resolved truth stays enforced at session start);
+  real agents-meta copy (connect hint names install + `opencode auth
+  login` + OPENCODE_MODEL and says plainly that subscriptions and Zen
+  aren't usable yet), `backendLabel` "API key (via opencode)", PromptBox
+  source badge. **Zen terms read and cited** in provider-policy.ts
+  (2026-08-13: no third-party-harness prohibition — the server API is
+  opencode's own documented programmatic surface; "own internal use"
+  clause; free-period training-data caveat): the disclosed-uncertainty
+  rule's exact shape, but opening a NEW provider under it is Kyle's call
+  (codex precedent), so the row stays CLOSED pending his decision — if
+  opened, local-only + caveat shown. Also fixed en route: the fourth
+  agent row overflowed the onboarding squeeze ramp by 14px — the
+  squeeze intercept moved 66→70 and the per-row floor metrics shaved
+  (full-chrome values untouched); the squeeze e2e passes with four READY
+  rows. Verification status, honestly: Tier-1 757/757 + Tier-2 152/152
+  green; e2e ran 96/97 before the CSS fix (the squeeze test its only
+  failure, after the hint-count assertion gained the fourth card) and
+  the fixed squeeze test passes in isolation — but two attempts at the
+  full post-fix e2e run were stopped externally mid-run (6/6 ok at each
+  stop), so ONE clean full-suite pass is still owed; folded into OC.5's
+  tier sweep.
+- [x] **Step OC.4c — Classified kind into Backend + ZEN OPENED** —
+  completed 2026-08-13, same day Kyle said "open Zen" (the decision the
+  OC.4b citation was waiting on). Built exactly per the design below:
+  `onBackendKind` seam + registry adoption at `activate()` (truthful kind
+  checkpointed), `kindPending` refusing remote actions pre-verification,
+  and the three relay-gate sites (attach, cockpit acts, uploads) unified
+  on one `relayGateRefusal` verdict in provider-policy.ts. The ChatGPT
+  gray now RUNS locally with its uncertainty disclosure (once per
+  provider, Mirafold-composed, no badge). **Zen**: new `gateway`
+  CredentialKind (additive on every wire union) — allowed locally for
+  opencode with the uncertainty + training-data disclosure, NEVER
+  relay-eligible (the allow-list refuses it by design); fresh
+  binary-only installs now detect live out of the box, and the /model
+  picker offers Zen rows. 761/761 + 152/152 green; the full-e2e sweep
+  remains owed to OC.5 (two prior runs externally stopped). — original
+  goal + design: **Goal:** the gray path runs under its TRUE kind. **Build:**
+  an optional `AgentSession.onBackendKind` seam (like `onResumeId`): the
+  OpenCode session publishes the OC.3-classified kind + provider at start;
+  the registry updates its `Backend` so the relay gate judges truth.
+  **The race that shapes the design:** hello-kind is optimistic
+  ("api-key"), so a relay viewport's FIRST prompt could slip the gate
+  before classification lands — closed by a `kindVerified` flag on
+  opencode Backends (server-side only): relay prompts refuse with an
+  honest "still verifying" message until the session publishes, local
+  viewports unaffected. Then the OC.3 session-level gray refusal lifts,
+  replaced by a Mirafold-composed disclosure notice at session start
+  (uncertainty stated, never permission — the codex CONNECT_HINT contract,
+  session-time edition). **Done when:** Tier-1 covers publish→registry
+  update, the pre-verification relay refusal, and the gray disclosure;
+  the relay itest proves a subscription-classified session never runs a
+  turn from a relay viewport.
+- [x] **Step OC.5 — Tier sweep + live end-to-end** — completed 2026-08-13
+  (one residual below): **`opencode-live.ltest.ts`** joins Tier 4 on the
+  codex pattern (real binary, never a hosted model; the scripted
+  OpenAI-compatible provider from the OC.2 probe; HOME/XDG jailed via a
+  new transport `env` seam so a real engine run never touches the
+  developer's own opencode state; skips cleanly when opencode isn't
+  installed). One 17s test drives the WHOLE loop through shipped code:
+  render through the real MCP stub, headless permission ask answered via
+  the bridge, usage, kind publish (config→local), and **resume across a
+  full engine restart**. All tiers green same-sitting: Tier-1 761/761,
+  Tier-2 152/152, Tier-3 97/97 (the sweep owed since OC.4b — paid),
+  Tier-4 1/1 live + verified clean skip. **Residual CONFIRMED by Kyle
+  2026-08-13**: real global install (`npm i -g opencode-ai` — his npm's
+  install-scripts blocking required the manual postinstall, the exact
+  failure the transport's stderr surfacing named; the session's
+  start-latch retry then worked as designed, no restarts) and a live
+  browser session on Zen: "heyyyy it works". Phase OC complete.
+  README/ADAPTERS.md refresh rides the wrapup.
+
+
+### Paintings polish — origin + fix-batch + instrumentation bodies
+
+## Paintings polish batch (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
+
+**Origin.** A paintings audit (this session) asked three questions: are the
+existing paintings at the delightful bar, does the agent actually reach for
+them, and are there coverage gaps. Verdict: the registry is strong (fallback
+architecture, CVD-safe charts, never-color-alone) with a short list of
+concrete defects; adoption is UNMEASURABLE (no instrumentation anywhere);
+coverage needs nothing new now (the 2026-07-10 survey already filled the real
+gaps, POST-RELEASE.md's 2026-08-02 growth analysis still governs). So: polish
+first, measurement second, new paintings demand-gated.
+
+- [x] **Fix batch** — completed 2026-08-13, all three tiers green
+  (724/152/97):
+  - `.rc` gains `overflow-wrap: anywhere` — an unbroken token (URL, SHA,
+    long path) in any painting's prose no longer pushes the transcript
+    sideways; inert on the monospace bodies (`white-space: pre` has no wrap
+    points), so code/console/diff keep their horizontal scroll.
+  - Chart: line charts fit the y domain to the DATA (`chartDomain`) — a
+    200–210 ms latency trend is no longer a flat stripe under a forced zero
+    baseline (bars still anchor to zero: a bar's length IS its value);
+    ≤2-point line charts draw always-on dots (a 1-point polyline painted
+    nothing); the forced last x label suppresses a stride label it would
+    collide with (`showXLabel`); grouped bars can no longer bleed past
+    their band at high category×series counts (`groupedBarLayout`). All
+    four pure + Tier-1-pinned.
+  - Table: every row renders exactly `columns.length` cells (surplus
+    truncated, missing padded — misaligned rows used to escape the header
+    silently); number cells right-align with `tabular-nums`
+    (`.rc-table-num`); empty `rows` shows a muted "no rows" instead of a
+    bare header. Tier-1-pinned (`Table.test.ts`, new).
+  - Code + Console bodies: vertical clamp (`max-height: 360px`, scroll) —
+    the diff body's existing treatment; a dumped whole file / 200k-char log
+    scrolls in its panel instead of consuming the transcript.
+  - **Diagram follows the app theme now (decision).** Pinned-dark is the
+    CODE-surface convention (`--code-bg` + ANSI/hljs palettes, manifest
+    PINNED_TOKENS); a diagram is a picture, not a code surface, and on the
+    light themes it rendered as a jarring dark slab. The frame body is
+    transparent (the panel surface is the canvas), mermaid re-initializes
+    per message with the shell-computed dark flag + `--surface` color, and
+    a `data-theme` MutationObserver re-posts on theme switch so baked-in
+    SVG colors follow. Sandbox posture unchanged (strict, no-network CSP,
+    postMessage-only source) — Tier-1 pins the transparent body +
+    per-message init.
+- [x] **Paintings-adoption instrumentation** — completed 2026-08-13: one
+  LOCAL log line per paint (`paint <component> agent=<agent>`) at
+  `registry.deliver()`, the choke point every adapter's stream crosses.
+  Local daemon log only, nothing leaves the machine; cheap enough to keep,
+  one `if` to delete if treated as temporary. Purpose: make "does this
+  engine actually reach for the render tools" answerable from logs — the
+  audit found the Codex/Gemini guidance asymmetry (one-shot first-turn
+  prepend vs. Claude's every-request system-prompt append) impossible to
+  evaluate without it.
+- Audit findings deliberately NOT fixed here (recorded, not lost): the two
+  hand-kept `TOOL_DESCRIPTIONS` maps (render-tools.ts / render-mcp.ts) have
+  drifted in wording with no guard test; no test pins Claude's
+  `mcpServers`/`systemPrompt.append` registration; the stdio
+  `emit_artifact` description omits the `mirafold.prompt/tool` sandbox API
+  that the in-process description documents (Codex/Gemini can't author
+  interactive artifacts); registry CSS half-lives in `08-picker.css`
+  (housekeeping); HBar tooltip parks at `left: 40%`. Each is a candidate
+  for a follow-up surfacing-parity step.
+
+
+### FD.1 + FD.2 step bodies
+
+### Phase FD.1 — Wire + daemon staging
+
+- [x] **Step FD.1 — Chunked upload messages + the staging writer** —
+  completed 2026-08-12: five additive message types + Q.2 fixtures,
+  `upload-handlers.ts` with 12 Tier-1 tests covering the full refusal
+  matrix, and 2 Tier-2 itests proving byte-exact staging + typed refusals
+  over a real socket. — **Goal:** a client can stream a bounded file to the daemon and get back
+  a staged absolute path, with every abuse path refused loudly. **Build:**
+  additive protocol types (`file_upload_begin {id,name,size}` /
+  `file_upload_chunk {id,data}` / `file_upload_abort {id}` client-side;
+  `file_upload_done {id,path,name}` / `file_upload_error {id,message}`
+  replies) + Q.2 fixtures; `server/sessions/upload-handlers.ts` on the
+  fs-handlers template (per-connection state, never throws, every
+  well-formed request gets exactly one reply); connection.ts delegation +
+  dispose on close. **Files:** `server/protocol.ts`,
+  `server/protocol.test.ts`, `server/sessions/upload-handlers.ts` (+
+  `.test.ts`), `server/sessions/connection.ts`,
+  `server/sessions/file-upload.itest.ts`. **Done when:** Tier-1 covers
+  sanitization (path-stripped names, control chars, dot-names, length
+  cap, collision suffixing), size/concurrency/stall caps, chunk-overflow
+  and chunk-before-begin refusals, and the remote relay gate; a Tier-2
+  itest streams real bytes over a real socket and reads back the exact
+  file from staging; `yarn typecheck` green.
+
+### Phase FD.2 — The drop experience in the shell
+
+- [x] **Step FD.2 — Dropzone, progress, path insertion, e2e, docs** —
+  completed 2026-08-12: window-level drop targets + overlay + upload strip
+  shipped, staged paths quoted into the prompt via the draft merge with a
+  polite announcement, 10 Tier-1 tests on the client core, and the e2e
+  proves the whole loop (synthesized `DataTransfer` drop → overlay →
+  staged-path in textarea → byte-exact file on disk → announcement). One
+  diagnosed trap recorded: the drag listeners attach only after the
+  session attaches, so a dispatch racing the mount fires into the void —
+  the e2e waits for the session UI first. — **Goal:** dragging files onto a session viewport uploads them and puts
+  their staged paths in the prompt, visibly and accessibly. **Build:**
+  `web/src/file-drop.ts` — pure chunking/state core + a
+  folder-picker-style reply router, Tier-1-tested; session-bus gains the
+  three send methods; Shell wires window-level drag listeners (gated off
+  onboarding), a shell-owned drop overlay + a compact upload strip above
+  the prompt (name + progress + dismissible error), quoted-path insertion
+  through the PromptDraft merge, and a polite announcement per attached
+  file; CSS in the prompt-area stylesheet. **Files:**
+  `web/src/file-drop.ts` (+ `.test.ts`), `web/src/session-bus.ts`,
+  `web/src/components/Shell.tsx`, styles, `server/testing/app.e2e.ts`,
+  README, POST-RELEASE.md (annotate the Input augment entry). **Done
+  when:** the e2e drops a real `File` via `DataTransfer` on the live page,
+  watches the strip, reads the staged path out of the textarea, verifies
+  the staged file's exact bytes on disk, and axe stays clean; all three
+  tiers green.
+
+
+### NF.1 + NF.2 step bodies
+
+### Phase NF.1 — The notify engine + both surfaces wired
+
+- [x] **Step NF.1 — Pure decision core, DOM binder, Shell + fleet wiring** —
+  completed 2026-08-12: `web/src/notify.ts` (reducer + binder + DOM wiring)
+  landed with 23 Tier-1 tests covering the full matrix below; both routes
+  wired exactly as specified, `yarn test` 695 green, typecheck clean. —
+  **Goal:** notifications actually fire from both routes, correctly
+  suppressed, coalesced, and self-closing, behind a preference that defaults
+  off. **Build:** `web/src/notify.ts`: (a) a pure transition reducer — given
+  the previous per-session state map, fresh session snapshots
+  (`{id, state: idle|busy|permission, title, agent?, detail?}`), and flags
+  `{enabled, granted, visible}`, return show/close actions plus the next map —
+  every rule above lives here; (b) `createNotifier(deps)` binding the reducer
+  to injected `{isVisible, permission, spawn, onVisibilityChange}` with a
+  `reset()` that reseeds state without emitting (used across socket
+  drop/reconnect so a forced `busy→idle` never fakes a turn-end). Wire Shell
+  (its `asks`/`busy` tri-state, title from the cwd basename, detail from
+  `asks[0]`) and FleetView (per-session from the `sessions` snapshot,
+  `wantsAnswer` for the permission side, close toasts for sessions that leave
+  the list). Clicking focuses the firing tab. **Files:** `web/src/notify.ts`,
+  `web/src/notify.test.ts`, `web/src/components/Shell.tsx`,
+  `web/src/components/FleetView.tsx`. **Done when:** Tier-1 tests prove the
+  reducer's full matrix (permission shown once; answered-elsewhere closes;
+  turn-end shown on `busy→idle` and `permission→idle`; visible suppresses
+  shows but still advances state; disabled/ungranted emit nothing; per-session
+  independence; vanished session closes; reset never emits) and the binder's
+  lifecycle against fakes; `yarn typecheck` passes.
+
+### Phase NF.2 — The settings affordance + end-to-end proof
+
+- [x] **Step NF.2 — Toggle in the settings card, e2e, docs** — completed
+  2026-08-12: Notifications section shipped in the settings card (switch row
+  + blocked hint), Shell owns preference/permission logic, e2e proves the
+  full hidden-tab loop (toggle → permission toast → answered → turn-end
+  toast → visibility closes all). One diagnosed trap recorded for future e2e
+  work: tsx's esbuild keepNames injects a module-scope `__name` helper into
+  compiled classes/accessor properties, which Playwright then serializes
+  WITHOUT the helper — init scripts and evaluates containing them die on a
+  ReferenceError, so the Notification stub and the visibility override are
+  plain-JS strings. — **Goal:** a
+  user can find and flip the feature, and headless Chrome proves the visible
+  behavior. **Build:** a Notifications section in the settings card
+  (`ThemePicker.tsx`, prop-driven — the card stays Vite-only and dumb): one
+  toggle row ("Notify me when a session needs me"), `aria-pressed`, a plain
+  hint line when the browser has the permission hard-denied ("blocked in
+  browser settings") or the API is absent. Shell owns the logic: preference in
+  `localStorage["mirafold-notify"]`, enabling requests browser permission when
+  still undecided. Fleet honors the same stored preference with no UI of its
+  own. Settings-card CSS additions in `web/src/styles/12-dialogs.css`.
+  **Files:** `web/src/components/ThemePicker.tsx`,
+  `web/src/components/Shell.tsx`, `web/src/notify.ts` (preference helpers),
+  `web/src/styles/12-dialogs.css`, `server/testing/app.e2e.ts`, README.
+  **Done when:** the e2e opens settings, sees the section, flips the toggle
+  (Notification API stubbed via init script), asserts the stored preference
+  and `aria-pressed`, and a stubbed-notification assertion proves a hidden-tab
+  permission event spawns exactly one tagged toast; axe stays clean;
+  `yarn test` + `yarn test:e2e` + `yarn typecheck` pass; README's shell-UI
+  section gains the tab-status-adjacent paragraph.
+

--- a/PLAN.md
+++ b/PLAN.md
@@ -3128,19 +3128,29 @@ signoff of the reported plan)*:
   three cards live at once, independent tick, out-of-order settle, expand/
   collapse, axe-clean, phone-width stack with no side scroll. Tiers
   810/152/57(app) green.
-- [ ] **SA.2 — The narration lane (wire + Claude Code + expand).**
-  Protocol: optional `parentId` on `text_delta`/`thinking_delta`,
-  documented as an opaque adapter-chosen handle (never parsed, only
-  grouped). Registry: coalescer merge key gains `parentId`. Adapter:
-  forward subagent text + thinking from parent-tagged complete messages
-  (message-grain deltas), per-subagent narration cap
-  (`SUBAGENT_TEXT_CAP_BYTES`, default 64 KB, explicit elision marker,
-  never silent). Client: expand/collapse on the card — full activity,
-  narration as inert plain text (fleet activity-line precedent), collapse
-  back to calm. Replay: rides the ring as-is (globally capped). Done
-  when: mock + Tier-1/2 prove per-parent bucketing (no cross-parent
-  merge), the cap's marker, and old-client shape compatibility; e2e:
-  expand shows narration live, collapse returns calm.
+- [x] **SA.2 — The narration lane (wire + Claude Code + expand).** —
+  completed 2026-08-14. Protocol: optional `parentId` on
+  `text_delta`/`thinking_delta`, documented opaque (grouped, never
+  parsed); checkpoint-store strict schemas widened to match (they would
+  have REJECTED the field — caught in-pass). Merge keys gained
+  `parentId` in BOTH coalescers (registry window + client delta-queue) so
+  parallel prose never concatenates across agents. Claude Code adapter:
+  parent-tagged complete-message text/thinking forward as message-grain
+  parented deltas through `SubagentProseBudget` (shared in
+  `adapters/types.ts` for SA.3; `SUBAGENT_TEXT_CAP_BYTES` 64 KB default,
+  one explicit elision marker, byte-safe slice, per-subagent ledger
+  cleared per turn); the F.1 buffered-text dedup rule untouched for the
+  parent; stale stream_event comment corrected. Client: `subtext`
+  entries route to their card BEFORE fold/close logic (child prose can't
+  fold parent thinking), extend-in-place per (parent|variant), closed by
+  that subagent's next tool row — the expansion (`SubagentActivity`)
+  interleaves calls + narration + dim italic reasoning in true stream
+  order, inert plain text (e2e asserts no markdown elements render);
+  Shell keeps subagent prose out of the turn-end announcement and the
+  activity label. Tests: adapter forwarding + wire order, budget
+  semantics (cap marker, per-agent ledgers, U+FFFD safety, reset),
+  registry + delta-queue no-cross-parent merges, e2e narration in the
+  expansion. Tiers 814/152/57(app) green.
 - [ ] **SA.3 — The OpenCode mapping (neutrality proven).** `isOurs`
   becomes a lane router: child-session events map to `parentId` = parent
   task part id (Map from `state.metadata.sessionId` +

--- a/PLAN.md
+++ b/PLAN.md
@@ -3196,6 +3196,23 @@ signoff of the reported plan)*:
   no-painting, ask attribution, depth-1 render rule).
   Tiers 817/152/57(app) green.
 
+**Post-phase test-audit (2026-08-14, same day; scope: the phase's tests).**
+Ten pins mutation-verified (six fresh mutations — summary recency, budget
+marker, unparented forwarding, lane disable [tripped four tests at once],
+both coalescer merge keys — plus the four bughunt pre-fix proofs); no
+theater and no wrong-target tests found; the e2e label sampling and the
+store-durability poll reviewed as timing-robust. TWO gaps found and
+filled, each mutation-proven: the store's every-frame round-trip test
+predated the lane (a reverted schema widening would have silently stripped
+deck replays — parented text/thinking/ask frames added), and the Tier-2
+fan-out itest never asserted the narration lane over the REAL daemon
+broadcast (parented prose presence + spawn integrity + no cross-parent
+merge added; only e2e covered that path before). One gap named and
+deliberately not filled: the deck component's replayed→no-elapsed wiring
+is pinned at the pure-function level only — the component line is
+one-line wiring whose e2e cost outweighs it; noted here so it's a
+decision, not an oversight.
+
 **Post-phase security audit (2026-08-14, same day; scope: the SA delta +
 its trust boundaries).** ZERO exploitable findings. ONE hardening landed
 (flood-cap parity, pinned): the shared `SubagentProseBudget` had no cap on

--- a/PLAN.md
+++ b/PLAN.md
@@ -3196,6 +3196,23 @@ signoff of the reported plan)*:
   no-painting, ask attribution, depth-1 render rule).
   Tiers 817/152/57(app) green.
 
+**Post-phase bughunt round 1 (2026-08-14, same day).** Two found + fixed with
+pinned regressions (each proven failing pre-fix): a REPLAYED running deck
+ticked a false elapsed (stamp = attach moment, not spawn — now shows no
+elapsed unless the record arrived live), and the OpenCode lane's
+session-edge maps cleared per turn, making a `background: true` child
+unroutable after its spawning turn — its permission ask dropped (the SA.0
+hang, resurrected in a narrower window); the edge maps are now
+session-lifetime (insert-time caps still bound growth). **One deferred,
+LATENT:** a background child streaming ONE text part ACROSS a turn
+boundary would re-emit that part's full text (the per-turn part tracker
+resets, so the next snapshot's suffix restarts at 0) — duplicated prose in
+its deck. Deferred because reachability is unconfirmed (requires the
+engine to spawn background children in stock config, itself unverified)
+AND a proper fix reopens the 2026-08-13 flood-cap design (the part
+trackers are per-turn precisely to stay bounded); revisit if background
+children are ever observed live.
+
 **Done when (phase).** Prompting the mock or a real engine into a parallel
 fan-out yields live per-subagent cards — calm summary, expandable to full
 narration — on desktop and phone, replayed faithfully to a late-attaching

--- a/PLAN.md
+++ b/PLAN.md
@@ -146,8 +146,11 @@ faithful per-agent skins) · **4** except 4.7 (→ Phase R) · **G, H, H2**
 backend picker) · **V** (visual + fidelity gaps) · **A** (accessibility) ·
 **C** (CI/CD) · **E** (Explorer) · **M** (Mission control) · **E2** (Explorer at scale) ·
 **E3** (Explorer visual polish) · **W** (live tree), **UX** (native prompt discovery, transcript fidelity,
-durable provider recovery, and branch test-audit closure), plus the finished
-steps of the still-open Phases **K, R, F, Q, L**.
+durable provider recovery, and branch test-audit closure) · **CR** (Changes
+review workspace) · **NF** (needs-you notifications) · **FD** (file
+drag-and-drop) · the paintings polish batch · **OC** (OpenCode adapter) ·
+the Gemini sunset · **RC** (remote OpenCode create) · **SA** (subagent
+view), plus the finished steps of the still-open Phases **K, R, F, Q, L**.
 
 Archive passes, each a section header in PLAN-ARCHIVE.md you can navigate to:
 2026-07-08 · 2026-07-10 · 2026-07-15 · "Moved 2026-07-17" · "Moved 2026-07-19"
@@ -157,7 +160,9 @@ E2/W step bodies, the Phase E/M narrative passes, the R.4l item-5
 investigation, the CI-flake breakdown, and finished stretch-goal specs) ·
 "Moved 2026-08-09" (Phase UX) · "Moved 2026-08-12 (prune — completed
 bodies)" (a sweep of finished bodies across Phases 4/R/A/Q, the 2026-07-27
-audit section, and the stretch goals).
+audit section, and the stretch goals) · "Moved 2026-08-14 (post-SA prune —
+completed bodies)" (the NF/FD step bodies, paintings polish, Phase OC, the
+Gemini sunset, Phase RC, and the whole Phase SA record).
 
 ---
 
@@ -2458,64 +2463,13 @@ only thing that triggers the browser's permission prompt (never page load).
 No secret ever enters a notification body — tool + detail are already
 user-visible PermBar strings.
 
-### Phase NF.1 — The notify engine + both surfaces wired
-
-- [x] **Step NF.1 — Pure decision core, DOM binder, Shell + fleet wiring** —
-  completed 2026-08-12: `web/src/notify.ts` (reducer + binder + DOM wiring)
-  landed with 23 Tier-1 tests covering the full matrix below; both routes
-  wired exactly as specified, `yarn test` 695 green, typecheck clean. —
-  **Goal:** notifications actually fire from both routes, correctly
-  suppressed, coalesced, and self-closing, behind a preference that defaults
-  off. **Build:** `web/src/notify.ts`: (a) a pure transition reducer — given
-  the previous per-session state map, fresh session snapshots
-  (`{id, state: idle|busy|permission, title, agent?, detail?}`), and flags
-  `{enabled, granted, visible}`, return show/close actions plus the next map —
-  every rule above lives here; (b) `createNotifier(deps)` binding the reducer
-  to injected `{isVisible, permission, spawn, onVisibilityChange}` with a
-  `reset()` that reseeds state without emitting (used across socket
-  drop/reconnect so a forced `busy→idle` never fakes a turn-end). Wire Shell
-  (its `asks`/`busy` tri-state, title from the cwd basename, detail from
-  `asks[0]`) and FleetView (per-session from the `sessions` snapshot,
-  `wantsAnswer` for the permission side, close toasts for sessions that leave
-  the list). Clicking focuses the firing tab. **Files:** `web/src/notify.ts`,
-  `web/src/notify.test.ts`, `web/src/components/Shell.tsx`,
-  `web/src/components/FleetView.tsx`. **Done when:** Tier-1 tests prove the
-  reducer's full matrix (permission shown once; answered-elsewhere closes;
-  turn-end shown on `busy→idle` and `permission→idle`; visible suppresses
-  shows but still advances state; disabled/ungranted emit nothing; per-session
-  independence; vanished session closes; reset never emits) and the binder's
-  lifecycle against fakes; `yarn typecheck` passes.
-
-### Phase NF.2 — The settings affordance + end-to-end proof
-
-- [x] **Step NF.2 — Toggle in the settings card, e2e, docs** — completed
-  2026-08-12: Notifications section shipped in the settings card (switch row
-  + blocked hint), Shell owns preference/permission logic, e2e proves the
-  full hidden-tab loop (toggle → permission toast → answered → turn-end
-  toast → visibility closes all). One diagnosed trap recorded for future e2e
-  work: tsx's esbuild keepNames injects a module-scope `__name` helper into
-  compiled classes/accessor properties, which Playwright then serializes
-  WITHOUT the helper — init scripts and evaluates containing them die on a
-  ReferenceError, so the Notification stub and the visibility override are
-  plain-JS strings. — **Goal:** a
-  user can find and flip the feature, and headless Chrome proves the visible
-  behavior. **Build:** a Notifications section in the settings card
-  (`ThemePicker.tsx`, prop-driven — the card stays Vite-only and dumb): one
-  toggle row ("Notify me when a session needs me"), `aria-pressed`, a plain
-  hint line when the browser has the permission hard-denied ("blocked in
-  browser settings") or the API is absent. Shell owns the logic: preference in
-  `localStorage["mirafold-notify"]`, enabling requests browser permission when
-  still undecided. Fleet honors the same stored preference with no UI of its
-  own. Settings-card CSS additions in `web/src/styles/12-dialogs.css`.
-  **Files:** `web/src/components/ThemePicker.tsx`,
-  `web/src/components/Shell.tsx`, `web/src/notify.ts` (preference helpers),
-  `web/src/styles/12-dialogs.css`, `server/testing/app.e2e.ts`, README.
-  **Done when:** the e2e opens settings, sees the section, flips the toggle
-  (Notification API stubbed via init script), asserts the stored preference
-  and `aria-pressed`, and a stubbed-notification assertion proves a hidden-tab
-  permission event spawns exactly one tagged toast; axe stays clean;
-  `yarn test` + `yarn test:e2e` + `yarn typecheck` pass; README's shell-UI
-  section gains the tab-status-adjacent paragraph.
+- [x] **NF.1 (engine + wiring) and NF.2 (settings + e2e) — BOTH COMPLETE
+  2026-08-12**; full bodies → **PLAN-ARCHIVE.md, "Moved 2026-08-14 (post-SA
+  prune — completed bodies)."** Standing gotcha kept from NF.2: tsx's esbuild
+  keepNames injects a module-scope `__name` helper that Playwright serializes
+  WITHOUT — init scripts / evaluated functions containing compiled classes or
+  const-assigned arrows die on a ReferenceError, so in-page stubs are plain-JS
+  strings (bit again in SA.1's e2e, 2026-08-14).
 
 ## File drag-and-drop input (opened 2026-08-12; Kyle-directed)
 
@@ -2549,109 +2503,21 @@ and path insertion are shell-owned end to end; a staged path enters the
 prompt via the existing draft-merge path, which never discards composed
 text.
 
-### Phase FD.1 — Wire + daemon staging
-
-- [x] **Step FD.1 — Chunked upload messages + the staging writer** —
-  completed 2026-08-12: five additive message types + Q.2 fixtures,
-  `upload-handlers.ts` with 12 Tier-1 tests covering the full refusal
-  matrix, and 2 Tier-2 itests proving byte-exact staging + typed refusals
-  over a real socket. — **Goal:** a client can stream a bounded file to the daemon and get back
-  a staged absolute path, with every abuse path refused loudly. **Build:**
-  additive protocol types (`file_upload_begin {id,name,size}` /
-  `file_upload_chunk {id,data}` / `file_upload_abort {id}` client-side;
-  `file_upload_done {id,path,name}` / `file_upload_error {id,message}`
-  replies) + Q.2 fixtures; `server/sessions/upload-handlers.ts` on the
-  fs-handlers template (per-connection state, never throws, every
-  well-formed request gets exactly one reply); connection.ts delegation +
-  dispose on close. **Files:** `server/protocol.ts`,
-  `server/protocol.test.ts`, `server/sessions/upload-handlers.ts` (+
-  `.test.ts`), `server/sessions/connection.ts`,
-  `server/sessions/file-upload.itest.ts`. **Done when:** Tier-1 covers
-  sanitization (path-stripped names, control chars, dot-names, length
-  cap, collision suffixing), size/concurrency/stall caps, chunk-overflow
-  and chunk-before-begin refusals, and the remote relay gate; a Tier-2
-  itest streams real bytes over a real socket and reads back the exact
-  file from staging; `yarn typecheck` green.
-
-### Phase FD.2 — The drop experience in the shell
-
-- [x] **Step FD.2 — Dropzone, progress, path insertion, e2e, docs** —
-  completed 2026-08-12: window-level drop targets + overlay + upload strip
-  shipped, staged paths quoted into the prompt via the draft merge with a
-  polite announcement, 10 Tier-1 tests on the client core, and the e2e
-  proves the whole loop (synthesized `DataTransfer` drop → overlay →
-  staged-path in textarea → byte-exact file on disk → announcement). One
-  diagnosed trap recorded: the drag listeners attach only after the
-  session attaches, so a dispatch racing the mount fires into the void —
-  the e2e waits for the session UI first. — **Goal:** dragging files onto a session viewport uploads them and puts
-  their staged paths in the prompt, visibly and accessibly. **Build:**
-  `web/src/file-drop.ts` — pure chunking/state core + a
-  folder-picker-style reply router, Tier-1-tested; session-bus gains the
-  three send methods; Shell wires window-level drag listeners (gated off
-  onboarding), a shell-owned drop overlay + a compact upload strip above
-  the prompt (name + progress + dismissible error), quoted-path insertion
-  through the PromptDraft merge, and a polite announcement per attached
-  file; CSS in the prompt-area stylesheet. **Files:**
-  `web/src/file-drop.ts` (+ `.test.ts`), `web/src/session-bus.ts`,
-  `web/src/components/Shell.tsx`, styles, `server/testing/app.e2e.ts`,
-  README, POST-RELEASE.md (annotate the Input augment entry). **Done
-  when:** the e2e drops a real `File` via `DataTransfer` on the live page,
-  watches the strip, reads the staged path out of the textarea, verifies
-  the staged file's exact bytes on disk, and axe stays clean; all three
-  tiers green.
+- [x] **FD.1 (wire + staging) and FD.2 (drop experience) — BOTH COMPLETE
+  2026-08-12**; full bodies → **PLAN-ARCHIVE.md, "Moved 2026-08-14 (post-SA
+  prune — completed bodies)."** Standing gotcha kept from FD.2: the drag
+  listeners attach only after the session attaches — an e2e dispatch racing
+  the mount fires into the void, so drop e2es wait for the session UI first.
 
 ## Paintings polish batch (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
 
-**Origin.** A paintings audit (this session) asked three questions: are the
-existing paintings at the delightful bar, does the agent actually reach for
-them, and are there coverage gaps. Verdict: the registry is strong (fallback
-architecture, CVD-safe charts, never-color-alone) with a short list of
-concrete defects; adoption is UNMEASURABLE (no instrumentation anywhere);
-coverage needs nothing new now (the 2026-07-10 survey already filled the real
-gaps, POST-RELEASE.md's 2026-08-02 growth analysis still governs). So: polish
-first, measurement second, new paintings demand-gated.
-
-- [x] **Fix batch** — completed 2026-08-13, all three tiers green
-  (724/152/97):
-  - `.rc` gains `overflow-wrap: anywhere` — an unbroken token (URL, SHA,
-    long path) in any painting's prose no longer pushes the transcript
-    sideways; inert on the monospace bodies (`white-space: pre` has no wrap
-    points), so code/console/diff keep their horizontal scroll.
-  - Chart: line charts fit the y domain to the DATA (`chartDomain`) — a
-    200–210 ms latency trend is no longer a flat stripe under a forced zero
-    baseline (bars still anchor to zero: a bar's length IS its value);
-    ≤2-point line charts draw always-on dots (a 1-point polyline painted
-    nothing); the forced last x label suppresses a stride label it would
-    collide with (`showXLabel`); grouped bars can no longer bleed past
-    their band at high category×series counts (`groupedBarLayout`). All
-    four pure + Tier-1-pinned.
-  - Table: every row renders exactly `columns.length` cells (surplus
-    truncated, missing padded — misaligned rows used to escape the header
-    silently); number cells right-align with `tabular-nums`
-    (`.rc-table-num`); empty `rows` shows a muted "no rows" instead of a
-    bare header. Tier-1-pinned (`Table.test.ts`, new).
-  - Code + Console bodies: vertical clamp (`max-height: 360px`, scroll) —
-    the diff body's existing treatment; a dumped whole file / 200k-char log
-    scrolls in its panel instead of consuming the transcript.
-  - **Diagram follows the app theme now (decision).** Pinned-dark is the
-    CODE-surface convention (`--code-bg` + ANSI/hljs palettes, manifest
-    PINNED_TOKENS); a diagram is a picture, not a code surface, and on the
-    light themes it rendered as a jarring dark slab. The frame body is
-    transparent (the panel surface is the canvas), mermaid re-initializes
-    per message with the shell-computed dark flag + `--surface` color, and
-    a `data-theme` MutationObserver re-posts on theme switch so baked-in
-    SVG colors follow. Sandbox posture unchanged (strict, no-network CSP,
-    postMessage-only source) — Tier-1 pins the transparent body +
-    per-message init.
-- [x] **Paintings-adoption instrumentation** — completed 2026-08-13: one
-  LOCAL log line per paint (`paint <component> agent=<agent>`) at
-  `registry.deliver()`, the choke point every adapter's stream crosses.
-  Local daemon log only, nothing leaves the machine; cheap enough to keep,
-  one `if` to delete if treated as temporary. Purpose: make "does this
-  engine actually reach for the render tools" answerable from logs — the
-  audit found the Codex/Gemini guidance asymmetry (one-shot first-turn
-  prepend vs. Claude's every-request system-prompt append) impossible to
-  evaluate without it.
+- [x] **Fix batch + adoption instrumentation — completed 2026-08-13** (all
+  tiers green). Full bodies → **PLAN-ARCHIVE.md, "Moved 2026-08-14 (post-SA
+  prune — completed bodies)."** Standing decisions: **diagrams follow the app
+  theme** (a diagram is a picture, not a code surface — the pinned-dark
+  convention stays for code/console/diff only); one LOCAL
+  `paint <component> agent=<agent>` log line at `registry.deliver()` makes
+  paintings adoption measurable (nothing leaves the machine).
 - Audit findings deliberately NOT fixed here (recorded, not lost): the two
   hand-kept `TOOL_DESCRIPTIONS` maps (render-tools.ts / render-mcp.ts) have
   drifted in wording with no guard test; no test pins Claude's
@@ -2662,618 +2528,80 @@ first, measurement second, new paintings demand-gated.
   (housekeeping); HBar tooltip parks at `left: 40%`. Each is a candidate
   for a follow-up surfacing-parity step.
 
-## Phase OC — OpenCode adapter (opened 2026-08-13; Kyle-directed)
+## Phase OC — OpenCode adapter (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
 
 **Product call.** Kyle, from a 2026-08-13 market check: OpenCode (~195k
-GitHub stars) is now the dominant open-source terminal agent — the largest
-user population Mirafold doesn't cover — and becomes the fourth adapter.
-(Same check surfaced that Gemini CLI was retired upstream 2026-06-18,
-replaced by the closed-source Antigravity CLI; Gemini-adapter sunset is
-agreed but explicitly deferred — NOT part of this phase.) The feasibility
-spike is **`server/adapters/opencode.spike.md`** (verdict GREEN): the
-event→`WireMsg` table, the `OPENCODE_CONFIG_CONTENT` MCP-injection path,
-the permission reply round-trip, and the provider-keyed credential-policy
-design all live there — the steps below execute that doc, and its two live
-gates come first.
+GitHub stars) is now the dominant open-source terminal agent and becomes the
+fourth adapter. The feasibility spike is **`server/adapters/opencode.spike.md`**
+(verdict GREEN) — its live-probe appendices remain the shape record.
 
-- [x] **Step OC.0 — Live gates + shape capture** — completed 2026-08-13,
-  same day, $0 and credential-free: scratchpad-local `opencode-ai@1.18.18`
-  with HOME jailed; Gate 1 PASSED (`OPENCODE_CONFIG_CONTENT` alone
-  connected the render MCP; tools advertise as `mirafold_render_*`), Gate 2
-  PASSED via a fake OpenAI-compatible provider (ask event is
-  **`permission.asked`** — published SDK types drift — reply `once` ran the
-  tool through to `session.idle`). Streaming is a true delta channel
-  (`message.part.delta`), usage + `modelID` ride each assistant message.
-  Bonuses: 1.18.18 offers no Anthropic/Google OAuth at all, and a fresh
-  install ships the free "OpenCode Zen" provider (needs its own OC.3
-  policy row). One residual folded into OC.3: confirm a stored
-  credential's oauth-vs-api kind is server-readable (needs a real
-  connected credential). Full appendix in the spike doc. — **Goal:** de-risk the
-  two spike gates and lock real shapes before adapter code exists.
-  **Build:** run `opencode serve` (scratchpad-local install is fine; no
-  global mutation) and confirm: (1) `OPENCODE_CONFIG_CONTENT` loads the
-  mirafold render MCP and its tools appear (exact tool-name prefix
-  captured); (2) a permission ask surfaces as `permission.updated` headless
-  and the reply endpoint resolves it; plus capture the provider catalog's
-  auth exposure (oauth-vs-api visible without reading `auth.json`?), the
-  streaming part-update granularity, and usage field names. A $0 provider
-  (Ollama or an existing API key) is needed for gate 2 only. **Done when:**
-  the spike doc's "confirm live" flags are each resolved GREEN/RED with
-  captured payloads appended to the doc.
-- [x] **Step OC.1 — Core adapter + Tier-1** — completed 2026-08-13:
-  `opencode.ts` (session: lazy spawn-with-retry latch, serial queue,
-  first-turn guidance flipped only after prompt acceptance, permission
-  bridge with deny-by-default timeout + external-reply handling +
-  interrupt grace fallback) + `opencode-events.ts` (mapper: delta/snapshot
-  text accrual, tool lifecycle, mirafold `render_*` recognition with
-  honest fallback, todo checklist, per-turn usage summing) +
-  `opencode-client.ts` (raw HTTP+SSE transport — the spike's SDK
-  recommendation REVERSED with the reason recorded there: live shapes
-  beat drifting generated types). 22 Tier-1 tests on captured shapes;
-  full Tier-1 suite 746/746; typecheck green. `AgentName` grew additively
-  (policy row fails closed, agent not in ADAPTER_AGENTS, so nothing is
-  offered before OC.3/OC.4). — **Goal:** an OpenCode session
-  behind the `AgentSession` seam, mock-verified. **Build:**
-  `server/adapters/opencode.ts` — spawn `opencode serve` on a free port
-  with a per-session `OPENCODE_SERVER_PASSWORD`, create the session, prompt
-  via `prompt_async` with the pinned `model`, normalize the SSE stream per
-  the spike table (text/reasoning accrual → deltas, tool parts →
-  `tool_use`/`tool_result` with `capOutput`, `todo.updated` → checklist,
-  `session.idle` → `turn_end`, `session.error` → sourced notice),
-  `interrupt()` → abort, `resumeId` = session id. SDK-vs-raw call finalized
-  at install per the spike. **Files:** `server/adapters/opencode.ts`
-  (+ `.test.ts` with a fake SSE feed), `server/protocol.ts` (`AgentName` +
-  fixtures — additive only). **Done when:** Tier-1 drives the full table
-  through a fake event feed; `yarn typecheck` green.
-- [x] **Step OC.2 — Render MCP + permission bridge** — completed
-  2026-08-13. The Tier-1 half had landed inside OC.1; this step ran the
-  live leg, $0 and credential-free (real `OpenCodeSession` → real spawned
-  engine → fake provider): **a card painted end-to-end** through the real
-  render-mcp stub, and **a permission ask round-tripped live** (ask → bar
-  shape → `once` → bash ran). It caught and fixed two adapter bugs
-  (health-poll wedge on pre-ready connections — per-attempt abort is
-  load-bearing; user-message parts echoing as text_delta — roles now
-  tracked, +1 test) and characterized one upstream engine behavior,
-  documented not gated: a cold server's first model call carries zero
-  tools; the engine self-recovers same-turn (spike appendix has the full
-  probe evidence). Suite 747/747, typecheck green. — **Goal:** generative
-  UI and the permission bar, faithfully. **Build:** inject
-  `renderMcpCommand()` under `MIRAFOLD_MCP` via `OPENCODE_CONFIG_CONTENT`
-  (additive merge; user config untouched); recognize mirafold tool parts by
-  the OC.0-confirmed prefix → `generativeUIMsg` (skip the raw tool block);
-  `permission.updated` → `permission_request`, `resolvePermission` → reply
-  `once`/`reject` (**never `always`** — that writes the user's own approval
-  state), `PERMISSION_TIMEOUT_MS` deny-by-default. **Done when:** Tier-1
-  proves render-call recognition + both permission outcomes + timeout; a
-  live render paints end-to-end.
-- [x] **Step OC.3 — Credential policy + registry wiring** — completed
-  2026-08-13, including the "needs a real credential" residual — resolved
-  with auth.json FIXTURES in the jailed probe home (no real credential
-  needed): the engine's own catalog distinguishes every kind (`source`
-  api/env/config/custom + the `opencode-oauth-dummy-key` OAuth marker), it
-  leaks raw stored secrets (stripped at the transport seam, never past
-  it), and 1.18.18 ignores a stored anthropic OAuth wholesale. Landed:
-  `classifyOpenCodeProvider` matrix in provider-policy.ts (fail-closed:
-  unknown OAuth, Zen-pending-terms, unrecognized shapes all refuse with
-  human copy), session-start enforcement in opencode.ts (pin resolved
-  from OPENCODE_MODEL or the user's config `model`; refusals precede any
-  engine session), shallow hello detection in index.ts (binary +
-  auth.json existence — contents unread), `Backend.provider` from the
-  pin. ChatGPT gray: policy-allowed, session-refused until OC.4 flows
-  classified kind into Backend (relay-gate truth). 8 policy tests + 3
-  session tests; suite 752/752; typecheck green. — **Goal:** the
-  policy matrix applied provider-aware, fail-closed. **Build:**
-  `provider-policy.ts` gains the OpenCode provider classification
-  (anthropic/google oauth → blocked; openai oauth → disclosed gray area;
-  api-key/env → `api-key`; local → `local`; **unclassified oauth →
-  blocked**), detection per the OC.0-confirmed path (server catalog
-  preferred; `auth.json` only with explicit consent); model pinned
-  per-prompt so the session provider is the one Mirafold set; registry:
-  `createSession` case, `agentHasCredentials("opencode")`, `Backend.provider`
-  carries the pick. Relay gate unchanged (already refuses `subscription`).
-  **Done when:** Tier-1 covers every matrix row incl. the fail-closed
-  default; blocked/gray states render their correct copy.
-- [x] **Step OC.4 — In-session fidelity surface** — completed 2026-08-13
-  (the original OC.4 split in two; the onboarding half is OC.4b below):
-  `opencode-commands.ts` on the codex picker pattern — `/model` paints the
-  cross-provider catalog (policy-filtered: only providers a pick can
-  actually run; a typed blocked pick refuses with its reason and keeps the
-  pin), `/agent` paints user-facing primaries only (`hidden` internals and
-  subagents excluded; pick rides every subsequent prompt), the engine's
-  own command catalog routes `/name` inputs to `POST /session/:id/command`
-  (the engine's real dispatcher, with pin + agent) and feeds
-  `emitPromptOptions` behind our two re-skins (engine rows badged
-  `source: "opencode"`). 6 new Tier-1 tests; suite 757/757; typecheck
-  green. — **Goal:** what an OpenCode user expects in-session.
-- [x] **Step OC.4b — Offerable + Zen terms citation** — completed
-  2026-08-13 (the kind-into-Backend half split to OC.4c; live onboarding
-  proof folds into OC.5): `opencode` joined ADAPTER_AGENTS +
-  `defaultAgent`; one shallow `backendOptions` api-key row (existence
-  probe; the provider-resolved truth stays enforced at session start);
-  real agents-meta copy (connect hint names install + `opencode auth
-  login` + OPENCODE_MODEL and says plainly that subscriptions and Zen
-  aren't usable yet), `backendLabel` "API key (via opencode)", PromptBox
-  source badge. **Zen terms read and cited** in provider-policy.ts
-  (2026-08-13: no third-party-harness prohibition — the server API is
-  opencode's own documented programmatic surface; "own internal use"
-  clause; free-period training-data caveat): the disclosed-uncertainty
-  rule's exact shape, but opening a NEW provider under it is Kyle's call
-  (codex precedent), so the row stays CLOSED pending his decision — if
-  opened, local-only + caveat shown. Also fixed en route: the fourth
-  agent row overflowed the onboarding squeeze ramp by 14px — the
-  squeeze intercept moved 66→70 and the per-row floor metrics shaved
-  (full-chrome values untouched); the squeeze e2e passes with four READY
-  rows. Verification status, honestly: Tier-1 757/757 + Tier-2 152/152
-  green; e2e ran 96/97 before the CSS fix (the squeeze test its only
-  failure, after the hint-count assertion gained the fourth card) and
-  the fixed squeeze test passes in isolation — but two attempts at the
-  full post-fix e2e run were stopped externally mid-run (6/6 ok at each
-  stop), so ONE clean full-suite pass is still owed; folded into OC.5's
-  tier sweep.
-- [x] **Step OC.4c — Classified kind into Backend + ZEN OPENED** —
-  completed 2026-08-13, same day Kyle said "open Zen" (the decision the
-  OC.4b citation was waiting on). Built exactly per the design below:
-  `onBackendKind` seam + registry adoption at `activate()` (truthful kind
-  checkpointed), `kindPending` refusing remote actions pre-verification,
-  and the three relay-gate sites (attach, cockpit acts, uploads) unified
-  on one `relayGateRefusal` verdict in provider-policy.ts. The ChatGPT
-  gray now RUNS locally with its uncertainty disclosure (once per
-  provider, Mirafold-composed, no badge). **Zen**: new `gateway`
-  CredentialKind (additive on every wire union) — allowed locally for
-  opencode with the uncertainty + training-data disclosure, NEVER
-  relay-eligible (the allow-list refuses it by design); fresh
-  binary-only installs now detect live out of the box, and the /model
-  picker offers Zen rows. 761/761 + 152/152 green; the full-e2e sweep
-  remains owed to OC.5 (two prior runs externally stopped). — original
-  goal + design: **Goal:** the gray path runs under its TRUE kind. **Build:**
-  an optional `AgentSession.onBackendKind` seam (like `onResumeId`): the
-  OpenCode session publishes the OC.3-classified kind + provider at start;
-  the registry updates its `Backend` so the relay gate judges truth.
-  **The race that shapes the design:** hello-kind is optimistic
-  ("api-key"), so a relay viewport's FIRST prompt could slip the gate
-  before classification lands — closed by a `kindVerified` flag on
-  opencode Backends (server-side only): relay prompts refuse with an
-  honest "still verifying" message until the session publishes, local
-  viewports unaffected. Then the OC.3 session-level gray refusal lifts,
-  replaced by a Mirafold-composed disclosure notice at session start
-  (uncertainty stated, never permission — the codex CONNECT_HINT contract,
-  session-time edition). **Done when:** Tier-1 covers publish→registry
-  update, the pre-verification relay refusal, and the gray disclosure;
-  the relay itest proves a subscription-classified session never runs a
-  turn from a relay viewport.
-- [x] **Step OC.5 — Tier sweep + live end-to-end** — completed 2026-08-13
-  (one residual below): **`opencode-live.ltest.ts`** joins Tier 4 on the
-  codex pattern (real binary, never a hosted model; the scripted
-  OpenAI-compatible provider from the OC.2 probe; HOME/XDG jailed via a
-  new transport `env` seam so a real engine run never touches the
-  developer's own opencode state; skips cleanly when opencode isn't
-  installed). One 17s test drives the WHOLE loop through shipped code:
-  render through the real MCP stub, headless permission ask answered via
-  the bridge, usage, kind publish (config→local), and **resume across a
-  full engine restart**. All tiers green same-sitting: Tier-1 761/761,
-  Tier-2 152/152, Tier-3 97/97 (the sweep owed since OC.4b — paid),
-  Tier-4 1/1 live + verified clean skip. **Residual CONFIRMED by Kyle
-  2026-08-13**: real global install (`npm i -g opencode-ai` — his npm's
-  install-scripts blocking required the manual postinstall, the exact
-  failure the transport's stderr surfacing named; the session's
-  start-latch retry then worked as designed, no restarts) and a live
-  browser session on Zen: "heyyyy it works". Phase OC complete.
-  README/ADAPTERS.md refresh rides the wrapup.
+- [x] **OC.0–OC.5 — ALL COMPLETE 2026-08-13**, live-verified same day
+  (Kyle: "heyyyy it works"). Full step bodies → **PLAN-ARCHIVE.md, "Moved
+  2026-08-14 (post-SA prune — completed bodies)."** Standing outcomes that
+  bind future work:
+  - **Raw HTTP+SSE transport, no SDK** (decision recorded in the spike doc:
+    live shapes beat drifting generated types).
+  - **Permission replies never send `always`** — that would persist approval
+    state into the user's own OpenCode config (docs/ADAPTERS.md matrix).
+  - **Zen OPENED by Kyle 2026-08-13** under the disclosed-uncertainty rule:
+    `gateway` CredentialKind, local-only, NEVER relay-eligible, uncertainty +
+    training-data disclosure shown (canonical row in provider-policy.ts).
+  - The ChatGPT gray runs locally under its TRUE classified kind
+    (`onBackendKind` → registry; `kindPending` refuses remote actions until
+    verified).
 
 ## Gemini sunset (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
 
-**Product call.** From the 2026-08-13 market check: Google retired Gemini
-CLI upstream on 2026-06-18 (closed-source Antigravity replaced it; the
-dated citation lives in provider-policy.ts's R.6 note). Kyle's calls, in
-order: sunset rather than migrate (same day, morning), hold while other
-work was in flight, then "do the gemini sunset" (same day, after Phase OC
-merged). Shape: **gentle** — the API-key path still functions under the
-Gemini API ToS, so nothing is removed or hidden; the adapter is deprecated
-honestly. Removal is parked in POST-RELEASE.md, gated on evidence of
-actual breakage, never on a calendar.
-
-- [x] **Deprecation surface** — completed 2026-08-13: additive
-  `AgentInfo.deprecated` (daemon-composed reason; the picker renders it as
-  a suffix on the existing status line — no new element, the squeeze
-  ramp's height budget holds), connect-hint copy updated with the dated
-  retirement, a once-per-session dated notice in the Gemini adapter
-  (Mirafold-composed, lands before the first turn completes), the
-  provider-policy row annotated (policy itself unchanged), and the
-  POST-RELEASE removal entry with its evidence gate. Tier-1 tests: the
-  notice rides once and unbadged; `deprecated` rides the hello for gemini
-  only.
+- [x] **Gentle deprecation shipped 2026-08-13** (Google retired Gemini CLI
+  upstream 2026-06-18 — dated citation in provider-policy.ts; Kyle's call:
+  sunset, not migrate; nothing removed — the API-key path still works).
+  Additive `AgentInfo.deprecated`, dated picker/notice copy, REMOVAL parked
+  in POST-RELEASE.md gated on evidence of breakage, never a calendar. Full
+  body → **PLAN-ARCHIVE.md, "Moved 2026-08-14 (post-SA prune — completed
+  bodies)."**
 
 ## Phase RC — Remote CREATE of OpenCode sessions (opened + ✅ COMPLETE 2026-08-13; Kyle-directed)
 
-**Why.** OC.4c's fail-closed design verifies an OpenCode session's credential
-kind at its first turn: until the engine classifies the pinned provider, the
-registry entry is `kindPending` and the relay gate refuses every remote
-action. Consequence (recorded in POST-RELEASE.md 2026-08-13, promoted here
-the same day at Kyle's direction): a remote viewport can ATTACH to an
-OpenCode session only after a first local turn — it can never CREATE one.
-Supporting remote creation means classifying BEFORE admitting the creator:
-spawn the engine, read the provider catalog, judge the pin, and only then
-attach the remote viewport. The gate itself does not change; only WHEN the
-truth arrives does.
-
-- [x] **RC.1 — the adapter seam.** — completed 2026-08-13. `AgentSession` gains optional
-  `verifyBackendKind?(): Promise<void>`: resolve once the truthful kind has
-  been published via `onBackendKind`, reject with the honest reason when it
-  cannot be (no binary, no pin, provider not connected, policy refusal).
-  OpenCode implements it as `ensureStarted()` — the full lazy-start path
-  (engine + policy + engine session), whose failure already resets the outer
-  latch so a later local prompt retries. No other adapter implements it:
-  their hello-time kind is already truthful.
-- [x] **RC.2 — the create path awaits truth.** — completed 2026-08-13
-  (`attachOrReapClassified`; timeout env `VERIFY_KIND_TIMEOUT_MS`, 30s
-  default). In `connection.ts`, a REMOTE
-  create (and the attach-path fallback create) of an entry that is
-  `kindPending` with a `verifyBackendKind` seam awaits classification —
-  bounded (30s) — BEFORE `attachTo` judges the relay gate. Local creates are
-  untouched: still synchronous, still lazy. On success the existing gate
-  judges the now-truthful kind (an ineligible provider still refuses with
-  the existing honest copy). On failure/timeout: the error goes to the
-  viewport and the minted session is REAPED (`registry.end`) — the
-  no-viewport leak rule from the 2026-07-29 bughunt applies unchanged. The
-  async detour catches its own errors (index.ts has no try/catch around
-  `handleMessage`).
-- [x] **RC.3 — the races.** — completed 2026-08-13 (d landed as a comment
-  correction only: the user-facing copy was already honest for the attach
-  path, and remote creates no longer surface it). (a) Viewport disconnects mid-classify → on
-  settle, a closed connection with a viewport-less entry reaps it. (b) A
-  second create/attach on the same connection while one classification is in
-  flight → refused honestly ("still verifying the previous create"); one
-  pending create per connection. (c) Entry torn down mid-classify → the
-  settle path checks `entries.get(id) === entry` before acting, like every
-  onBackendKind consumer. (d) `relayGateRefusal`'s `kindPending` copy stays
-  honest for BOTH paths now that remote creates verify inline: the
-  "run its first turn from its own machine" sentence describes only the
-  attach-to-existing case.
-- [x] **RC.4 — tests** — completed 2026-08-13: 7 connection-grain tests in
-  `server/sessions/remote-create.test.ts` (own process so the verify
-  timeout pins via env before module load; a registry session-factory test
-  seam injects the fake classifying session) + 2 adapter-grain in
-  `opencode.test.ts` (`verifyBackendKind` resolves after publish / rejects
-  honestly and stays retryable). Tiers 803/152/97 green. Original scope
-  (Tier 2 grain, `makeTransport` seam; no real engine):
-  Remote create allowed (kind publishes api-key → viewport attaches); remote
-  create policy-refused (subscription pin → refusal + entry reaped, no
-  MAX_SESSIONS leak); classify failure (engine start throws → honest error +
-  reap); timeout (kind never publishes → bounded refusal + reap); disconnect
-  mid-classify (no leak); local create unaffected (no await, still lazy).
-  The existing remote-attach regressions stay green.
-
-**Done when.** A relay viewport can create a fresh OpenCode session pinned to
-an allowed provider and drive it immediately; a subscription/Zen pin is
-refused at create with the honest reason and leaks nothing; all tiers green.
+- [x] **RC.1–RC.4 — ALL COMPLETE 2026-08-13** (classify-before-create:
+  `verifyBackendKind` seam + `attachOrReapClassified`, bounded 30s, races
+  closed, 9 tests; a relay viewport can now CREATE an OpenCode session, not
+  just attach). Full bodies → **PLAN-ARCHIVE.md, "Moved 2026-08-14 (post-SA
+  prune — completed bodies)."** The seam is documented in docs/ADAPTERS.md.
 
 ## Phase SA — Subagent view (opened + ✅ COMPLETE 2026-08-14; Kyle-directed; plan signed off by Kyle, executed same day)
 
-**Why.** When a session's agent spawns its own subagents, render them as a
-live, legible structure — calm by default, fully expandable — instead of
-dropping their narration and scattering their tool rows. Today the Claude
-Code adapter forwards a subagent's tool calls (nested, T2.4) but drops its
-prose: the SDK never forwards subagent token-level deltas (main-session-only
-stream, confirmed vs docs 2026-08-14), but subagent COMPLETE assistant
-messages — text and thinking blocks tagged `parent_tool_use_id` — do arrive,
-and the adapter skips them (`claude-code.ts` `!parentId` gate). The data is
-in the stream at message grain; Mirafold chooses not to render it — in
-tension with never-hide, sharpest when a stuck subagent explains itself and
-the user never sees it. Framing sharpened by research: the TERMINAL shows
-even less (a panel row — name, elapsed, tokens; no prose, no per-agent tool
-activity — a gap third-party tools visibly fill), so this is not fixing a
-hiding-vs-terminal bug; it is Mirafold being MORE faithful than the terminal
-to what the agent is actually doing.
-A live per-subagent card is also the product thesis made vivid: parallel
-agents shown side by side, which one interleaved terminal column physically
-cannot do. Automatic — the user prompts normally; when the agent fans out,
-this rendering just happens.
+- [x] **SA.0–SA.4 + post-phase refactor, two bughunt rounds, security audit,
+  and test-audit — ALL COMPLETE 2026-08-14**, full bodies → **PLAN-ARCHIVE.md,
+  "Moved 2026-08-14 (post-SA prune — completed bodies)."** Shipped: live
+  **subagent decks** (calm summary → expandable calls + narration), the
+  parented-delta narration lane (opaque `parentId` on deltas + permission
+  asks), and the OpenCode child-session mapping proving the lane
+  agent-neutral — plus an OpenCode defect fix (child permission asks used to
+  drop and hang). PR #47. The lane's standing rules for future adapters live
+  in **docs/ADAPTERS.md §3**; the rendering/trust posture in README §6.3 and
+  SECURITY.md; the decided vocabulary in GLOSSARY (*subagent deck*).
 
-**The hard line.** Mirafold DISPLAYS the agent's own coordination — it
-renders what the engine already decided to do. It never spawns or directs
-subagents itself (the homegrown-orchestrator trap, a non-negotiable).
+**The hard line (standing):** Mirafold DISPLAYS the agent's own coordination —
+it never spawns or directs subagents itself (the homegrown-orchestrator trap).
 *Mirafold shows coordination; it never performs it.*
 
-**Decided 2026-08-14 (Kyle signed off on all of these):**
-
-1. **One card per subagent; no invented group container.** Each spawn gets
-   its own live card anchored where its Task row is today. No batch notion,
-   no synthesized group title (shell-voice rule: Mirafold never composes a
-   sentence about the agent's intent). A neutral counted summary line
-   ("3 agents · 2 running") is later polish, not structure.
-2. **Subagent traffic rides the replay ring, per-subagent byte-capped.**
-   A late-attaching viewport sees what a present one saw — dropping it from
-   replay would rebuild the hiding problem for exactly the away user. Cap
-   in the flood-cap spirit; elision marked explicitly (`truncatedBytes`
-   precedent), never silent.
-3. **Wire shape: reuse `text_delta`/`thinking_delta` with optional
-   `parentId`** — the exact additive precedent `tool_use`/`tool_result`
-   set; old clients degrade to today's behavior. No new delta type.
-   **`parentId` is an opaque adapter-chosen handle**: for Claude Code it
-   happens to be the Task tool_use id, but the protocol never promises
-   that; shared code only groups by it, never parses or dereferences it.
-4. **A card must be able to exist without a tool row to anchor to.**
-   Tool-call-spawning engines anchor on (become) the Task row; an engine
-   without one gets a way to announce the spawn (synthetic tool_use-shaped
-   record vs. small additive spawn message — build-time call, requirement
-   named now so the card component is not hard-wired to Task rows).
-5. **Render depth 1 — what the stream surfaces — stated assumption.**
-   (Corrected by research 2026-08-14: engines DO nest — Claude Code to
-   depth 3 by default, but grandchild traffic never reaches the parent
-   stream, only the top-level child's summary returns; OpenCode denies
-   `task` to children by default, though user config can allow nesting,
-   unbounded.) The rule: cards render what the engine surfaces to the
-   session; engine-hidden grandchildren are the ENGINE's choice, not ours.
-   OpenCode parentage resolves transitively (`Session.parentID` is a plain
-   edge), so a configured nesting maps to the nearest stream-visible
-   ancestor's card — documented degradation, not breakage.
-6. **Agent-neutral, proven: OpenCode mapping is IN scope as the final
-   step.** Neutrality is only real once a second adapter maps the lane.
-   Codex is OUT of build scope, with the posture corrected by research
-   2026-08-14: Codex NOW HAS first-class multi-agent (collab tools,
-   default-on since ~2026-02, official docs) — children are full sibling
-   THREADS (own thread id + event stream, `parentThreadId` edges); the
-   parent stream carries spawn/status items (`collabAgentToolCall`,
-   `subAgentActivity`) but never child inner activity, which needs
-   per-thread subscriptions via the app-server protocol — i.e. gated on
-   F.5, and the TS SDK we drive types none of the collab items yet.
-   A Codex SUMMARY-card mapping may be reachable pre-F.5 from untyped
-   collab items; deliberately deferred, revisit at F.5. (Vocabulary trap
-   confirmed: Codex `task_started`/`task_complete` = the whole TURN.)
-   Gemini is sunset.
-7. **Trusted shell:** the card is Mirafold chrome derived from the stream —
-   all subagent prose renders as inert plain text (fleet activity-line
-   precedent), never markdown, never agent-painted HTML.
-8. **Phase shape: mock-first, three beats.** (a) Mock parallel-subagent
-   scenario + summary cards built ENTIRELY from data already on the wire —
-   spawn/finish/tool rows/elapsed/current action all derive from existing
-   `tool_use`/`tool_result` + parentId; zero protocol change; visible win
-   alone. (b) Narration forwarding + the expanded view. (c) The OpenCode
-   mapping. Expanded-view interaction design (the calm/expand balance) is
-   deliberately decided at build time with the mock running.
-
-**Research pass — DONE 2026-08-14 (three agents + local reads). Load-bearing
-findings, beyond the corrections folded into the decisions above:**
-
-- **Claude Code (SDK pin 0.3.201):** subagent narration arrives at MESSAGE
-  grain only (complete assistant messages with `parent_tool_use_id`; deltas
-  are main-session-only per docs). To verify empirically in SA.0: that
-  parent-tagged messages arrive LIVE during the child's run (T2.4's ticking
-  nested rows suggest yes; one doc reading suggested end-of-run) — and that
-  subagent permission asks already route through the parent `canUseTool`.
-  Terminal shows a subagent panel row only (name/elapsed/tokens). Default
-  concurrent-subagent cap 20 — cards must stack legibly at that count.
-- **OpenCode (live OpenAPI capture + engine binary, 1.18.18; NEVER yet
-  exercised live — SA.0 owes the probe):** child sessions ride the SAME
-  global `/event` stream we already consume, tagged with their own
-  `sessionID`; our `isOurs` filter (`opencode.ts:170`, applied across
-  `opencode-events.ts`) drops them whole, per design comment and a pinned
-  test. Spawn = the `task` TOOL part on the parent + `session.created` with
-  `Session.parentID`; the JOIN key parent-task-part → child is
-  `state.metadata.sessionId` (lowercase-d casing, engine inconsistency; the
-  session event alone recovers the parent SESSION, not the Task row). The
-  `subtask` command path converges on the same task tool part — one lane
-  rule covers both. Child gets `todowrite` denied by default — no checklist
-  clobber hazard. **DEFECT FOUND: child-session `permission.asked` events
-  are dropped today — a subagent hitting a permission gate hangs, no UI, no
-  deny timer (`opencode.ts:544` timer only starts for accepted asks).**
-  Reply endpoint for the fix: `POST /permission/{requestID}/reply` (takes
-  only the request id — session-agnostic; our current per-session reply
-  endpoint is marked deprecated in the live spec). Also: child
-  `session.idle` must not end the parent's turn once the lane opens; spike
-  doc's "subtask/agent parts" subagent claim is incomplete — correct it.
-- **Local (registry.ts):** replay ring already double-capped (4000 msgs /
-  32 MB, oldest-first) — riding it is memory-safe; the per-subagent
-  narration cap therefore lives at the ADAPTER (also bounds relay bytes);
-  sizing precedent `TOOL_OUTPUT_CAP_BYTES` 64 KB. **The 33 ms delta
-  coalescer merges on `pending.type === msg.type` only (`registry.ts:589`)
-  — once deltas carry `parentId` the merge key MUST include it**, or parent
-  and child prose concatenate into one message.
-
-**Steps** *(each single-pass; implementation gated on Kyle's explicit
-signoff of the reported plan)*:
-
-- [x] **SA.0 — Live probes + record the truth.** — completed 2026-08-14,
-  both probes credential-free/zero-spend. **OpenCode** (real engine 1.18.18,
-  OC.5-style scripted provider, raw global-stream capture): parent `task`
-  tool part (`pending`) arrives ONE event before child `session.created`;
-  `running` metadata carries the join key
-  (`state.metadata.sessionId`/`parentSessionId`, lowercase d, + `model`;
-  `completed` adds `truncated`); the child `Session` itself carries `agent`,
-  a title from the description, and a ruleset showing `task` denied
-  (depth-1 default confirmed live). Child text/tool/step parts AND
-  token-grain `message.part.delta`s ride the global stream tagged with the
-  child id. Child `permission.asked` arrived (child `sessionID`,
-  `patterns`, `tool.callID`); **the deprecated per-session reply endpoint
-  accepted a reply addressed with the ROOT session id — 200, child
-  unblocked — so it does NOT validate ownership (1.18.18)**; SA.3 still
-  moves to `/permission/{requestID}/reply` (modern, session-agnostic).
-  Child `session.idle` fired BEFORE the parent task part completed and well
-  before parent idle — the parent-turn guard is real. Curated capture:
-  `server/testing/opencode-subagent-fixture.ts`. **Claude Code** (real
-  bundled CLI via SDK 0.3.201, scripted Anthropic endpoint via
-  `ANTHROPIC_BASE_URL`, STREAMING input mirroring the adapter):
-  (a) parent-tagged assistant messages arrive LIVE mid-child-run (child's
-  Bash tool_use yielded before the fake server even served the child's next
-  request), zero parent-tagged `stream_event`s — narration is message-grain,
-  confirmed empirically; (b) **a subagent's gated tool call DOES fire the
-  parent query's `canUseTool`** (proved with a parent-Bash control in the
-  same run) — the existing permission bar already covers subagent tools —
-  but the callback carries NO subagent identifier (extras =
-  suggestions/blockedPath/displayName only), so CC asks stay UNATTRIBUTED
-  on cards this phase, faithful to the terminal. Two design-relevant
-  extras: the spawn tool in 0.3.201 is named **`Agent`** (not `Task`) — the
-  card anchor must key on "the tool_use other messages reference as
-  `parentId`", name-agnostic; and bare `echo` never prompted (the CLI's own
-  safe-command auto-approval — faithful, not a bug). Spike doc's subagent
-  paragraph corrected. Probe scripts: session scratchpad `sa0/`
-  (`probe.mjs`, `cc-probe2.mjs`); recipes summarized above are sufficient
-  to re-derive them.
-- [x] **SA.1 — Mock scenario + summary cards (zero protocol change).** —
-  completed 2026-08-14. `playSubagent` is now a three-spawn parallel
-  fan-out (distinct paces; the second-spawned finishes first). Client:
-  `SubagentCard` in RenderZone (supersedes the T2.4 SubagentGroup) — any
-  tool_use other records reference as `parentId` becomes the card,
-  name-agnostic; calm summary = agent type + spawn description (verbatim,
-  never composed), state dot (pulse honors reduced-motion), tool count,
-  elapsed ticking ONLY while running (client-side stamp — honest under
-  replay, where a settled card shows no stale duration), current action =
-  newest unanswered child, result first-line once done; expandable to the
-  existing nested ToolCallList. Derivation is pure
-  (`web/src/subagent-card.ts`, 7 Tier-1 tests). Cards are fold
-  BOUNDARIES for the settled-activity compaction and their children are
-  invisible to it (omitted, not boundaries — parent-level runs don't
-  split on child traffic). Tier-2 itest updated to the fan-out contract
-  (children tag their own spawn; settle order ≠ spawn order). E2e (app):
-  three cards live at once, independent tick, out-of-order settle, expand/
-  collapse, axe-clean, phone-width stack with no side scroll. Tiers
-  810/152/57(app) green.
-- [x] **SA.2 — The narration lane (wire + Claude Code + expand).** —
-  completed 2026-08-14. Protocol: optional `parentId` on
-  `text_delta`/`thinking_delta`, documented opaque (grouped, never
-  parsed); checkpoint-store strict schemas widened to match (they would
-  have REJECTED the field — caught in-pass). Merge keys gained
-  `parentId` in BOTH coalescers (registry window + client delta-queue) so
-  parallel prose never concatenates across agents. Claude Code adapter:
-  parent-tagged complete-message text/thinking forward as message-grain
-  parented deltas through `SubagentProseBudget` (shared in
-  `adapters/types.ts` for SA.3; `SUBAGENT_TEXT_CAP_BYTES` 64 KB default,
-  one explicit elision marker, byte-safe slice, per-subagent ledger
-  cleared per turn); the F.1 buffered-text dedup rule untouched for the
-  parent; stale stream_event comment corrected. Client: `subtext`
-  entries route to their card BEFORE fold/close logic (child prose can't
-  fold parent thinking), extend-in-place per (parent|variant), closed by
-  that subagent's next tool row — the expansion (`SubagentActivity`)
-  interleaves calls + narration + dim italic reasoning in true stream
-  order, inert plain text (e2e asserts no markdown elements render);
-  Shell keeps subagent prose out of the turn-end announcement and the
-  activity label. Tests: adapter forwarding + wire order, budget
-  semantics (cap marker, per-agent ledgers, U+FFFD safety, reset),
-  registry + delta-queue no-cross-parent merges, e2e narration in the
-  expansion. Tiers 814/152/57(app) green.
-- [x] **SA.3 — The OpenCode mapping (neutrality proven).** — completed
-  2026-08-14. The mapper gained `laneOf`: "root" | spawn-part-id |
-  undefined (unroutable → skipped whole, the pre-lane behavior). Edges
-  from the root task part's `state.metadata` ({sessionId,
-  parentSessionId} — captured shape-wise, not by tool name, so the lane
-  stays name-agnostic) + child `session.created`, resolved transitively —
-  a configured nested grandchild lands on the nearest stream-visible
-  card (tested). Child text/reasoning → parented deltas through the
-  shared `SubagentProseBudget`; child tool parts → parented
-  `tool_use`/`tool_result` (roles tracked for child messages so the task
-  prompt's echo never replays as narration); a child's RENDER call gets
-  the honest tool record, never a painting (cards are calls + prose);
-  child step/status/idle/error never touch root turn state or the
-  activity line. **Defect fixed:** child `permission.asked` surfaces on
-  the shell bar with additive `parentId` on `permission_request`
-  (protocol + store schema + PermBar dim "subagent" chip + announcer
-  suffix), deny timer armed, replies via the modern session-agnostic
-  `POST /permission/{requestID}/reply` (the deprecated per-session
-  endpoint — which the SA.0 probe showed never validated ownership —
-  dropped everywhere). Tests: the SA.0 captured run replayed whole
-  through the shipped session (spawn anchor, parented calls/prose,
-  attributed ask, single turn_end), grandchild transitivity, no-painting
-  rule, unroutable fallback; Tier-4 live extends with a REAL engine
-  fan-out (attributed ask answered through the production bridge, child
-  bash + narration on the lane, parent reply top-level) — green.
-  Tiers 817/152/57(app)/1(live) green.
-- [x] **SA.4 — Docs + glossary.** — completed 2026-08-14. The glossary
-  already NAMED this surface — a *deck* is shell chrome and "card" is its
-  "(was)" column — so SA.4 opened with a vocabulary-compliance rename of
-  SA.1–SA.3's code: `SubagentCard`→`SubagentDeck`,
-  `subagent-card.ts`→`subagent-deck.ts`, CSS `.subagent-card*`→
-  `.subagent-deck*`, comments and e2e selectors converted; all tiers
-  re-verified green after. GLOSSARY gains a dedicated *subagent deck* row
-  (master + all 4 copies, diff-clean; relay/site/desktop copies committed
-  in their repos — docs-only, UNPUSHED, awaiting Kyle). README: the
-  Claude Code subagent-traffic paragraph rewritten to the SA truth
-  (message-grain prose, budget cap, the deck, name-agnostic anchor,
-  canUseTool coverage), `subtext` in the RenderZone entry list, mock
-  hook description updated. ADAPTERS.md: the capability-matrix subagent
-  row rewritten per adapter (incl. the recorded Codex F.5-deferred
-  posture) + a §3 "subagent lane" contract block for the next adapter
-  author (opaque handle, relationship anchor, budget, inert prose,
-  no-painting, ask attribution, depth-1 render rule).
-  Tiers 817/152/57(app) green.
-
-**Post-phase test-audit (2026-08-14, same day; scope: the phase's tests).**
-Ten pins mutation-verified (six fresh mutations — summary recency, budget
-marker, unparented forwarding, lane disable [tripped four tests at once],
-both coalescer merge keys — plus the four bughunt pre-fix proofs); no
-theater and no wrong-target tests found; the e2e label sampling and the
-store-durability poll reviewed as timing-robust. TWO gaps found and
-filled, each mutation-proven: the store's every-frame round-trip test
-predated the lane (a reverted schema widening would have silently stripped
-deck replays — parented text/thinking/ask frames added), and the Tier-2
-fan-out itest never asserted the narration lane over the REAL daemon
-broadcast (parented prose presence + spawn integrity + no cross-parent
-merge added; only e2e covered that path before). One gap named and
-deliberately not filled: the deck component's replayed→no-elapsed wiring
-is pinned at the pure-function level only — the component line is
-one-line wiring whose e2e cost outweighs it; noted here so it's a
-decision, not an oversight.
-
-**Post-phase security audit (2026-08-14, same day; scope: the SA delta +
-its trust boundaries).** ZERO exploitable findings. ONE hardening landed
-(flood-cap parity, pinned): the shared `SubagentProseBudget` had no cap on
-DISTINCT parent ids, so a hostile/looping engine fabricating unlimited
-`parent_tool_use_id` values could grow the ledger without bound within a
-turn — now capped (`MAX_SUBAGENTS_PER_TURN` 2000; past it a NEW subagent's
-prose drops silently, the same degradation as every other per-turn cap;
-OpenCode's parent ids were already bounded by the spawn-part cap, so this
-mainly guards the Claude lane). Verified-clean facts worth keeping: a
-Claude Code SUBAGENT cannot reach the render MCP tools — proved through
-the REAL adapter + shipped in-process MCP server against a scripted
-endpoint (the SDK withholds MCP tools from subagents: 31 child tools, no
-`mcp__mirafold*`), so the no-painting rule holds on BOTH engines (OpenCode
-by our lane code, Claude by the engine itself); subagent prose renders
-inert everywhere (no markdown, no HTML sinks); the deck and the permission
-chip are shell chrome with engine text confined to inert slots; the store's
-`idSchema` bounds a tampered checkpoint's `parentId` at 1 KB; the
-committed fixture carries no secret-shaped strings; alternating parent ids
-cannot defeat the coalescers into unbounded ring growth (count + byte caps
-hold); `laneOf` is cycle-safe (hop cap).
-
-**Post-phase bughunt round 2 (2026-08-14, same day).** Two more found +
-fixed, pins proven failing pre-fix: (1) `zone_reset` cleared every
-streaming ref EXCEPT the new subtext map — a same-page full-replay
-(reconnect) with an open subagent prose run swallowed the replayed
-narration into entry ids that no longer existed (deck came back
-empty-handed); pinned by a resilience e2e that kills+restarts the daemon
-inside the slow-subagent hook's window (new mock hook `delegate slowly`),
-with a store-durability poll so the 250ms checkpoint debounce can't race
-the kill. (2) Child tool traffic steered the ROOT activity line (both
-`tool_use` setting the label and `tool_result` clearing it), contradicting
-the SA.3 design statement the server side already honored — the label now
-ignores parented tool traffic in both directions; pinned by multi-sampled
-label assertions in the SA.1 e2e. Diagnosis bonus, recorded: interior
-frames reach the checkpoint store on a 250ms debounce, so a daemon killed
-inside it loses the un-flushed tail — pre-existing, honest (the turn
-replays as interrupted), not a defect.
-
-**Post-phase bughunt round 1 (2026-08-14, same day).** Two found + fixed with
-pinned regressions (each proven failing pre-fix): a REPLAYED running deck
-ticked a false elapsed (stamp = attach moment, not spawn — now shows no
-elapsed unless the record arrived live), and the OpenCode lane's
-session-edge maps cleared per turn, making a `background: true` child
-unroutable after its spawning turn — its permission ask dropped (the SA.0
-hang, resurrected in a narrower window); the edge maps are now
-session-lifetime (insert-time caps still bound growth). **One deferred,
-LATENT:** a background child streaming ONE text part ACROSS a turn
-boundary would re-emit that part's full text (the per-turn part tracker
-resets, so the next snapshot's suffix restarts at 0) — duplicated prose in
-its deck. Deferred because reachability is unconfirmed (requires the
-engine to spawn background children in stock config, itself unverified)
-AND a proper fix reopens the 2026-08-13 flood-cap design (the part
-trackers are per-turn precisely to stay bounded); revisit if background
-children are ever observed live.
-
-**Done when (phase).** Prompting the mock or a real engine into a parallel
-fan-out yields live per-subagent cards — calm summary, expandable to full
-narration — on desktop and phone, replayed faithfully to a late-attaching
-viewport within caps; Claude Code and OpenCode both map the lane; an
-OpenCode subagent's permission ask no longer hangs; nothing anywhere spawns
-or directs a subagent from Mirafold's side; all tiers green.
+**Deferred findings (recorded here so they're not lost):**
+- **LATENT (bughunt 2026-08-14):** a `background: true` OpenCode child
+  streaming ONE text part ACROSS a turn boundary would re-emit that part's
+  full text (the per-turn part tracker resets, so the snapshot's suffix
+  restarts at 0) — duplicated prose in its deck. Deferred because
+  reachability is unconfirmed (requires the engine to spawn background
+  children in stock config, itself unverified) AND a proper fix reopens the
+  2026-08-13 flood-cap design (the part trackers are per-turn precisely to
+  stay bounded); revisit if background children are ever observed live.
+- **Test-audit deliberate skip (2026-08-14):** the deck component's
+  replayed→no-elapsed wiring is pinned at the pure-function level only
+  (`deckElapsedSeconds`); the one-line component wiring has no e2e of its
+  own — a decision, not an oversight.
+- **Codex subagents:** the engine HAS first-class multi-agent (collab,
+  default-on since ~2026-02) but child inner activity needs app-server
+  per-thread subscriptions — mapping deferred to **Phase F Step F.5**; the
+  researched posture is recorded in docs/ADAPTERS.md's capability matrix.
 
 ## Phase PN — Panes (file views beside the transcript)
 

--- a/PLAN.md
+++ b/PLAN.md
@@ -2947,7 +2947,7 @@ truth arrives does.
 an allowed provider and drive it immediately; a subscription/Zen pin is
 refused at create with the honest reason and leaks nothing; all tiers green.
 
-## Phase SA — Subagent view (opened 2026-08-14; Kyle-directed; steps pending the research pass + Kyle's signoff)
+## Phase SA — Subagent view (opened + ✅ COMPLETE 2026-08-14; Kyle-directed; plan signed off by Kyle, executed same day)
 
 **Why.** When a session's agent spawns its own subagents, render them as a
 live, legible structure — calm by default, fully expandable — instead of
@@ -3177,11 +3177,24 @@ signoff of the reported plan)*:
   fan-out (attributed ask answered through the production bridge, child
   bash + narration on the lane, parent reply top-level) — green.
   Tiers 817/152/57(app)/1(live) green.
-- [ ] **SA.4 — Docs + glossary.** README (the card in the surfaces
-  section), ADAPTERS.md (the subagent lane: opaque `parentId`, the
-  per-adapter mapping table incl. the recorded Codex posture), GLOSSARY
-  term for the card (master + 4 copies, same sitting per umbrella rule).
-  Done when: docs read standalone; glossary copies diff-clean.
+- [x] **SA.4 — Docs + glossary.** — completed 2026-08-14. The glossary
+  already NAMED this surface — a *deck* is shell chrome and "card" is its
+  "(was)" column — so SA.4 opened with a vocabulary-compliance rename of
+  SA.1–SA.3's code: `SubagentCard`→`SubagentDeck`,
+  `subagent-card.ts`→`subagent-deck.ts`, CSS `.subagent-card*`→
+  `.subagent-deck*`, comments and e2e selectors converted; all tiers
+  re-verified green after. GLOSSARY gains a dedicated *subagent deck* row
+  (master + all 4 copies, diff-clean; relay/site/desktop copies committed
+  in their repos — docs-only, UNPUSHED, awaiting Kyle). README: the
+  Claude Code subagent-traffic paragraph rewritten to the SA truth
+  (message-grain prose, budget cap, the deck, name-agnostic anchor,
+  canUseTool coverage), `subtext` in the RenderZone entry list, mock
+  hook description updated. ADAPTERS.md: the capability-matrix subagent
+  row rewritten per adapter (incl. the recorded Codex F.5-deferred
+  posture) + a §3 "subagent lane" contract block for the next adapter
+  author (opaque handle, relationship anchor, budget, inert prose,
+  no-painting, ask attribution, depth-1 render rule).
+  Tiers 817/152/57(app) green.
 
 **Done when (phase).** Prompting the mock or a real engine into a parallel
 fan-out yields live per-subagent cards — calm summary, expandable to full

--- a/PLAN.md
+++ b/PLAN.md
@@ -2947,6 +2947,217 @@ truth arrives does.
 an allowed provider and drive it immediately; a subscription/Zen pin is
 refused at create with the honest reason and leaks nothing; all tiers green.
 
+## Phase SA — Subagent view (opened 2026-08-14; Kyle-directed; steps pending the research pass + Kyle's signoff)
+
+**Why.** When a session's agent spawns its own subagents, render them as a
+live, legible structure — calm by default, fully expandable — instead of
+dropping their narration and scattering their tool rows. Today the Claude
+Code adapter forwards a subagent's tool calls (nested, T2.4) but drops its
+prose: the SDK never forwards subagent token-level deltas (main-session-only
+stream, confirmed vs docs 2026-08-14), but subagent COMPLETE assistant
+messages — text and thinking blocks tagged `parent_tool_use_id` — do arrive,
+and the adapter skips them (`claude-code.ts` `!parentId` gate). The data is
+in the stream at message grain; Mirafold chooses not to render it — in
+tension with never-hide, sharpest when a stuck subagent explains itself and
+the user never sees it. Framing sharpened by research: the TERMINAL shows
+even less (a panel row — name, elapsed, tokens; no prose, no per-agent tool
+activity — a gap third-party tools visibly fill), so this is not fixing a
+hiding-vs-terminal bug; it is Mirafold being MORE faithful than the terminal
+to what the agent is actually doing.
+A live per-subagent card is also the product thesis made vivid: parallel
+agents shown side by side, which one interleaved terminal column physically
+cannot do. Automatic — the user prompts normally; when the agent fans out,
+this rendering just happens.
+
+**The hard line.** Mirafold DISPLAYS the agent's own coordination — it
+renders what the engine already decided to do. It never spawns or directs
+subagents itself (the homegrown-orchestrator trap, a non-negotiable).
+*Mirafold shows coordination; it never performs it.*
+
+**Decided 2026-08-14 (Kyle signed off on all of these):**
+
+1. **One card per subagent; no invented group container.** Each spawn gets
+   its own live card anchored where its Task row is today. No batch notion,
+   no synthesized group title (shell-voice rule: Mirafold never composes a
+   sentence about the agent's intent). A neutral counted summary line
+   ("3 agents · 2 running") is later polish, not structure.
+2. **Subagent traffic rides the replay ring, per-subagent byte-capped.**
+   A late-attaching viewport sees what a present one saw — dropping it from
+   replay would rebuild the hiding problem for exactly the away user. Cap
+   in the flood-cap spirit; elision marked explicitly (`truncatedBytes`
+   precedent), never silent.
+3. **Wire shape: reuse `text_delta`/`thinking_delta` with optional
+   `parentId`** — the exact additive precedent `tool_use`/`tool_result`
+   set; old clients degrade to today's behavior. No new delta type.
+   **`parentId` is an opaque adapter-chosen handle**: for Claude Code it
+   happens to be the Task tool_use id, but the protocol never promises
+   that; shared code only groups by it, never parses or dereferences it.
+4. **A card must be able to exist without a tool row to anchor to.**
+   Tool-call-spawning engines anchor on (become) the Task row; an engine
+   without one gets a way to announce the spawn (synthetic tool_use-shaped
+   record vs. small additive spawn message — build-time call, requirement
+   named now so the card component is not hard-wired to Task rows).
+5. **Render depth 1 — what the stream surfaces — stated assumption.**
+   (Corrected by research 2026-08-14: engines DO nest — Claude Code to
+   depth 3 by default, but grandchild traffic never reaches the parent
+   stream, only the top-level child's summary returns; OpenCode denies
+   `task` to children by default, though user config can allow nesting,
+   unbounded.) The rule: cards render what the engine surfaces to the
+   session; engine-hidden grandchildren are the ENGINE's choice, not ours.
+   OpenCode parentage resolves transitively (`Session.parentID` is a plain
+   edge), so a configured nesting maps to the nearest stream-visible
+   ancestor's card — documented degradation, not breakage.
+6. **Agent-neutral, proven: OpenCode mapping is IN scope as the final
+   step.** Neutrality is only real once a second adapter maps the lane.
+   Codex is OUT of build scope, with the posture corrected by research
+   2026-08-14: Codex NOW HAS first-class multi-agent (collab tools,
+   default-on since ~2026-02, official docs) — children are full sibling
+   THREADS (own thread id + event stream, `parentThreadId` edges); the
+   parent stream carries spawn/status items (`collabAgentToolCall`,
+   `subAgentActivity`) but never child inner activity, which needs
+   per-thread subscriptions via the app-server protocol — i.e. gated on
+   F.5, and the TS SDK we drive types none of the collab items yet.
+   A Codex SUMMARY-card mapping may be reachable pre-F.5 from untyped
+   collab items; deliberately deferred, revisit at F.5. (Vocabulary trap
+   confirmed: Codex `task_started`/`task_complete` = the whole TURN.)
+   Gemini is sunset.
+7. **Trusted shell:** the card is Mirafold chrome derived from the stream —
+   all subagent prose renders as inert plain text (fleet activity-line
+   precedent), never markdown, never agent-painted HTML.
+8. **Phase shape: mock-first, three beats.** (a) Mock parallel-subagent
+   scenario + summary cards built ENTIRELY from data already on the wire —
+   spawn/finish/tool rows/elapsed/current action all derive from existing
+   `tool_use`/`tool_result` + parentId; zero protocol change; visible win
+   alone. (b) Narration forwarding + the expanded view. (c) The OpenCode
+   mapping. Expanded-view interaction design (the calm/expand balance) is
+   deliberately decided at build time with the mock running.
+
+**Research pass — DONE 2026-08-14 (three agents + local reads). Load-bearing
+findings, beyond the corrections folded into the decisions above:**
+
+- **Claude Code (SDK pin 0.3.201):** subagent narration arrives at MESSAGE
+  grain only (complete assistant messages with `parent_tool_use_id`; deltas
+  are main-session-only per docs). To verify empirically in SA.0: that
+  parent-tagged messages arrive LIVE during the child's run (T2.4's ticking
+  nested rows suggest yes; one doc reading suggested end-of-run) — and that
+  subagent permission asks already route through the parent `canUseTool`.
+  Terminal shows a subagent panel row only (name/elapsed/tokens). Default
+  concurrent-subagent cap 20 — cards must stack legibly at that count.
+- **OpenCode (live OpenAPI capture + engine binary, 1.18.18; NEVER yet
+  exercised live — SA.0 owes the probe):** child sessions ride the SAME
+  global `/event` stream we already consume, tagged with their own
+  `sessionID`; our `isOurs` filter (`opencode.ts:170`, applied across
+  `opencode-events.ts`) drops them whole, per design comment and a pinned
+  test. Spawn = the `task` TOOL part on the parent + `session.created` with
+  `Session.parentID`; the JOIN key parent-task-part → child is
+  `state.metadata.sessionId` (lowercase-d casing, engine inconsistency; the
+  session event alone recovers the parent SESSION, not the Task row). The
+  `subtask` command path converges on the same task tool part — one lane
+  rule covers both. Child gets `todowrite` denied by default — no checklist
+  clobber hazard. **DEFECT FOUND: child-session `permission.asked` events
+  are dropped today — a subagent hitting a permission gate hangs, no UI, no
+  deny timer (`opencode.ts:544` timer only starts for accepted asks).**
+  Reply endpoint for the fix: `POST /permission/{requestID}/reply` (takes
+  only the request id — session-agnostic; our current per-session reply
+  endpoint is marked deprecated in the live spec). Also: child
+  `session.idle` must not end the parent's turn once the lane opens; spike
+  doc's "subtask/agent parts" subagent claim is incomplete — correct it.
+- **Local (registry.ts):** replay ring already double-capped (4000 msgs /
+  32 MB, oldest-first) — riding it is memory-safe; the per-subagent
+  narration cap therefore lives at the ADAPTER (also bounds relay bytes);
+  sizing precedent `TOOL_OUTPUT_CAP_BYTES` 64 KB. **The 33 ms delta
+  coalescer merges on `pending.type === msg.type` only (`registry.ts:589`)
+  — once deltas carry `parentId` the merge key MUST include it**, or parent
+  and child prose concatenate into one message.
+
+**Steps** *(each single-pass; implementation gated on Kyle's explicit
+signoff of the reported plan)*:
+
+- [x] **SA.0 — Live probes + record the truth.** — completed 2026-08-14,
+  both probes credential-free/zero-spend. **OpenCode** (real engine 1.18.18,
+  OC.5-style scripted provider, raw global-stream capture): parent `task`
+  tool part (`pending`) arrives ONE event before child `session.created`;
+  `running` metadata carries the join key
+  (`state.metadata.sessionId`/`parentSessionId`, lowercase d, + `model`;
+  `completed` adds `truncated`); the child `Session` itself carries `agent`,
+  a title from the description, and a ruleset showing `task` denied
+  (depth-1 default confirmed live). Child text/tool/step parts AND
+  token-grain `message.part.delta`s ride the global stream tagged with the
+  child id. Child `permission.asked` arrived (child `sessionID`,
+  `patterns`, `tool.callID`); **the deprecated per-session reply endpoint
+  accepted a reply addressed with the ROOT session id — 200, child
+  unblocked — so it does NOT validate ownership (1.18.18)**; SA.3 still
+  moves to `/permission/{requestID}/reply` (modern, session-agnostic).
+  Child `session.idle` fired BEFORE the parent task part completed and well
+  before parent idle — the parent-turn guard is real. Curated capture:
+  `server/testing/opencode-subagent-fixture.ts`. **Claude Code** (real
+  bundled CLI via SDK 0.3.201, scripted Anthropic endpoint via
+  `ANTHROPIC_BASE_URL`, STREAMING input mirroring the adapter):
+  (a) parent-tagged assistant messages arrive LIVE mid-child-run (child's
+  Bash tool_use yielded before the fake server even served the child's next
+  request), zero parent-tagged `stream_event`s — narration is message-grain,
+  confirmed empirically; (b) **a subagent's gated tool call DOES fire the
+  parent query's `canUseTool`** (proved with a parent-Bash control in the
+  same run) — the existing permission bar already covers subagent tools —
+  but the callback carries NO subagent identifier (extras =
+  suggestions/blockedPath/displayName only), so CC asks stay UNATTRIBUTED
+  on cards this phase, faithful to the terminal. Two design-relevant
+  extras: the spawn tool in 0.3.201 is named **`Agent`** (not `Task`) — the
+  card anchor must key on "the tool_use other messages reference as
+  `parentId`", name-agnostic; and bare `echo` never prompted (the CLI's own
+  safe-command auto-approval — faithful, not a bug). Spike doc's subagent
+  paragraph corrected. Probe scripts: session scratchpad `sa0/`
+  (`probe.mjs`, `cc-probe2.mjs`); recipes summarized above are sufficient
+  to re-derive them.
+- [ ] **SA.1 — Mock scenario + summary cards (zero protocol change).**
+  MockSession gains a parallel-subagent scenario (3 spawns, interleaved
+  nested tool traffic, out-of-order finishes). Client: the subagent card —
+  the Task row becomes a live card (agent type + prompt from the spawn
+  input; running/done state, tool count, elapsed, current action — ALL
+  derived from existing `tool_use`/`tool_result` + `parentId` data).
+  Calm summary only; card is shell chrome; phone renders the same card
+  stacked (no new drill-in). Axe-clean, focus discipline. Done when: in
+  headless Chrome against the mock, three cards run live at once, tick
+  independently, finish out of order; Tier-1 covers the card reducer.
+- [ ] **SA.2 — The narration lane (wire + Claude Code + expand).**
+  Protocol: optional `parentId` on `text_delta`/`thinking_delta`,
+  documented as an opaque adapter-chosen handle (never parsed, only
+  grouped). Registry: coalescer merge key gains `parentId`. Adapter:
+  forward subagent text + thinking from parent-tagged complete messages
+  (message-grain deltas), per-subagent narration cap
+  (`SUBAGENT_TEXT_CAP_BYTES`, default 64 KB, explicit elision marker,
+  never silent). Client: expand/collapse on the card — full activity,
+  narration as inert plain text (fleet activity-line precedent), collapse
+  back to calm. Replay: rides the ring as-is (globally capped). Done
+  when: mock + Tier-1/2 prove per-parent bucketing (no cross-parent
+  merge), the cap's marker, and old-client shape compatibility; e2e:
+  expand shows narration live, collapse returns calm.
+- [ ] **SA.3 — The OpenCode mapping (neutrality proven).** `isOurs`
+  becomes a lane router: child-session events map to `parentId` = parent
+  task part id (Map from `state.metadata.sessionId` +
+  `session.created`/`Session.parentID`, resolved transitively); child
+  text/reasoning → parentId'd deltas (capped, SA.2 lane), child tool
+  parts → parentId'd `tool_use`/`tool_result`; child `session.idle` and
+  status must not touch parent turn state. **Fix the defect: child
+  permission asks surface in the shell's permission UI attributed to the
+  subagent, answered via `/permission/{requestID}/reply`, deny-by-default
+  timer armed.** Update the "skipped whole" test to the new contract;
+  extend the Tier-4 live test with a scripted-provider subagent run.
+  Done when: a real OpenCode subagent's cards/narration/permission ask
+  all work end-to-end on the scripted harness; all tiers green.
+- [ ] **SA.4 — Docs + glossary.** README (the card in the surfaces
+  section), ADAPTERS.md (the subagent lane: opaque `parentId`, the
+  per-adapter mapping table incl. the recorded Codex posture), GLOSSARY
+  term for the card (master + 4 copies, same sitting per umbrella rule).
+  Done when: docs read standalone; glossary copies diff-clean.
+
+**Done when (phase).** Prompting the mock or a real engine into a parallel
+fan-out yields live per-subagent cards — calm summary, expandable to full
+narration — on desktop and phone, replayed faithfully to a late-attaching
+viewport within caps; Claude Code and OpenCode both map the lane; an
+OpenCode subagent's permission ask no longer hangs; nothing anywhere spawns
+or directs a subagent from Mirafold's side; all tiers green.
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **Why.** Kyle (2026-07-26): open a file and see it in its own pane. Also the

--- a/PLAN.md
+++ b/PLAN.md
@@ -3196,6 +3196,27 @@ signoff of the reported plan)*:
   no-painting, ask attribution, depth-1 render rule).
   Tiers 817/152/57(app) green.
 
+**Post-phase security audit (2026-08-14, same day; scope: the SA delta +
+its trust boundaries).** ZERO exploitable findings. ONE hardening landed
+(flood-cap parity, pinned): the shared `SubagentProseBudget` had no cap on
+DISTINCT parent ids, so a hostile/looping engine fabricating unlimited
+`parent_tool_use_id` values could grow the ledger without bound within a
+turn — now capped (`MAX_SUBAGENTS_PER_TURN` 2000; past it a NEW subagent's
+prose drops silently, the same degradation as every other per-turn cap;
+OpenCode's parent ids were already bounded by the spawn-part cap, so this
+mainly guards the Claude lane). Verified-clean facts worth keeping: a
+Claude Code SUBAGENT cannot reach the render MCP tools — proved through
+the REAL adapter + shipped in-process MCP server against a scripted
+endpoint (the SDK withholds MCP tools from subagents: 31 child tools, no
+`mcp__mirafold*`), so the no-painting rule holds on BOTH engines (OpenCode
+by our lane code, Claude by the engine itself); subagent prose renders
+inert everywhere (no markdown, no HTML sinks); the deck and the permission
+chip are shell chrome with engine text confined to inert slots; the store's
+`idSchema` bounds a tampered checkpoint's `parentId` at 1 KB; the
+committed fixture carries no secret-shaped strings; alternating parent ids
+cannot defeat the coalescers into unbounded ring growth (count + byte caps
+hold); `laneOf` is cycle-safe (hop cap).
+
 **Post-phase bughunt round 2 (2026-08-14, same day).** Two more found +
 fixed, pins proven failing pre-fix: (1) `zone_reset` cleared every
 streaming ref EXCEPT the new subtext map — a same-page full-replay

--- a/PLAN.md
+++ b/PLAN.md
@@ -3109,16 +3109,25 @@ signoff of the reported plan)*:
   paragraph corrected. Probe scripts: session scratchpad `sa0/`
   (`probe.mjs`, `cc-probe2.mjs`); recipes summarized above are sufficient
   to re-derive them.
-- [ ] **SA.1 — Mock scenario + summary cards (zero protocol change).**
-  MockSession gains a parallel-subagent scenario (3 spawns, interleaved
-  nested tool traffic, out-of-order finishes). Client: the subagent card —
-  the Task row becomes a live card (agent type + prompt from the spawn
-  input; running/done state, tool count, elapsed, current action — ALL
-  derived from existing `tool_use`/`tool_result` + `parentId` data).
-  Calm summary only; card is shell chrome; phone renders the same card
-  stacked (no new drill-in). Axe-clean, focus discipline. Done when: in
-  headless Chrome against the mock, three cards run live at once, tick
-  independently, finish out of order; Tier-1 covers the card reducer.
+- [x] **SA.1 — Mock scenario + summary cards (zero protocol change).** —
+  completed 2026-08-14. `playSubagent` is now a three-spawn parallel
+  fan-out (distinct paces; the second-spawned finishes first). Client:
+  `SubagentCard` in RenderZone (supersedes the T2.4 SubagentGroup) — any
+  tool_use other records reference as `parentId` becomes the card,
+  name-agnostic; calm summary = agent type + spawn description (verbatim,
+  never composed), state dot (pulse honors reduced-motion), tool count,
+  elapsed ticking ONLY while running (client-side stamp — honest under
+  replay, where a settled card shows no stale duration), current action =
+  newest unanswered child, result first-line once done; expandable to the
+  existing nested ToolCallList. Derivation is pure
+  (`web/src/subagent-card.ts`, 7 Tier-1 tests). Cards are fold
+  BOUNDARIES for the settled-activity compaction and their children are
+  invisible to it (omitted, not boundaries — parent-level runs don't
+  split on child traffic). Tier-2 itest updated to the fan-out contract
+  (children tag their own spawn; settle order ≠ spawn order). E2e (app):
+  three cards live at once, independent tick, out-of-order settle, expand/
+  collapse, axe-clean, phone-width stack with no side scroll. Tiers
+  810/152/57(app) green.
 - [ ] **SA.2 — The narration lane (wire + Claude Code + expand).**
   Protocol: optional `parentId` on `text_delta`/`thinking_delta`,
   documented as an opaque adapter-chosen handle (never parsed, only

--- a/PLAN.md
+++ b/PLAN.md
@@ -3196,6 +3196,23 @@ signoff of the reported plan)*:
   no-painting, ask attribution, depth-1 render rule).
   Tiers 817/152/57(app) green.
 
+**Post-phase bughunt round 2 (2026-08-14, same day).** Two more found +
+fixed, pins proven failing pre-fix: (1) `zone_reset` cleared every
+streaming ref EXCEPT the new subtext map — a same-page full-replay
+(reconnect) with an open subagent prose run swallowed the replayed
+narration into entry ids that no longer existed (deck came back
+empty-handed); pinned by a resilience e2e that kills+restarts the daemon
+inside the slow-subagent hook's window (new mock hook `delegate slowly`),
+with a store-durability poll so the 250ms checkpoint debounce can't race
+the kill. (2) Child tool traffic steered the ROOT activity line (both
+`tool_use` setting the label and `tool_result` clearing it), contradicting
+the SA.3 design statement the server side already honored — the label now
+ignores parented tool traffic in both directions; pinned by multi-sampled
+label assertions in the SA.1 e2e. Diagnosis bonus, recorded: interior
+frames reach the checkpoint store on a 250ms debounce, so a daemon killed
+inside it loses the un-flushed tail — pre-existing, honest (the turn
+replays as interrupted), not a defect.
+
 **Post-phase bughunt round 1 (2026-08-14, same day).** Two found + fixed with
 pinned regressions (each proven failing pre-fix): a REPLAYED running deck
 ticked a false elapsed (stamp = attach moment, not spawn — now shows no

--- a/PLAN.md
+++ b/PLAN.md
@@ -3151,19 +3151,32 @@ signoff of the reported plan)*:
   semantics (cap marker, per-agent ledgers, U+FFFD safety, reset),
   registry + delta-queue no-cross-parent merges, e2e narration in the
   expansion. Tiers 814/152/57(app) green.
-- [ ] **SA.3 — The OpenCode mapping (neutrality proven).** `isOurs`
-  becomes a lane router: child-session events map to `parentId` = parent
-  task part id (Map from `state.metadata.sessionId` +
-  `session.created`/`Session.parentID`, resolved transitively); child
-  text/reasoning → parentId'd deltas (capped, SA.2 lane), child tool
-  parts → parentId'd `tool_use`/`tool_result`; child `session.idle` and
-  status must not touch parent turn state. **Fix the defect: child
-  permission asks surface in the shell's permission UI attributed to the
-  subagent, answered via `/permission/{requestID}/reply`, deny-by-default
-  timer armed.** Update the "skipped whole" test to the new contract;
-  extend the Tier-4 live test with a scripted-provider subagent run.
-  Done when: a real OpenCode subagent's cards/narration/permission ask
-  all work end-to-end on the scripted harness; all tiers green.
+- [x] **SA.3 — The OpenCode mapping (neutrality proven).** — completed
+  2026-08-14. The mapper gained `laneOf`: "root" | spawn-part-id |
+  undefined (unroutable → skipped whole, the pre-lane behavior). Edges
+  from the root task part's `state.metadata` ({sessionId,
+  parentSessionId} — captured shape-wise, not by tool name, so the lane
+  stays name-agnostic) + child `session.created`, resolved transitively —
+  a configured nested grandchild lands on the nearest stream-visible
+  card (tested). Child text/reasoning → parented deltas through the
+  shared `SubagentProseBudget`; child tool parts → parented
+  `tool_use`/`tool_result` (roles tracked for child messages so the task
+  prompt's echo never replays as narration); a child's RENDER call gets
+  the honest tool record, never a painting (cards are calls + prose);
+  child step/status/idle/error never touch root turn state or the
+  activity line. **Defect fixed:** child `permission.asked` surfaces on
+  the shell bar with additive `parentId` on `permission_request`
+  (protocol + store schema + PermBar dim "subagent" chip + announcer
+  suffix), deny timer armed, replies via the modern session-agnostic
+  `POST /permission/{requestID}/reply` (the deprecated per-session
+  endpoint — which the SA.0 probe showed never validated ownership —
+  dropped everywhere). Tests: the SA.0 captured run replayed whole
+  through the shipped session (spawn anchor, parented calls/prose,
+  attributed ask, single turn_end), grandchild transitivity, no-painting
+  rule, unroutable fallback; Tier-4 live extends with a REAL engine
+  fan-out (attributed ask answered through the production bridge, child
+  bash + narration on the lane, parent reply top-level) — green.
+  Tiers 817/152/57(app)/1(live) green.
 - [ ] **SA.4 — Docs + glossary.** README (the card in the surfaces
   section), ADAPTERS.md (the subagent lane: opaque `parentId`, the
   per-adapter mapping table incl. the recorded Codex posture), GLOSSARY

--- a/README.md
+++ b/README.md
@@ -970,10 +970,27 @@ mediation path (§5.4).
     with the same id completes the record, capped by `capOutput` with an
     honest `truncatedBytes` (T2.3). Results are only forwarded for ids the
     session announced.
-  - **Subagent traffic** (events with a `parent_tool_use_id`): its text and
-    thinking stay dropped — a subagent's monologue must not paint into the
-    transcript — but its tool *calls* are now forwarded tagged with
-    `parentId` (T2.4), which the client nests under the owning Task row.
+  - **Subagent traffic** (events with a `parent_tool_use_id`): its tool
+    *calls* forward tagged with `parentId` (T2.4), and since Phase SA its
+    PROSE forwards too — the SDK never streams subagent token deltas
+    (main-session-only, verified against the real CLI in the SA.0 probe),
+    but its complete assistant messages arrive live mid-run, so their text
+    and thinking blocks become message-grain parented deltas, capped
+    per-subagent by `SubagentProseBudget` (`SUBAGENT_TEXT_CAP_BYTES`,
+    explicit elision marker). The client renders each spawn as a live
+    **subagent deck** (GLOSSARY): calm summary — agent type, the spawn's own
+    description, state, tool count, elapsed while running, current action —
+    expandable to the nested calls interleaved with the subagent's own words
+    as inert plain text, never markdown. The deck anchors on "the tool_use
+    other records reference as `parentId`", never on a tool NAME (the SDK's
+    spawn tool is `Agent` as of 0.3.201, was `Task`; OpenCode's is `task`).
+    `parentId` itself is an OPAQUE adapter-chosen handle — shared code only
+    groups by it. A subagent's permission-gated tool call already rides the
+    parent `canUseTool` (verified live, SA.0), so the permission bar covers
+    subagents with no extra plumbing; the callback carries no subagent
+    identity, so Claude Code asks stay unattributed (OpenCode's are
+    attributed — `permission_request.parentId` — and show a dim "subagent"
+    chip).
   - **Task list** (T2.5): the SDK's `TaskCreate`/`TaskUpdate` family (its
     successor to `TodoWrite`) is folded into one live `todo-list` render that
     updates in place; the raw Task* rows and their results are swallowed.
@@ -1029,7 +1046,9 @@ emissions: streamed `thinking_delta`, fake `tool_use`/`tool_result` records
 (incl. an Edit with a real before/after and a Write), a `usage` record, the
 reply streamed in 16-char chunks at ~12ms, then `turn_end`. Keyword hooks in
 the prompt drive every other capability API-free — `artifact`/`broken`/
-`navigates` (Phase 3 + its fallbacks), `subagent`/`delegate` (nested Task),
+`navigates` (Phase 3 + its fallbacks), `subagent`/`delegate` (a three-spawn
+parallel fan-out with narration — three live subagent decks, out-of-order
+finishes; Phase SA),
 `todo`/`plan` (live checklist), `huge` (the elision marker), `dangerous`
 (permission prompt). `close()` clears all pending timers.
 
@@ -1159,9 +1178,11 @@ same relative URL works unchanged.
 
 State: a flat list of `Entry`s — text blocks (`{kind:"text", …}`), rendered
 components (`{kind:"render", …}`), tool records (`{kind:"tool", …}`, which
-may carry `parentId` for subagent calls), thinking blocks (`{kind:"thinking",
-…}`), and artifacts (`{kind:"artifact", …}`) — in the exact order they
-arrived on the wire, plus an ephemeral `Status`. The reducer-like
+may carry `parentId` for subagent calls), subagent prose
+(`{kind:"subtext", …}` — parented narration/thinking, rendered only inside
+its subagent deck's expansion, never top-level), thinking blocks
+(`{kind:"thinking", …}`), and artifacts (`{kind:"artifact", …}`) — in the
+exact order they arrived on the wire, plus an ephemeral `Status`. The reducer-like
 subscription handles each `ZoneMsg`:
 
 - `user_prompt` → append a done user text entry, show `thinking`.

--- a/README.md
+++ b/README.md
@@ -211,11 +211,15 @@ The contract between server and browser. Currently on the wire:
 ```ts
 // Server → browser
 type WireMsg =
-  | { type: "text_delta"; text: string }                           // streamed markdown
+  | { type: "text_delta"; text: string;                            // streamed markdown;
+      parentId?: string }                                          //   parentId = a SUBAGENT's
+                                                                   //   prose (SA.2, opaque
+                                                                   //   handle → its deck)
   | { type: "prompt_options"; options: PromptOption[] }             // provider-owned
                                                                     // pre-submit / + $
                                                                     // completion catalog
-  | { type: "thinking_delta"; text: string }                       // T2.1: reasoning stream
+  | { type: "thinking_delta"; text: string; parentId?: string }    // T2.1: reasoning stream
+                                                                   //   (parentId as above)
   | { type: "status"; state: "thinking" | "tool"; label?: string } // activity line
   | { type: "turn_end" }                                           // finalize the turn
   | { type: "error"; message: string }
@@ -242,7 +246,9 @@ type WireMsg =
       input?: Record<string, unknown>; parentId?: string }
   | { type: "tool_result"; output: string; isError?: boolean; id: string;
       truncatedBytes?: number; parentId?: string }
-  | { type: "permission_request"; tool: string; detail: string; id: string } // T.3
+  | { type: "permission_request"; tool: string; detail: string; id: string; // T.3;
+      parentId?: string }                                          //   set = a subagent's ask
+                                                                   //   (SA.3, "subagent" chip)
   | { type: "permission_resolved"; id: string; allow: boolean } // 2026-07-28: the ask
                                                    //   resolved (any viewport's answer,
                                                    //   timeout, interrupt) — every
@@ -683,8 +689,8 @@ web/               the browser app (React 19 + Vite)
                        command in a ModalCard — the phone's truncated preview
                        was unreadable; Shell keeps owning asks + the wire answer
     RenderZone.tsx     OUTPUT ZONE: WireMsg interpreter → entries, incl.
-                       thinking blocks, artifacts, subagent grouping, and the
-                       completed-turn activity fold
+                       thinking blocks, artifacts, subagent decks (SA), and
+                       the completed-turn activity fold
     ActivityLine.tsx   the always-visible work indicator (4.14): cycling
                        asterisk + label + elapsed seconds, prompt-area chrome
                        above the box — never a transcript entry, so no scroll
@@ -700,9 +706,10 @@ web/               the browser app (React 19 + Vite)
                        bottom; folds to one row of controls at phone width
                        (R.4l), where it also hosts the Files and Changes
                        workspace toggles (the activity rail is desktop-only)
-    GearGlyph.tsx      the settings/tool gear as a flat outline drawing, three
-                       homes: the settings button, the subagent head, the
-                       fleet activity line (2026-07-25 — the ⚙ character
+    GearGlyph.tsx      the settings/tool gear as a flat outline drawing; its
+                       homes: the settings button, the subagent deck meta
+                       line, the completed-turn activity fold, the fleet
+                       activity line (2026-07-25 — the ⚙ character
                        rendered from the color-emoji font and clashed with
                        every glyph beside it)
     FilesGlyph.tsx     the Explorer/files glyph drawing — the activity-bar
@@ -977,7 +984,9 @@ mediation path (§5.4).
     but its complete assistant messages arrive live mid-run, so their text
     and thinking blocks become message-grain parented deltas, capped
     per-subagent by `SubagentProseBudget` (`SUBAGENT_TEXT_CAP_BYTES`,
-    explicit elision marker). The client renders each spawn as a live
+    explicit elision marker; the ledger also caps DISTINCT subagents per
+    turn — audit 2026-08-14 — so fabricated parent ids can't grow it
+    unboundedly). The client renders each spawn as a live
     **subagent deck** (GLOSSARY): calm summary — agent type, the spawn's own
     description, state, tool count, elapsed while running, current action —
     expandable to the nested calls interleaved with the subagent's own words
@@ -990,7 +999,10 @@ mediation path (§5.4).
     subagents with no extra plumbing; the callback carries no subagent
     identity, so Claude Code asks stay unattributed (OpenCode's are
     attributed — `permission_request.parentId` — and show a dim "subagent"
-    chip).
+    chip). A subagent cannot paint: the SDK withholds MCP tools from
+    subagent contexts entirely (proved through the real adapter + shipped
+    in-process render server, audit 2026-08-14), so the render tools are
+    parent-only on this engine by construction.
   - **Task list** (T2.5): the SDK's `TaskCreate`/`TaskUpdate` family (its
     successor to `TodoWrite`) is folded into one live `todo-list` render that
     updates in place; the raw Task* rows and their results are swallowed.
@@ -1048,7 +1060,9 @@ reply streamed in 16-char chunks at ~12ms, then `turn_end`. Keyword hooks in
 the prompt drive every other capability API-free — `artifact`/`broken`/
 `navigates` (Phase 3 + its fallbacks), `subagent`/`delegate` (a three-spawn
 parallel fan-out with narration — three live subagent decks, out-of-order
-finishes; Phase SA),
+finishes; Phase SA), `delegate slowly` (ONE spawn whose narration streams
+seconds before its first tool call — the deterministic window for
+mid-turn-reset tests),
 `todo`/`plan` (live checklist), `huge` (the elision marker), `dangerous`
 (permission prompt). `close()` clears all pending timers.
 
@@ -1197,7 +1211,12 @@ subscription handles each `ZoneMsg`:
   deliberate correctness detail: if the user sends a new prompt mid-stream,
   the user entry is appended after the streaming block, and deltas still
   route to the right block by id instead of gluing the reply's tail onto
-  the wrong one.
+  the wrong one. A delta carrying `parentId` is a SUBAGENT's prose (SA.2)
+  and routes to a `subtext` entry inside its deck instead — before the
+  fold/close logic, so a child streaming never folds the parent's open
+  thinking or closes the parent's streaming block; per-parent open runs
+  live in their own ref (`subtextIds`), closed by that subagent's next tool
+  row and cleared at `turn_end` and `zone_reset`.
 - `render` → if the wire `id` has been seen, **update that entry's props in
   place** (this is what keeps pinned widgets live); otherwise append a
   render entry and close the streaming text block, so later deltas open a
@@ -1221,8 +1240,23 @@ subscription handles each `ZoneMsg`:
   opening a fold preserves every normalized input and result. `ToolBlock.tsx`
   renders those details — Edit/Write as a colored diff / code (T2.2), with
   any `truncatedBytes` as an explicit elision marker (T2.3). Calls tagged
-  with `parentId` stay inside the turn's activity rather than becoming extra
-  top-level churn (T2.4).
+  with `parentId` render inside their **subagent deck**, never top-level
+  (T2.4/SA.1) — next bullet.
+- **The subagent deck** (Phase SA): a spawn whose wire id other records
+  reference as `parentId` becomes a live deck — the anchor is that
+  relationship, never a tool name. Calm summary (agent type + the spawn's
+  own description verbatim, pulsing state dot, tool count, current action =
+  the newest unanswered child call; derivation is pure in
+  `web/src/subagent-deck.ts`), expandable to the full activity: child calls
+  interleaved with the subagent's narration and dim reasoning in true
+  stream order, all inert plain text. Elapsed seconds tick only while the
+  spawn is running AND its record arrived live — a replayed record's stamp
+  is the attach moment, so a replayed deck shows no elapsed rather than a
+  false one. Decks are hard fold-boundaries for the settled-activity
+  compaction and their children are invisible to it; child tool traffic
+  never steers the root activity line in either direction (each deck shows
+  its own action). A subagent's permission ask paints the same shell bar
+  with a dim "subagent" chip (`permission_request.parentId`).
 - `artifact` → route to `Artifact.tsx` (the sandboxed iframe, Phase 3);
   re-sending an id replaces it in place, same as `render`.
 - `picker` → append a `PickerBlock.tsx` entry: the SHELL-owned selector
@@ -1501,7 +1535,9 @@ these tuning knobs:
 checkpoint remains),
 `PERMISSION_TIMEOUT_MS` (how long a permission prompt waits before denying),
 `TOOL_OUTPUT_CAP_BYTES` (per-result output cap before the elision marker,
-default 64 KB), `BANG_CONTEXT_CAP` (tail of a `!` transcript injected into
+default 64 KB), `SUBAGENT_TEXT_CAP_BYTES` (per-subagent narration cap before
+its elision marker, default 64 KB — Phase SA),
+`BANG_CONTEXT_CAP` (tail of a `!` transcript injected into
 the agent's context, default 16 KB), `MAX_THINKING_TOKENS` (opt-in extended
 thinking), `MAX_WS_PAYLOAD` (largest inbound WS frame, default 1 MB),
 `MAX_SESSIONS` (concurrent-session ceiling, default 100), `MIRAFOLD_TOKEN`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -28,6 +28,15 @@ adapter-owned badge, and entries containing invisible direction/line controls
 are dropped. A provider cannot choose the badge text or present its metadata as
 an unattributed Mirafold instruction.
 
+Subagent decks (Phase SA, 2026-08-14) put a subagent's own narration and
+reasoning inside shell chrome: it renders as inert plain text only, never
+markdown or HTML, and a subagent cannot paint generative-UI components — on
+OpenCode the adapter's lane refuses it, and on Claude Code the SDK withholds
+the MCP render tools from subagent contexts (verified against the real
+adapter). Per-subagent narration is byte-capped with an explicit elision
+marker, and the cap's ledger bounds distinct subagents per turn, so a
+hostile or looping engine cannot grow it — or the wire — without bound.
+
 ## Running it safely
 
 Mirafold drives an agent that has your filesystem and your shell. That is the

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -214,14 +214,20 @@ them. The rules, for the next adapter author:
 - **Prose is budget-capped per subagent.** Every forwarded subagent
   text/thinking chunk passes `SubagentProseBudget` (`adapters/types.ts`;
   `SUBAGENT_TEXT_CAP_BYTES`, default 64 KB) — one explicit elision marker at
-  exhaustion, never a silent cut, ledger cleared each turn. This bounds what
-  one subagent can add to the wire, the replay ring, and relay bytes.
+  exhaustion, never a silent cut, ledger cleared each turn. The ledger also
+  caps DISTINCT subagents per turn (audit 2026-08-14 flood parity): past it
+  a new parent id's prose drops silently, like every other per-turn cap.
+  This bounds what one subagent — or a fabricating engine — can add to the
+  wire, the replay ring, and relay bytes.
 - **Prose renders inert.** Subagent words paint as plain text inside the
   deck's expansion — never markdown, never top-level transcript (they must
   not fold the parent's thinking, steer the activity label, or land in the
   turn-end announcement).
 - **A subagent's render call never paints.** Paintings are session-level;
-  inside a deck it gets the honest `tool_use`/`tool_result` record.
+  inside a deck it gets the honest `tool_use`/`tool_result` record. On
+  OpenCode this is our lane code; on Claude Code the ENGINE enforces it —
+  the SDK withholds MCP tools from subagent contexts (proved through the
+  real adapter + shipped in-process render server, audit 2026-08-14).
 - **A subagent's permission ask surfaces on the shell bar** with `parentId`
   when the engine can attribute it (OpenCode can; Claude Code's
   `canUseTool` callback carries no subagent identity, so its asks ride

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -196,6 +196,44 @@ paths through one `finish`, as `claude-code.ts` does).
 **`close()`** — idempotent teardown: end generators, abort turns, kill child
 processes, clear timers. After `close()`, no further messages may be emitted.
 
+**The subagent lane (Phase SA)** — when the engine spawns its own subagents,
+the adapter maps them onto the neutral lane instead of dropping or flattening
+them. The rules, for the next adapter author:
+
+- **`parentId` is an opaque adapter-chosen handle.** Claude Code uses the
+  spawn `tool_use` id; OpenCode uses the parent `task` PART id. Shared code
+  (registry, client, replay) only ever GROUPS by it — nothing parses,
+  dereferences, or compares it across adapters. Pick whatever your engine's
+  natural join key is.
+- **The deck anchors on the relationship, never a tool name.** The client
+  turns "a tool_use other records reference as `parentId`" into a live
+  subagent deck (GLOSSARY). Engines whose spawn is not a tool call (Codex's
+  collab threads, if mapped post-F.5) would need a spawn record for the deck
+  to anchor on — the requirement is named here so the deck component never
+  grows a name check.
+- **Prose is budget-capped per subagent.** Every forwarded subagent
+  text/thinking chunk passes `SubagentProseBudget` (`adapters/types.ts`;
+  `SUBAGENT_TEXT_CAP_BYTES`, default 64 KB) — one explicit elision marker at
+  exhaustion, never a silent cut, ledger cleared each turn. This bounds what
+  one subagent can add to the wire, the replay ring, and relay bytes.
+- **Prose renders inert.** Subagent words paint as plain text inside the
+  deck's expansion — never markdown, never top-level transcript (they must
+  not fold the parent's thinking, steer the activity label, or land in the
+  turn-end announcement).
+- **A subagent's render call never paints.** Paintings are session-level;
+  inside a deck it gets the honest `tool_use`/`tool_result` record.
+- **A subagent's permission ask surfaces on the shell bar** with `parentId`
+  when the engine can attribute it (OpenCode can; Claude Code's
+  `canUseTool` callback carries no subagent identity, so its asks ride
+  unattributed), and the same deny-by-default timer as any ask. A child's
+  lifecycle events (idle, status, error) must never touch the parent turn's
+  state — its failure surfaces through the spawn record's result.
+- **Render depth 1 — what the stream surfaces.** Engines nest deeper
+  (Claude Code to depth 3, engine-hidden; OpenCode only if the user
+  configures it). Resolve parentage transitively to the nearest
+  stream-visible ancestor's deck; engine-hidden grandchildren are the
+  ENGINE's choice, faithfully absent.
+
 ## 4. Capability matrix (shipped providers, as implemented)
 
 | Capability | `claude-code` | `codex` | `opencode` | `gemini-cli` | `mock` |
@@ -207,7 +245,7 @@ processes, clear timers. After `close()`, no further messages may be emitted.
 | Text streaming granularity | token-level (`includePartialMessages`) | **buffered** — one `text_delta` per completed item (SDK emits no token deltas today) | token-level: a true delta channel (`message.part.delta`) plus snapshot accrual | chunked `message` events | 16-char chunks |
 | Thinking stream (`thinking_delta`) | ✅ full fidelity | ✅ when reasoning items appear | ✅ (`reasoning` parts) | ❌ observed absent → never fires (I3 proof) | ✅ scripted |
 | Tool records (`tool_use`/`tool_result`) | ✅ full input, diffs | ✅ (`command_execution`, `file_change`, `mcp_tool_call`, `web_search`; only `status: "failed"` maps to `isError` — a completed command with a nonzero exit stays non-error, its exit code annotated in the output, matching the Codex TUI) | ✅ (tool parts; error output capped by `capOutput` like success) | ✅ | ✅ |
-| Subagent nesting (`parentId`) | ✅ (`parent_tool_use_id`) | ❌ n/a | ❌ child sessions skipped whole; their work surfaces through the parent's `task` part | ❌ n/a | ✅ scripted |
+| Subagent lane (`parentId` on calls, prose, asks — the subagent deck; Phase SA) | ✅ calls (`parent_tool_use_id`) + prose from parent-tagged COMPLETE messages (the SDK never streams subagent token deltas — SA.0 probe), budget-capped; asks ride the parent `canUseTool` unattributed | ❌ deferred to F.5: collab exists engine-side (default-on since ~2026-02), children are sibling THREADS whose inner activity needs app-server per-thread subscriptions; the TS SDK types none of it | ✅ full lane: child sessions on the same global stream map to the spawn part id (`state.metadata.sessionId` join, transitive for configured nesting), prose budget-capped, `permission.asked` surfaced ATTRIBUTED (`permission_request.parentId`) and replied via the session-agnostic `POST /permission/{requestID}/reply`; a child's render call gets an honest tool record, never a painting | ❌ n/a (sunset) | ✅ scripted three-spawn fan-out with narration |
 | Live todo checklist (`render` todo-list) | ✅ (TaskCreate/Update fold) | ✅ (`todo_list` item) | ✅ (`todo.updated`) | ❌ | ✅ |
 | Interactive permissions (`permission_request`) | ✅ full round-trip via `canUseTool` + inherited `settings.json` | ❌ SDK exposes no approval callback → inherits user's Codex approval config (I3) | ✅ full round-trip: `permission.asked` → reply `once`/`reject` (never `always` — that would persist into the user's own OpenCode state) | ❌ headless can't prompt → user's own tool approvals inherited; only our render server is scoped-allowed | ✅ (`dangerous` keyword) |
 | Usage (`usage` msg) | ✅ tokens + cumulative `total_cost_usd` | ✅ tokens (`cached_input_tokens` is a subset of input — never re-added) | ✅ tokens + cost per assistant message, summed into one per-turn `usage` | ✅ per-model token breakdown | ✅ |

--- a/server/adapters/claude-code.test.ts
+++ b/server/adapters/claude-code.test.ts
@@ -250,6 +250,17 @@ test("SA.2: the per-subagent narration budget caps with one explicit marker, per
   assert.equal(budget.take("a", "fresh"), "fresh"); // turn boundary resets
 });
 
+test("audit: the ledger caps DISTINCT subagents per turn — fabricated parent ids can't grow it unboundedly", async () => {
+  const { SubagentProseBudget } = await import("./types");
+  const budget = new SubagentProseBudget(1_000, 2);
+  assert.equal(budget.take("p1", "one"), "one");
+  assert.equal(budget.take("p2", "two"), "two");
+  assert.equal(budget.take("p3", "three"), "", "a third distinct parent is dropped silently");
+  assert.equal(budget.take("p1", "still fine"), "still fine", "tracked parents keep their budget");
+  budget.clear();
+  assert.equal(budget.take("p3", "next turn"), "next turn", "the cap is per turn");
+});
+
 test("checklist: task tools fold into one render id per turn, list persists, id re-anchors next turn", async () => {
   const { s, msgs, awaitTurnEnd } = makeSession(
     [

--- a/server/adapters/claude-code.test.ts
+++ b/server/adapters/claude-code.test.ts
@@ -192,10 +192,62 @@ test("subagent traffic: tool calls nest under the Task id; text and task tools s
   assert.equal(msgs.find((m) => m.type === "tool_result" && m.id === "in1")!.parentId, "task1");
   assert.ok(msgs.some((m) => m.type === "tool_result" && m.id === "task1"));
 
-  assert.ok(!msgs.some((m) => m.type === "text_delta")); // subagent prose filtered
+  // A parent-tagged stream_event is dropped (the SDK never sends them —
+  // SA.0 probe — the guard is fail-safe); subagent prose forwards only from
+  // complete assistant messages, of which this turn scripts none.
+  assert.ok(!msgs.some((m) => m.type === "text_delta"));
   assert.ok(!msgs.some((m) => m.type === "render")); // subagent TodoWrite swallowed
   assert.ok(!msgs.some((m) => m.type === "tool_use" && m.id === "st1"));
   s.close();
+});
+
+test("SA.2: subagent narration forwards — parent-tagged text and thinking blocks become parented deltas", async () => {
+  const { s, msgs, awaitTurnEnd } = makeSession([
+    assistant([{ type: "tool_use", id: "task1", name: "Agent", input: { prompt: "delegate" } }]),
+    // The subagent narrates, reasons, acts — all COMPLETE messages, live.
+    assistant([{ type: "text", text: "Following the cookie…" }], "task1"),
+    assistant([{ type: "thinking", thinking: "the relay never sees it" }], "task1"),
+    assistant([{ type: "tool_use", id: "in1", name: "Read", input: { file_path: "a.ts" } }], "task1"),
+    user([{ type: "tool_result", tool_use_id: "in1", content: "inner out" }], "task1"),
+    user([{ type: "tool_result", tool_use_id: "task1", content: "done" }]),
+    // Parent prose after the fan-out: buffered-text rule untouched — no
+    // deltas streamed this turn, so the buffered copy paints, un-parented.
+    assistant([{ type: "text", text: "PARENT SUMMARY" }]),
+    RESULT,
+  ]);
+  s.pushPrompt("go");
+  await awaitTurnEnd();
+
+  const subText = msgs.find((m) => m.type === "text_delta" && m.parentId === "task1")!;
+  assert.equal(subText.text, "Following the cookie…");
+  const subThink = msgs.find((m) => m.type === "thinking_delta" && m.parentId === "task1")!;
+  assert.equal(subThink.text, "the relay never sees it");
+  const parentText = msgs.find((m) => m.type === "text_delta" && m.parentId === undefined)!;
+  assert.equal(parentText.text, "PARENT SUMMARY");
+  // Wire order: the subagent's narration lands between its spawn and its
+  // first tool call, exactly as streamed.
+  const order = msgs
+    .filter((m) => (m.type === "tool_use" && (m.id === "task1" || m.id === "in1")) || m.parentId === "task1")
+    .map((m) => m.type + ":" + (m.id ?? ""));
+  assert.deepEqual(order, ["tool_use:task1", "text_delta:", "thinking_delta:", "tool_use:in1", "tool_result:in1"]);
+  s.close();
+});
+
+test("SA.2: the per-subagent narration budget caps with one explicit marker, per subagent", async () => {
+  const { SubagentProseBudget, SUBAGENT_PROSE_ELIDED } = await import("./types");
+  const budget = new SubagentProseBudget(10);
+  assert.equal(budget.take("a", "12345"), "12345"); // within budget
+  const second = budget.take("a", "678901234"); // crosses the 10-byte cap
+  assert.equal(second, "67890" + SUBAGENT_PROSE_ELIDED(10));
+  assert.equal(budget.take("a", "more"), ""); // capped: silent thereafter (marker already shown)
+  // Budgets are PER subagent — a sibling still has its own headroom.
+  assert.equal(budget.take("b", "hello"), "hello");
+  // Multi-byte safety: a chunk sliced mid-codepoint decodes to U+FFFD, never throws.
+  const tight = new SubagentProseBudget(1);
+  const sliced = tight.take("c", "é"); // 2 bytes UTF-8
+  assert.ok(sliced.startsWith("�"));
+  budget.clear();
+  assert.equal(budget.take("a", "fresh"), "fresh"); // turn boundary resets
 });
 
 test("checklist: task tools fold into one render id per turn, list persists, id re-anchors next turn", async () => {

--- a/server/adapters/claude-code.ts
+++ b/server/adapters/claude-code.ts
@@ -22,6 +22,7 @@ import {
   joinTextBlocks,
   toolDetail,
   PERMISSION_TIMEOUT_MS,
+  SubagentProseBudget,
 } from "./types";
 import { AsyncQueue, CLOSE } from "./async-queue";
 import { createLogger, scrubSelectedEndpoint, verbose } from "../log";
@@ -144,6 +145,8 @@ export class ClaudeCodeSession implements AgentSession {
   // arrive as buffered assistant text with zero deltas), the buffered text is
   // the ONLY copy and must be emitted, or the command runs but nothing paints (F.1).
   private streamedText = false;
+  // SA.2: per-subagent narration budget for the turn (cleared with it).
+  private subagentProse = new SubagentProseBudget();
   // In-flight permission prompts, keyed by wire id → resolver.
   private pendingAsks = new Map<string, (allow: boolean) => void>();
 
@@ -424,7 +427,10 @@ export class ClaudeCodeSession implements AgentSession {
       for await (const msg of this.engine) {
         switch (msg.type) {
           case "stream_event": {
-            if (msg.parent_tool_use_id) break; // subagent traffic — not ours to render
+            // Subagent deltas never arrive here (SDK streams are main-session
+            // only — SA.0 probe); a subagent's prose forwards from its
+            // complete assistant messages below. Guard kept fail-safe.
+            if (msg.parent_tool_use_id) break;
             const ev = msg.event;
             if (ev.type === "content_block_delta" && ev.delta.type === "text_delta") {
               this.streamedText = true; // F.1: mark this turn as streamed
@@ -444,19 +450,37 @@ export class ClaudeCodeSession implements AgentSession {
             break;
           }
           case "assistant": {
-            // Subagent tool CALLS are shown, nested (T2.4); subagent text and
-            // thinking stay filtered — those come via stream_event, still
-            // dropped above. parentId = the Task tool_use this call belongs to.
+            // Subagent tool CALLS are shown, nested (T2.4), and since SA.2 a
+            // subagent's PROSE rides too: the SDK never forwards subagent
+            // token deltas (stream_event stays main-session-only — the break
+            // above is belt and suspenders), but its COMPLETE assistant
+            // messages arrive live mid-run tagged parent_tool_use_id (SA.0
+            // probe), so text and thinking blocks forward at message grain,
+            // budget-capped per subagent. parentId = the spawn tool_use id.
             const parentId = msg.parent_tool_use_id ?? undefined;
             for (const block of msg.message.content) {
               // Buffered assistant text with no preceding deltas — the
-              // shape slash-command output arrives in. Emit only when this
-              // turn streamed nothing (else it's a duplicate of the stream),
-              // and never for a subagent (its prose stays filtered like its
-              // deltas). Renders the command output that would otherwise vanish (F.1).
+              // shape slash-command output arrives in. For the PARENT, emit
+              // only when this turn streamed nothing (else it's a duplicate
+              // of the stream) — renders the command output that would
+              // otherwise vanish (F.1). For a SUBAGENT there is never a
+              // delta stream to duplicate: forward, capped.
               if (block.type === "text") {
-                if (!parentId && !this.streamedText && typeof block.text === "string" && block.text) {
+                if (typeof block.text !== "string" || !block.text) continue;
+                if (parentId) {
+                  const capped = this.subagentProse.take(parentId, block.text);
+                  if (capped) this.emit({ type: "text_delta", text: capped, parentId });
+                } else if (!this.streamedText) {
                   this.emit({ type: "text_delta", text: block.text });
+                }
+                continue;
+              }
+              // A subagent's reasoning (parent thinking streams via
+              // stream_event above; emitting it here too would duplicate).
+              if (block.type === "thinking") {
+                if (parentId && typeof block.thinking === "string" && block.thinking) {
+                  const capped = this.subagentProse.take(parentId, block.thinking);
+                  if (capped) this.emit({ type: "thinking_delta", text: capped, parentId });
                 }
                 continue;
               }
@@ -552,6 +576,8 @@ export class ClaudeCodeSession implements AgentSession {
   /** The turn's closing frame: surface an error result, report per-turn
    *  usage, reset per-turn state, and end the turn. */
   private handleResultMsg(msg: SDKResultMessage) {
+    // Spawns don't outlive their turn; the narration ledger resets with it.
+    this.subagentProse.clear();
     if (msg.is_error) {
       const detail = "result" in msg ? msg.result : msg.subtype;
       this.emit({ type: "error", message: this.safeEngineText(detail) });

--- a/server/adapters/claude-code.ts
+++ b/server/adapters/claude-code.ts
@@ -409,6 +409,13 @@ export class ClaudeCodeSession implements AgentSession {
     for (const cb of this.listeners) cb(msg);
   }
 
+  /** A subagent's narration/reasoning chunk: budget-capped, then onto its
+   *  deck's lane — or nothing at all once the budget is spent (SA.2). */
+  private emitSubagentProse(parentId: string, type: "text_delta" | "thinking_delta", text: string) {
+    const capped = this.subagentProse.take(parentId, text);
+    if (capped) this.emit({ type, text: capped, parentId });
+  }
+
   private async *promptStream(): AsyncGenerator<SDKUserMessage> {
     while (true) {
       const item = await this.queue.next();
@@ -467,21 +474,15 @@ export class ClaudeCodeSession implements AgentSession {
               // delta stream to duplicate: forward, capped.
               if (block.type === "text") {
                 if (typeof block.text !== "string" || !block.text) continue;
-                if (parentId) {
-                  const capped = this.subagentProse.take(parentId, block.text);
-                  if (capped) this.emit({ type: "text_delta", text: capped, parentId });
-                } else if (!this.streamedText) {
-                  this.emit({ type: "text_delta", text: block.text });
-                }
+                if (parentId) this.emitSubagentProse(parentId, "text_delta", block.text);
+                else if (!this.streamedText) this.emit({ type: "text_delta", text: block.text });
                 continue;
               }
               // A subagent's reasoning (parent thinking streams via
               // stream_event above; emitting it here too would duplicate).
               if (block.type === "thinking") {
-                if (parentId && typeof block.thinking === "string" && block.thinking) {
-                  const capped = this.subagentProse.take(parentId, block.thinking);
-                  if (capped) this.emit({ type: "thinking_delta", text: capped, parentId });
-                }
+                if (parentId && typeof block.thinking === "string" && block.thinking)
+                  this.emitSubagentProse(parentId, "thinking_delta", block.thinking);
                 continue;
               }
               if (block.type !== "tool_use") continue;

--- a/server/adapters/mock.ts
+++ b/server/adapters/mock.ts
@@ -943,41 +943,91 @@ export class MockSession implements AgentSession {
     this.endTurn(d);
   }
 
-  /** Deterministic T2.4 hook: a Task whose inner tool calls nest under it
-   *  (subagent text stays hidden). */
+  /** Deterministic SA.1 hook (supersedes the T2.4 single-Task version): a
+   *  parallel fan-out — three spawns whose inner calls interleave and whose
+   *  finishes land OUT OF ORDER (the first-spawned is not the first done),
+   *  so three live cards tick independently in one transcript. */
   private playSubagent() {
-    const taskId = randomUUID();
     this.beginTurn();
-    this.schedule(() => {
-      this.emit({ type: "status", state: "tool", label: "Task" });
-      this.emit({
-        type: "tool_use",
-        name: "Task",
-        detail: "research: audit the config loader",
-        id: taskId,
-        input: { description: "audit config loader", subagent_type: "Explore" },
-      });
-    }, 350);
-    // Subagent's inner calls — each tagged with the Task's id as parentId.
-    const inner: { name: string; detail: string; output: string }[] = [
-      { name: "Grep", detail: '-rn "loadConfig" src/', output: "src/config.ts:12: export function loadConfig(" },
-      { name: "Read", detail: "src/config.ts", output: Array.from({ length: 4 }, (_, i) => `${i + 1}→${pick(SENTENCES)}`).join("\n") },
-      { name: "Bash", detail: "node -e 'require(\"./config\")'", output: "config OK — 3 sources merged" },
+    type Fan = {
+      id: string;
+      type: string;
+      desc: string;
+      spawnAt: number;
+      inner: { name: string; detail: string; output: string }[];
+      pace: number; // ms between this agent's events — distinct per agent
+      result: string;
+    };
+    const fans: Fan[] = [
+      {
+        id: randomUUID(),
+        type: "Explore",
+        desc: "find auth entry points",
+        spawnAt: 350,
+        pace: 520,
+        inner: [
+          { name: "Grep", detail: '-rn "authenticate" server/', output: "server/auth.ts:14: export function authenticate(" },
+          { name: "Read", detail: "server/auth.ts", output: Array.from({ length: 4 }, (_, i) => `${i + 1}→${pick(SENTENCES)}`).join("\n") },
+          { name: "Grep", detail: '-rn "cookie" server/', output: "server/auth.ts:41: setCookie(res, token)" },
+        ],
+        result: "Two entry points: the socket handshake and the token cookie mint.",
+      },
+      {
+        // Spawned SECOND, finishes FIRST — the out-of-order proof.
+        id: randomUUID(),
+        type: "Explore",
+        desc: "map session handling",
+        spawnAt: 430,
+        pace: 300,
+        inner: [
+          { name: "Grep", detail: '-rn "SessionRegistry" server/', output: "server/sessions/registry.ts:88: export class SessionRegistry" },
+          { name: "Read", detail: "server/sessions/registry.ts", output: "registry: entries keyed by session id; idle unload after 4h" },
+        ],
+        result: "Sessions live in one registry; viewports attach and detach freely.",
+      },
+      {
+        id: randomUUID(),
+        type: "general-purpose",
+        desc: "trace the token path",
+        spawnAt: 510,
+        pace: 640,
+        inner: [
+          { name: "Grep", detail: '-rn "mirafold_token" .', output: "4 hits across server/ and web/" },
+          { name: "Read", detail: "server/relay/relay.ts", output: "120 lines — the relay never sees the token" },
+          { name: "Bash", detail: "node scripts/token-audit.js", output: "token-audit: PASS — daemon-only" },
+          { name: "Read", detail: "web/src/session-bus.ts", output: "the browser holds it in a cookie, never in JS state" },
+        ],
+        result: "The token never leaves the daemon — confirmed end to end.",
+      },
     ];
-    let d = 700;
-    for (const t of inner) {
-      const cid = randomUUID();
-      d += randInt(250, 450);
-      this.schedule(() => this.emit({ type: "tool_use", name: t.name, detail: t.detail, id: cid, parentId: taskId }), d);
-      d += randInt(250, 450);
-      this.schedule(() => this.emit({ type: "tool_result", output: t.output, id: cid, parentId: taskId }), d);
+    let lastDone = 0;
+    for (const fan of fans) {
+      this.schedule(() => {
+        this.emit({ type: "status", state: "tool", label: "Task" });
+        this.emit({
+          type: "tool_use",
+          name: "Task",
+          detail: fan.desc,
+          id: fan.id,
+          input: { description: fan.desc, subagent_type: fan.type },
+        });
+      }, fan.spawnAt);
+      let d = fan.spawnAt;
+      for (const t of fan.inner) {
+        const cid = randomUUID();
+        d += fan.pace;
+        this.schedule(() => this.emit({ type: "tool_use", name: t.name, detail: t.detail, id: cid, parentId: fan.id }), d);
+        d += fan.pace;
+        this.schedule(() => this.emit({ type: "tool_result", output: t.output, id: cid, parentId: fan.id }), d);
+      }
+      d += 250;
+      this.schedule(() => this.emit({ type: "tool_result", output: fan.result, id: fan.id }), d);
+      lastDone = Math.max(lastDone, d);
     }
-    d += 300;
-    this.schedule(
-      () => this.emit({ type: "tool_result", output: "Audit complete: loader merges 3 sources; no precedence bug found.", id: taskId }),
-      d,
+    const d = this.streamText(
+      "All three subagents reported back — auth has two entry points, sessions are registry-kept, and the token stays daemon-side.",
+      lastDone + 300,
     );
-    d = this.streamText("The subagent audited the config loader — it merges three sources correctly, no precedence bug.", d + 200);
     this.endTurn(d);
   }
 

--- a/server/adapters/mock.ts
+++ b/server/adapters/mock.ts
@@ -508,6 +508,7 @@ export class MockSession implements AgentSession {
     if (/revise the selected workspace change/i.test(text)) return this.playMarkdownReview();
     if (/interactive|button/i.test(text)) return this.playActionCard();
     if (/todo|checklist|step by step|plan it/i.test(text)) return this.playChecklist();
+    if (/delegate slowly/i.test(text)) return this.playSlowSubagent();
     if (/subagent|delegate/i.test(text)) return this.playSubagent();
     if (/huge|big output|large output|truncat/i.test(text)) return this.playHugeOutput();
     if (/artifact/i.test(text)) {
@@ -1045,6 +1046,36 @@ export class MockSession implements AgentSession {
       "All three subagents reported back — auth has two entry points, sessions are registry-kept, and the token stays daemon-side.",
       lastDone + 300,
     );
+    this.endTurn(d);
+  }
+
+  /** Deterministic reconnect-window hook (bughunt 2026-08-14 r2): ONE spawn
+   *  whose narration streams early and whose first tool call comes SECONDS
+   *  later — a wide, deterministic window in which the subagent's prose run
+   *  is open, for tests that reset the transcript mid-turn (daemon restart,
+   *  reattach). The fast fan-out's windows are too narrow to hit reliably. */
+  private playSlowSubagent() {
+    const taskId = randomUUID();
+    this.beginTurn();
+    this.schedule(() => {
+      this.emit({ type: "status", state: "tool", label: "Task" });
+      this.emit({
+        type: "tool_use",
+        name: "Task",
+        detail: "survey the workspace",
+        id: taskId,
+        input: { description: "survey the workspace", subagent_type: "Explore" },
+      });
+    }, 300);
+    this.schedule(
+      () => this.emit({ type: "text_delta", text: "Surveying the workspace layout…", parentId: taskId }),
+      700,
+    );
+    const cid = randomUUID();
+    this.schedule(() => this.emit({ type: "tool_use", name: "Read", detail: "README.md", id: cid, parentId: taskId }), 9_000);
+    this.schedule(() => this.emit({ type: "tool_result", output: "read 40 lines", id: cid, parentId: taskId }), 9_300);
+    this.schedule(() => this.emit({ type: "tool_result", output: "Survey complete.", id: taskId }), 9_600);
+    const d = this.streamText("The slow subagent finished its survey.", 9_800);
     this.endTurn(d);
   }
 

--- a/server/adapters/mock.ts
+++ b/server/adapters/mock.ts
@@ -954,6 +954,10 @@ export class MockSession implements AgentSession {
       type: string;
       desc: string;
       spawnAt: number;
+      // SA.2: the subagent's own narration, streamed into its card's
+      // expansion right after the spawn (message-grain, like the real
+      // Claude Code lane).
+      says: string;
       inner: { name: string; detail: string; output: string }[];
       pace: number; // ms between this agent's events — distinct per agent
       result: string;
@@ -965,6 +969,7 @@ export class MockSession implements AgentSession {
         desc: "find auth entry points",
         spawnAt: 350,
         pace: 520,
+        says: "Sweeping the server for authentication entry points…",
         inner: [
           { name: "Grep", detail: '-rn "authenticate" server/', output: "server/auth.ts:14: export function authenticate(" },
           { name: "Read", detail: "server/auth.ts", output: Array.from({ length: 4 }, (_, i) => `${i + 1}→${pick(SENTENCES)}`).join("\n") },
@@ -979,6 +984,7 @@ export class MockSession implements AgentSession {
         desc: "map session handling",
         spawnAt: 430,
         pace: 300,
+        says: "Looking for the session registry and its lifecycle…",
         inner: [
           { name: "Grep", detail: '-rn "SessionRegistry" server/', output: "server/sessions/registry.ts:88: export class SessionRegistry" },
           { name: "Read", detail: "server/sessions/registry.ts", output: "registry: entries keyed by session id; idle unload after 4h" },
@@ -991,6 +997,7 @@ export class MockSession implements AgentSession {
         desc: "trace the token path",
         spawnAt: 510,
         pace: 640,
+        says: "Following the cookie from auth.ts into the relay…",
         inner: [
           { name: "Grep", detail: '-rn "mirafold_token" .', output: "4 hits across server/ and web/" },
           { name: "Read", detail: "server/relay/relay.ts", output: "120 lines — the relay never sees the token" },
@@ -1013,12 +1020,22 @@ export class MockSession implements AgentSession {
         });
       }, fan.spawnAt);
       let d = fan.spawnAt;
+      d += Math.floor(fan.pace / 2);
+      this.schedule(() => this.emit({ type: "text_delta", text: fan.says, parentId: fan.id }), d);
       for (const t of fan.inner) {
         const cid = randomUUID();
         d += fan.pace;
         this.schedule(() => this.emit({ type: "tool_use", name: t.name, detail: t.detail, id: cid, parentId: fan.id }), d);
         d += fan.pace;
         this.schedule(() => this.emit({ type: "tool_result", output: t.output, id: cid, parentId: fan.id }), d);
+      }
+      // One reasoning line mid-run for the slow agent — the expansion shows
+      // thinking dimmer than narration (SA.2).
+      if (fan.type === "general-purpose") {
+        this.schedule(
+          () => this.emit({ type: "thinking_delta", text: "The relay never sees it — confirming the browser side.", parentId: fan.id }),
+          d - fan.pace,
+        );
       }
       d += 250;
       this.schedule(() => this.emit({ type: "tool_result", output: fan.result, id: fan.id }), d);

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -54,8 +54,12 @@ export interface OpenCodeTransport {
     args: string,
     opts: { model?: string; agent?: string },
   ): Promise<void>;
+  // Session-agnostic since SA.3 (POST /permission/{requestID}/reply — the
+  // modern endpoint): a SUBAGENT session's ask is answered by the same call,
+  // no session id required. The per-session endpoint it replaces is marked
+  // deprecated in the live 1.18.18 spec (and, measured in the SA.0 probe,
+  // never validated session↔permission ownership anyway).
   replyPermission(
-    sessionID: string,
     permissionID: string,
     // Never "always": that would persist an approval into the user's own
     // OpenCode state, which is theirs to grant in their own tool.
@@ -425,15 +429,11 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
     });
   }
 
-  async replyPermission(
-    sessionID: string,
-    permissionID: string,
-    response: "once" | "reject",
-  ): Promise<void> {
-    await this.request(
-      `/session/${encodeURIComponent(sessionID)}/permissions/${encodeURIComponent(permissionID)}`,
-      { method: "POST", body: JSON.stringify({ response }) },
-    );
+  async replyPermission(permissionID: string, response: "once" | "reject"): Promise<void> {
+    await this.request(`/permission/${encodeURIComponent(permissionID)}/reply`, {
+      method: "POST",
+      body: JSON.stringify({ reply: response }),
+    });
   }
 
   close(): void {

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from "node:crypto";
 import type { WireMsg } from "../protocol";
-import { capOutput, toolDetail, type TodoItem } from "./types";
+import { capOutput, toolDetail, SubagentProseBudget, type TodoItem } from "./types";
 import { generativeUIMsg, MIRAFOLD_MCP, RENDER_ID_RE } from "./render-mcp-cmd";
 import type { OpenCodeEvent } from "./opencode-client";
 
@@ -46,20 +46,35 @@ export class OpenCodeEventMapper {
   private lastModel?: string;
   private lastStatus?: "thinking" | "tool";
   private todoRenderId?: string;
+  // SA.3, the subagent lane: a child session's traffic maps to its spawn's
+  // task PART id — the same opaque handle every wire lane groups by. Edges
+  // come from the parent task part's state.metadata ({sessionId,
+  // parentSessionId} — the SA.0 probe's join key, lowercase d) and from
+  // child `session.created` (Session.parentID), resolved transitively so a
+  // user-configured NESTED grandchild lands on its nearest stream-visible
+  // ancestor's card. Cleared per turn like the part maps — a `background:
+  // true` child outliving its turn goes unroutable and is skipped, exactly
+  // as all child traffic was before the lane existed.
+  private sessionParents = new Map<string, string>();
+  private spawnParts = new Map<string, string>();
+  private subagentProse = new SubagentProseBudget();
 
   constructor(
     private readonly options: {
       emit: (msg: WireMsg) => void;
       workspaceDir: string;
-      /** The one session this mapper narrates. Subagent child sessions share
-       *  the event stream under their own ids and are skipped whole — their
-       *  work surfaces through the parent's `task` tool part. */
+      /** The ROOT session this mapper narrates. Subagent child sessions
+       *  share the event stream under their own ids and ride the subagent
+       *  lane (SA.3): their calls and prose group under the parent task
+       *  part's id via `laneOf`, never the top-level transcript. */
       isOurs: (sessionID: unknown) => boolean;
       learnModel: (modelID: string) => void;
       onPermissionAsked: (ask: {
         id: string;
         permission: string;
         detail: string;
+        /** Set when the asker is a subagent — the lane's opaque handle. */
+        parentId?: string;
       }) => void;
       /** A reply observed on the stream (answered by another client, e.g. a
        *  TUI attached to the same engine session) — not our own echo. */
@@ -80,6 +95,27 @@ export class OpenCodeEventMapper {
     // still find its track — a fresh default would re-emit its whole text.
     this.parts.clear();
     this.roles.clear();
+    // The subagent lane resets on the same schedule and for the same reason.
+    this.sessionParents.clear();
+    this.spawnParts.clear();
+    this.subagentProse.clear();
+  }
+
+  /** Which lane a session's traffic belongs to: "root" for the session this
+   *  mapper narrates; the spawn part id (the opaque wire handle) for a
+   *  child, resolved transitively — a configured nested grandchild lands on
+   *  its nearest stream-visible ancestor's card; undefined = unroutable,
+   *  skipped whole (pre-SA.3 behavior). */
+  private laneOf(sessionID: unknown): "root" | string | undefined {
+    if (this.options.isOurs(sessionID)) return "root";
+    let cursor = typeof sessionID === "string" ? sessionID : undefined;
+    for (let hops = 0; cursor !== undefined && hops < 16; hops++) {
+      const parent = this.sessionParents.get(cursor);
+      if (parent === undefined) return undefined;
+      if (this.options.isOurs(parent)) return this.spawnParts.get(cursor);
+      cursor = parent;
+    }
+    return undefined;
   }
 
   endTurn() {
@@ -106,23 +142,45 @@ export class OpenCodeEventMapper {
       case "todo.updated":
         if (this.options.isOurs(p["sessionID"])) this.onTodos(p["todos"]);
         break;
+      case "session.created": {
+        // A child spawn's session edge (SA.3). The task part's metadata is
+        // what yields the CARD handle; this edge is what makes transitive
+        // (grandchild) resolution possible.
+        const info = p["info"] as Record<string, unknown> | undefined;
+        const id = info?.["id"];
+        const parentID = info?.["parentID"];
+        if (
+          typeof id === "string" &&
+          typeof parentID === "string" &&
+          this.sessionParents.size < MAX_PARTS_PER_TURN
+        )
+          this.sessionParents.set(id, parentID);
+        break;
+      }
       case "permission.asked": {
-        if (!this.options.isOurs(p["sessionID"])) break;
+        // A SUBAGENT's ask surfaces too (SA.3) — before the lane, child asks
+        // were dropped whole and a gated subagent hung with no UI and no
+        // deny timer (SA.0 finding). Unroutable sessions stay skipped.
+        const lane = this.laneOf(p["sessionID"]);
+        if (lane === undefined) break;
         const patterns = Array.isArray(p["patterns"]) ? p["patterns"].map(String) : [];
         this.options.onPermissionAsked({
           id: String(p["id"]),
           permission: String(p["permission"] ?? "tool"),
           detail: patterns.join(", ") || String(p["permission"] ?? ""),
+          ...(lane !== "root" ? { parentId: lane } : {}),
         });
         break;
       }
       case "permission.replied":
-        if (this.options.isOurs(p["sessionID"]))
+        if (this.laneOf(p["sessionID"]) !== undefined)
           this.options.onPermissionReplied(String(p["requestID"]), String(p["reply"]));
         break;
       case "session.error": {
         // `sessionID` can be absent on transport-level errors; treat those as
-        // ours rather than swallow them.
+        // ours rather than swallow them. A KNOWN child's error is NOT the
+        // root turn's death — it surfaces honestly as the spawn part's error
+        // result on the parent stream (SA.3).
         if (p["sessionID"] !== undefined && !this.options.isOurs(p["sessionID"])) break;
         this.options.emit({ type: "error", message: `OpenCode error: ${sessionErrorText(p)}` });
         this.options.endTurn();
@@ -155,9 +213,17 @@ export class OpenCodeEventMapper {
 
   private onMessage(p: Record<string, unknown>) {
     const info = p["info"] as Record<string, unknown> | undefined;
-    if (!info || !this.options.isOurs(info["sessionID"] ?? p["sessionID"])) return;
+    if (!info) return;
+    const lane = this.laneOf(info["sessionID"] ?? p["sessionID"]);
+    if (lane === undefined) return;
+    // Roles are tracked for CHILD messages too (SA.3): a child's user-role
+    // message is the task prompt, and its parts must never replay as the
+    // subagent's own narration — the same echo rule the root obeys.
     if (typeof info["role"] === "string" && this.roles.size < MAX_PARTS_PER_TURN)
       this.roles.set(String(info["id"]), info["role"]);
+    // Usage and model stay the ROOT conversation's: the status bar counts
+    // the session's own context weight, as before the lane.
+    if (lane !== "root") return;
     if (info["role"] !== "assistant") return;
     const modelID = typeof info["modelID"] === "string" ? info["modelID"] : undefined;
     if (modelID) {
@@ -216,40 +282,46 @@ export class OpenCodeEventMapper {
 
   private onPartSnapshot(p: Record<string, unknown>) {
     const part = p["part"] as Record<string, unknown> | undefined;
-    if (!part || !this.options.isOurs(part["sessionID"] ?? p["sessionID"])) return;
+    if (!part) return;
+    const lane = this.laneOf(part["sessionID"] ?? p["sessionID"]);
+    if (lane === undefined) return;
+    const parentId = lane === "root" ? undefined : lane;
     const partID = String(part["id"]);
     const type = String(part["type"]);
     const fromUser = this.roles.get(String(part["messageID"])) === "user";
     switch (type) {
       case "step-start":
-        this.status("thinking");
+        // A child's step boundaries never steer the root activity line.
+        if (!parentId) this.status("thinking");
         break;
       case "text": {
         if (fromUser) break; // the prompt's own echo — never replayed as output
         const track = this.track(partID, "text");
-        if (track) this.emitTextSuffix(track, String(part["text"] ?? ""));
+        if (track) this.emitTextSuffix(track, String(part["text"] ?? ""), parentId);
         break;
       }
       case "reasoning": {
         if (fromUser) break;
-        this.status("thinking");
+        if (!parentId) this.status("thinking");
         const track = this.track(partID, "reasoning");
         if (!track) break;
         // A delta that beat this snapshot registered the part as "text";
         // the snapshot is authoritative — correct the lane for the rest of
         // the stream (bughunt round 2, latent).
         track.kind = "reasoning";
-        this.emitTextSuffix(track, String(part["text"] ?? ""));
+        this.emitTextSuffix(track, String(part["text"] ?? ""), parentId);
         break;
       }
       case "tool":
-        this.onToolPart(partID, part);
+        this.onToolPart(partID, part, parentId);
         break;
     }
   }
 
   private onPartDelta(p: Record<string, unknown>) {
-    if (!this.options.isOurs(p["sessionID"])) return;
+    const lane = this.laneOf(p["sessionID"]);
+    if (lane === undefined) return;
+    const parentId = lane === "root" ? undefined : lane;
     if (p["field"] !== "text") return;
     if (this.roles.get(String(p["messageID"])) === "user") return;
     // Deltas can beat the part's first snapshot; an unknown part defaults to
@@ -258,24 +330,38 @@ export class OpenCodeEventMapper {
     const delta = String(p["delta"] ?? "");
     if (!track || !delta || track.kind === "tool" || track.kind === "other") return;
     track.emitted += delta.length;
-    this.emitStreamText(track, delta);
+    this.emitStreamText(track, delta, parentId);
   }
 
-  private emitTextSuffix(track: PartTrack, text: string) {
+  private emitTextSuffix(track: PartTrack, text: string, parentId?: string) {
     if (text.length <= track.emitted) return;
     const suffix = text.slice(track.emitted);
     track.emitted = text.length;
-    this.emitStreamText(track, suffix);
+    this.emitStreamText(track, suffix, parentId);
   }
 
-  private emitStreamText(track: PartTrack, text: string) {
+  private emitStreamText(track: PartTrack, text: string, parentId?: string) {
+    // A subagent's prose rides its card's lane, budget-capped (SA.3 — the
+    // same per-subagent cap the Claude Code lane applies). `emitted` above
+    // tracks SOURCE position either way, so a capped card still consumes
+    // the stream correctly and later suffixes stay aligned.
+    if (parentId) {
+      const capped = this.subagentProse.take(parentId, text);
+      if (!capped) return;
+      this.options.emit({
+        type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
+        text: capped,
+        parentId,
+      });
+      return;
+    }
     this.options.emit({
       type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
       text,
     });
   }
 
-  private onToolPart(partID: string, part: Record<string, unknown>) {
+  private onToolPart(partID: string, part: Record<string, unknown>, parentId?: string) {
     const track = this.track(partID, "tool");
     if (!track) return;
     track.kind = "tool";
@@ -283,12 +369,34 @@ export class OpenCodeEventMapper {
     const state = (part["state"] ?? {}) as Record<string, unknown>;
     const status = String(state["status"] ?? "");
     const input = (state["input"] ?? {}) as Record<string, unknown>;
+    // SA.3: a ROOT tool part whose metadata names a spawned session is the
+    // card anchor — record the join (the SA.0 probe's key: metadata
+    // {sessionId, parentSessionId}, lowercase d, engine casing verbatim).
+    // Read shape-wise, not by tool name, so the lane stays name-agnostic.
+    if (!parentId) {
+      const meta = state["metadata"] as Record<string, unknown> | undefined;
+      const childSession = meta?.["sessionId"];
+      const parentSession = meta?.["parentSessionId"];
+      if (
+        typeof childSession === "string" &&
+        typeof parentSession === "string" &&
+        this.spawnParts.size < MAX_PARTS_PER_TURN
+      ) {
+        this.spawnParts.set(childSession, partID);
+        this.sessionParents.set(childSession, parentSession);
+      }
+    }
     if (tool.startsWith(MCP_PREFIX)) {
-      this.onMirafoldTool(partID, track, tool, state, input);
-      return;
+      // A SUBAGENT's render call does not paint — paintings are session-level
+      // chrome, and a card's content is calls + prose (SA charter). It gets
+      // the honest tool record instead, nested in its card.
+      if (!parentId) {
+        this.onMirafoldTool(partID, track, tool, state, input);
+        return;
+      }
     }
     if (status === "running" || status === "completed" || status === "error")
-      this.announceTool(track, partID, tool, input);
+      this.announceTool(track, partID, tool, input, parentId);
     if (track.finished) return;
     if (status === "completed") {
       track.finished = true;
@@ -298,6 +406,7 @@ export class OpenCodeEventMapper {
         output: text,
         id: partID,
         ...(truncatedBytes ? { truncatedBytes } : {}),
+        ...(parentId ? { parentId } : {}),
       });
     } else if (status === "error") {
       track.finished = true;
@@ -311,6 +420,7 @@ export class OpenCodeEventMapper {
         isError: true,
         id: partID,
         ...(truncatedBytes ? { truncatedBytes } : {}),
+        ...(parentId ? { parentId } : {}),
       });
     }
   }
@@ -320,16 +430,19 @@ export class OpenCodeEventMapper {
     partID: string,
     tool: string,
     input: Record<string, unknown>,
+    parentId?: string,
   ) {
     if (track.announced) return;
     track.announced = true;
-    this.status("tool", tool);
+    // A child's tool churn never steers the root activity line (SA.3).
+    if (!parentId) this.status("tool", tool);
     this.options.emit({
       type: "tool_use",
       name: tool,
       detail: toolDetail(input),
       id: partID,
       input,
+      ...(parentId ? { parentId } : {}),
     });
   }
 

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -52,7 +52,7 @@ export class OpenCodeEventMapper {
   // parentSessionId} — the SA.0 probe's join key, lowercase d) and from
   // child `session.created` (Session.parentID), resolved transitively so a
   // user-configured NESTED grandchild lands on its nearest stream-visible
-  // ancestor's card. Cleared per turn like the part maps — a `background:
+  // ancestor's deck. Cleared per turn like the part maps — a `background:
   // true` child outliving its turn goes unroutable and is skipped, exactly
   // as all child traffic was before the lane existed.
   private sessionParents = new Map<string, string>();
@@ -104,7 +104,7 @@ export class OpenCodeEventMapper {
   /** Which lane a session's traffic belongs to: "root" for the session this
    *  mapper narrates; the spawn part id (the opaque wire handle) for a
    *  child, resolved transitively — a configured nested grandchild lands on
-   *  its nearest stream-visible ancestor's card; undefined = unroutable,
+   *  its nearest stream-visible ancestor's deck; undefined = unroutable,
    *  skipped whole (pre-SA.3 behavior). */
   private laneOf(sessionID: unknown): "root" | string | undefined {
     if (this.options.isOurs(sessionID)) return "root";
@@ -144,7 +144,7 @@ export class OpenCodeEventMapper {
         break;
       case "session.created": {
         // A child spawn's session edge (SA.3). The task part's metadata is
-        // what yields the CARD handle; this edge is what makes transitive
+        // what yields the DECK handle; this edge is what makes transitive
         // (grandchild) resolution possible.
         const info = p["info"] as Record<string, unknown> | undefined;
         const id = info?.["id"];
@@ -341,7 +341,7 @@ export class OpenCodeEventMapper {
   }
 
   private emitStreamText(track: PartTrack, text: string, parentId?: string) {
-    // A subagent's prose rides its card's lane, budget-capped (SA.3 — the
+    // A subagent's prose rides its deck's lane, budget-capped (SA.3 — the
     // same per-subagent cap the Claude Code lane applies). `emitted` above
     // tracks SOURCE position either way, so a capped card still consumes
     // the stream correctly and later suffixes stay aligned.
@@ -370,7 +370,7 @@ export class OpenCodeEventMapper {
     const status = String(state["status"] ?? "");
     const input = (state["input"] ?? {}) as Record<string, unknown>;
     // SA.3: a ROOT tool part whose metadata names a spawned session is the
-    // card anchor — record the join (the SA.0 probe's key: metadata
+    // deck anchor — record the join (the SA.0 probe's key: metadata
     // {sessionId, parentSessionId}, lowercase d, engine casing verbatim).
     // Read shape-wise, not by tool name, so the lane stays name-agnostic.
     if (!parentId) {
@@ -389,7 +389,7 @@ export class OpenCodeEventMapper {
     if (tool.startsWith(MCP_PREFIX)) {
       // A SUBAGENT's render call does not paint — paintings are session-level
       // chrome, and a card's content is calls + prose (SA charter). It gets
-      // the honest tool record instead, nested in its card.
+      // the honest tool record instead, nested in its deck.
       if (!parentId) {
         this.onMirafoldTool(partID, track, tool, state, input);
         return;

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -52,9 +52,12 @@ export class OpenCodeEventMapper {
   // parentSessionId} — the SA.0 probe's join key, lowercase d) and from
   // child `session.created` (Session.parentID), resolved transitively so a
   // user-configured NESTED grandchild lands on its nearest stream-visible
-  // ancestor's deck. Cleared per turn like the part maps — a `background:
-  // true` child outliving its turn goes unroutable and is skipped, exactly
-  // as all child traffic was before the lane existed.
+  // ancestor's deck. SESSION-lifetime, not per-turn (bughunt 2026-08-14):
+  // a `background: true` child outlives its spawning turn, and clearing
+  // these at the next startTurn made it unroutable — dropping, among other
+  // things, its permission ask (the SA.0 hang, resurrected). The transcript
+  // keeps old spawn records, so a late child event routing to a past turn's
+  // deck is CORRECT. Growth stays bounded by the insert-time size caps.
   private sessionParents = new Map<string, string>();
   private spawnParts = new Map<string, string>();
   private subagentProse = new SubagentProseBudget();
@@ -95,9 +98,9 @@ export class OpenCodeEventMapper {
     // still find its track — a fresh default would re-emit its whole text.
     this.parts.clear();
     this.roles.clear();
-    // The subagent lane resets on the same schedule and for the same reason.
-    this.sessionParents.clear();
-    this.spawnParts.clear();
+    // The narration budget is turn-scoped; the lane's session-edge maps are
+    // deliberately NOT cleared here — see their declaration (a background
+    // child outlives its turn and must stay routable).
     this.subagentProse.clear();
   }
 

--- a/server/adapters/opencode-events.ts
+++ b/server/adapters/opencode-events.ts
@@ -343,21 +343,14 @@ export class OpenCodeEventMapper {
   private emitStreamText(track: PartTrack, text: string, parentId?: string) {
     // A subagent's prose rides its deck's lane, budget-capped (SA.3 — the
     // same per-subagent cap the Claude Code lane applies). `emitted` above
-    // tracks SOURCE position either way, so a capped card still consumes
+    // tracks SOURCE position either way, so a capped deck still consumes
     // the stream correctly and later suffixes stay aligned.
-    if (parentId) {
-      const capped = this.subagentProse.take(parentId, text);
-      if (!capped) return;
-      this.options.emit({
-        type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
-        text: capped,
-        parentId,
-      });
-      return;
-    }
+    const forwarded = parentId ? this.subagentProse.take(parentId, text) : text;
+    if (!forwarded) return;
     this.options.emit({
       type: track.kind === "reasoning" ? "thinking_delta" : "text_delta",
-      text,
+      text: forwarded,
+      ...(parentId ? { parentId } : {}),
     });
   }
 

--- a/server/adapters/opencode-live.ltest.ts
+++ b/server/adapters/opencode-live.ltest.ts
@@ -79,12 +79,34 @@ function startFakeModel(): Promise<{ port: number; close: () => void }> {
           usage: { prompt_tokens: 10, completion_tokens: 4, total_tokens: 14 },
         });
       };
+      // Routing is by the LAST user message — the turn's actual prompt —
+      // because with the SA.3 subagent turn in the transcript, whole-history
+      // matching would misroute the resume turn.
+      const lastUser = JSON.stringify(
+        [...messages].reverse().find((m) => m.role === "user")?.content ?? "",
+      );
       const renderDone = flat.includes("Rendered card");
       const probeTurn = flat.includes("probe command");
       const bashDone = messages.some(
         (m) => m.role === "tool" && /oc5-live/.test(JSON.stringify(m.content ?? "")),
       );
-      if (!renderDone) toolCall("mirafold_render_card", { title: "Live Probe", body: "OC.5 end to end" });
+      if (/CHILD_TASK/.test(lastUser)) {
+        // The CHILD conversation (SA.3): a permission-gated bash, then its
+        // report — narration the lane must carry.
+        const childBashDone = messages.some(
+          (m) => m.role === "tool" && /oc5-child/.test(JSON.stringify(m.content ?? "")),
+        );
+        if (!childBashDone) toolCall("bash", { command: "echo oc5-child", description: "child probe" });
+        else text("CHILD DONE — reporting back from inside the subagent.");
+      } else if (/spawn the subagent/.test(lastUser)) {
+        if (!flat.includes("CHILD DONE"))
+          toolCall("task", {
+            description: "live probe child",
+            prompt: "CHILD_TASK: run the child probe exactly once, then stop.",
+            subagent_type: "general",
+          });
+        else text("FANOUT DONE");
+      } else if (!renderDone) toolCall("mirafold_render_card", { title: "Live Probe", body: "OC.5 end to end" });
       else if (!probeTurn) text("CARD DONE");
       else if (!bashDone) toolCall("bash", { command: "echo oc5-live", description: "probe" });
       else text("BASH DONE");
@@ -187,6 +209,37 @@ test("OC.5: real engine — render, permission, usage, resume, all through the s
     );
     // The fake provider is the user's own config — no gray disclosure rides.
     assert.equal(first.msgs.filter((m) => m.type === "notice").length, 0);
+
+    // Turn 3 (SA.3): a REAL subagent — the engine's task tool spawns a child
+    // session on the same server; its permission ask, calls, and prose all
+    // ride the lane, attributed to the spawn card.
+    first.session.pushPrompt("now spawn the subagent");
+    await waitFor(
+      () => first.msgs.some((m) => m.type === "permission_request" && m.parentId),
+      "the child's attributed ask",
+      60_000,
+      () => seenTypes(first),
+    );
+    const childAsk = first.msgs.find((m) => m.type === "permission_request" && m.parentId)!;
+    first.session.resolvePermission(childAsk.id, true);
+    await waitFor(() => first.turnEnds() >= 3, "turn 3 (fan-out)", 120_000, () => seenTypes(first));
+    const spawnRow = first.msgs.find((m) => m.type === "tool_use" && m.name === "task")!;
+    assert.equal(spawnRow.parentId, undefined, "the spawn is the card anchor, un-nested");
+    assert.equal(childAsk.parentId, spawnRow.id, "the ask is attributed to the spawn card");
+    assert.ok(
+      first.msgs.some((m) => m.type === "tool_use" && m.parentId === spawnRow.id && m.name === "bash"),
+      "the child's bash rode the lane",
+    );
+    assert.ok(
+      first.msgs.some(
+        (m) => m.type === "text_delta" && m.parentId === spawnRow.id && /CHILD DONE/.test(m.text),
+      ),
+      "the child's narration rode the lane",
+    );
+    assert.ok(
+      first.msgs.some((m) => m.type === "text_delta" && !m.parentId && /FANOUT DONE/.test(m.text)),
+      "the parent's own reply stayed top-level",
+    );
 
     // Resume: engine-side persistence across a full server restart.
     const resumeId = first.session.resumeId;

--- a/server/adapters/opencode.spike.md
+++ b/server/adapters/opencode.spike.md
@@ -186,9 +186,20 @@ The relay gate is untouched: `allowedOverRelay` already refuses
   (their whitelist/blacklist config already applied server-side).
   `modelName` = the per-prompt `modelID`, known at selection — better than
   the mid-stream refinement the other adapters need.
-- **Subagents** (`@general`, `@explore`, `@scout`): their invocations arrive
-  as `subtask`/`agent` parts — v1 renders them as ordinary transcript
-  activity; child-session navigation is TUI chrome we don't reproduce.
+- **Subagents** (`@general`, `@explore`, `@scout`): *(corrected 2026-08-14 by
+  the SA.0 live probe — the original claim here, "invocations arrive as
+  `subtask`/`agent` parts", was incomplete: `SubtaskPart` is the COMMAND
+  input path and `AgentPart` an @-mention marker.)* The model-initiated
+  spawn is a **`task` TOOL part on the parent session** plus a child
+  `session.created` whose `Session.parentID` points at the parent; the join
+  key from Task row to child is the tool part's `state.metadata.sessionId`
+  (lowercase d — engine casing inconsistency, verbatim). The child's own
+  text/tool/step parts, token-grain `message.part.delta`s, `permission.asked`
+  (child `sessionID`) and `session.idle` all ride the SAME global `/event`
+  stream. Captured sequence: `server/testing/opencode-subagent-fixture.ts`
+  (probe recipe: the OC.5 scripted-provider jail + a parent turn scripted to
+  call `task` with `subagent_type: "general"`). The command path converges on
+  the same task tool part, so one lane rule covers both.
 
 ## SDK vs raw HTTP — recommendation: take `@opencode-ai/sdk`
 

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -473,6 +473,59 @@ test("SA.3: the captured subagent run maps whole — spawn card anchor, parented
   session.close();
 });
 
+test("a background child stays routable ACROSS turns — its ask surfaces instead of hanging (bughunt 2026-08-14)", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("spawn a background task");
+  // Turn 1: the spawn edge is learned, the parent turn completes.
+  feed(
+    ev("message.part.updated", {
+      sessionID: SES,
+      part: {
+        sessionID: SES,
+        messageID: "m1",
+        id: "prt_bg",
+        type: "tool",
+        tool: "task",
+        callID: "c1",
+        state: {
+          status: "completed",
+          input: { description: "bg child" },
+          output: "started in background",
+          metadata: { sessionId: "ses_bg", parentSessionId: SES, background: true },
+        },
+      },
+    }),
+    ev("session.created", { sessionID: "ses_bg", info: { id: "ses_bg", parentID: SES } }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  // Turn 2 begins (startTurn resets the per-turn maps); only NOW does the
+  // still-running background child ask and speak. Before the fix the lane
+  // maps cleared with the turn and both events were dropped — the ask hang.
+  await prompt("meanwhile…");
+  feed(
+    ev("permission.asked", {
+      sessionID: "ses_bg",
+      id: "per_bg1",
+      permission: "bash",
+      patterns: ["touch x"],
+    }),
+    ev("message.part.updated", {
+      sessionID: "ses_bg",
+      part: { sessionID: "ses_bg", messageID: "m9", id: "p9", type: "text", text: "still working" },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd(2);
+  const ask = msgs.find((m) => m.type === "permission_request" && m.id === "per_bg1")!;
+  assert.equal(ask.parentId, "prt_bg", "the cross-turn ask surfaced, attributed to its deck");
+  assert.ok(
+    msgs.some((m) => m.type === "text_delta" && m.parentId === "prt_bg" && /still working/.test(m.text)),
+    "the cross-turn prose still routes to the deck",
+  );
+  session.close();
+});
+
 test("SA.3: a grandchild resolves transitively to the nearest stream-visible card", async () => {
   const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
   await prompt("go");

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -8,6 +8,7 @@ import { RENDER_GUIDANCE } from "../render-tools";
 import { OpenCodeSession } from "./opencode";
 import type { OpenCodeEvent, OpenCodeTransport } from "./opencode-client";
 import { waitFor } from "../testing/wait-for";
+import { OPENCODE_SUBAGENT_EVENTS } from "../testing/opencode-subagent-fixture";
 
 // OC.1: the OpenCode event→WireMsg mapping and the turn grammar, on synthetic
 // events whose shapes are the OC.0 live capture (opencode.spike.md) — no
@@ -83,7 +84,7 @@ class FakeTransport implements OpenCodeTransport {
   async abort(_sessionID: string) {
     this.aborts++;
   }
-  async replyPermission(_sessionID: string, permissionID: string, response: "once" | "reject") {
+  async replyPermission(permissionID: string, response: "once" | "reject") {
     this.replies.push({ permissionID, response });
   }
   close() {
@@ -397,7 +398,7 @@ test("the user message's own echoed parts never replay as output", async () => {
   session.close();
 });
 
-test("subagent child-session events are skipped whole", async () => {
+test("an UNROUTABLE session's events are skipped whole (no spawn edge, no lane — SA.3 fallback)", async () => {
   const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
   await prompt("hi");
   feed(
@@ -411,6 +412,156 @@ test("subagent child-session events are skipped whole", async () => {
   await awaitTurnEnd();
   assert.equal(msgs.some((m) => m.type === "text_delta"), false);
   assert.equal(msgs.filter((m) => m.type === "turn_end").length, 1);
+  session.close();
+});
+
+// ---- SA.3: the subagent lane, proven against the SA.0 live capture. The
+// fixture is a REAL `opencode serve` 1.18.18 subagent run recorded raw; ids
+// (part, message, permission) are verbatim, sessions normalized.
+
+function feedFixture(feed: (...evs: OpenCodeEvent[]) => void, rootAs: string) {
+  for (const e of OPENCODE_SUBAGENT_EVENTS) {
+    const rewritten = JSON.parse(
+      JSON.stringify(e).replaceAll("ses_sa0probe00000000000root", rootAs),
+    ) as OpenCodeEvent;
+    feed(rewritten);
+  }
+}
+
+const FIXTURE_CHILD = "ses_sa0probe0000000000child";
+
+test("SA.3: the captured subagent run maps whole — spawn card anchor, parented calls and prose, ask surfaced, no early turn end", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("spawn the probe subagent");
+  // The fixture's join key: the root task part that announced the child.
+  const spawnEvent = OPENCODE_SUBAGENT_EVENTS.find((e) => {
+    const part = (e.properties as Record<string, any>)["part"];
+    return part?.tool === "task" && part?.state?.metadata?.sessionId === FIXTURE_CHILD;
+  })!;
+  const spawnPartId = (spawnEvent.properties as Record<string, any>)["part"]["id"] as string;
+  feedFixture(feed, SES);
+  await awaitTurnEnd();
+
+  // The spawn announces un-parented — it IS the card anchor.
+  const spawn = msgs.find((m) => m.type === "tool_use" && m.id === spawnPartId)!;
+  assert.equal(spawn.name, "task");
+  assert.equal(spawn.parentId, undefined);
+  // The child's bash rides the lane, tagged with the spawn part id.
+  const childBash = msgs.find((m) => m.type === "tool_use" && m.name === "bash")!;
+  assert.equal(childBash.parentId, spawnPartId);
+  assert.equal(
+    msgs.find((m) => m.type === "tool_result" && m.id === childBash.id)?.parentId,
+    spawnPartId,
+  );
+  // The child's prose rides too, parented (never as top-level transcript).
+  const childProse = msgs.filter((m) => m.type === "text_delta" && m.parentId === spawnPartId);
+  assert.ok(childProse.length >= 1, "child narration forwarded on the lane");
+  assert.ok(
+    childProse.some((m) => /CHILD DONE/.test(m.text)),
+    "the child's own words arrived verbatim",
+  );
+  // The child's permission ask SURFACED, attributed to the card — before
+  // SA.3 it was dropped whole and the subagent hung (SA.0 finding).
+  const ask = msgs.find((m) => m.type === "permission_request")!;
+  assert.equal(ask.tool, "bash");
+  assert.equal(ask.parentId, spawnPartId);
+  // The fixture's own reply event resolves it (another-client path).
+  assert.ok(msgs.some((m) => m.type === "permission_resolved" && m.id === ask.id));
+  // The child's session.idle must NOT have ended the turn — exactly one
+  // turn_end, and it comes after the parent's own idle.
+  assert.equal(msgs.filter((m) => m.type === "turn_end").length, 1);
+  session.close();
+});
+
+test("SA.3: a grandchild resolves transitively to the nearest stream-visible card", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("go");
+  feed(
+    // Root spawns a child (task part metadata = the join key)…
+    ev("message.part.updated", {
+      sessionID: SES,
+      part: {
+        sessionID: SES,
+        messageID: "m1",
+        id: "prt_spawn",
+        type: "tool",
+        tool: "task",
+        callID: "c1",
+        state: {
+          status: "running",
+          input: { description: "child" },
+          metadata: { sessionId: "ses_kid", parentSessionId: SES },
+        },
+      },
+    }),
+    ev("session.created", { sessionID: "ses_kid", info: { id: "ses_kid", parentID: SES } }),
+    // …and the child (user-configured nesting) spawns a grandchild.
+    ev("session.created", { sessionID: "ses_grand", info: { id: "ses_grand", parentID: "ses_kid" } }),
+    ev("message.part.updated", {
+      sessionID: "ses_grand",
+      part: {
+        sessionID: "ses_grand",
+        messageID: "m2",
+        id: "prt_g1",
+        type: "tool",
+        tool: "grep",
+        callID: "c2",
+        state: { status: "completed", input: { pattern: "x" }, output: "hit" },
+      },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  // The grandchild's call lands on the CHILD's card — the nearest
+  // stream-visible ancestor — documented degradation, never breakage.
+  const grand = msgs.find((m) => m.type === "tool_use" && m.id === "prt_g1")!;
+  assert.equal(grand.parentId, "prt_spawn");
+  session.close();
+});
+
+test("SA.3: a subagent's render call gets the honest tool record, never a painting", async () => {
+  const { session, msgs, prompt, feed, awaitTurnEnd } = makeSession();
+  await prompt("go");
+  feed(
+    ev("message.part.updated", {
+      sessionID: SES,
+      part: {
+        sessionID: SES,
+        messageID: "m1",
+        id: "prt_spawn",
+        type: "tool",
+        tool: "task",
+        callID: "c1",
+        state: {
+          status: "running",
+          input: { description: "child" },
+          metadata: { sessionId: "ses_kid", parentSessionId: SES },
+        },
+      },
+    }),
+    ev("message.part.updated", {
+      sessionID: "ses_kid",
+      part: {
+        sessionID: "ses_kid",
+        messageID: "m2",
+        id: "prt_r1",
+        type: "tool",
+        tool: "mirafold_render_card",
+        callID: "c2",
+        state: {
+          status: "completed",
+          input: { title: "T", body: "B" },
+          output: "rendered mirafold-id=abc123",
+        },
+      },
+    }),
+    idle(),
+  );
+  await awaitTurnEnd();
+  assert.equal(msgs.some((m) => m.type === "render"), false, "no painting from inside a card");
+  const row = msgs.find((m) => m.type === "tool_use" && m.id === "prt_r1")!;
+  assert.equal(row.parentId, "prt_spawn");
+  assert.ok(msgs.some((m) => m.type === "tool_result" && m.id === "prt_r1" && m.parentId === "prt_spawn"));
   session.close();
 });
 

--- a/server/adapters/opencode.ts
+++ b/server/adapters/opencode.ts
@@ -536,23 +536,37 @@ export class OpenCodeSession implements AgentSession {
     this.turnDone = undefined;
   }
 
-  private onPermissionAsked(ask: { id: string; permission: string; detail: string }) {
+  private onPermissionAsked(ask: {
+    id: string;
+    permission: string;
+    detail: string;
+    parentId?: string;
+  }) {
     if (this.closed || this.pendingPermissions.has(ask.id)) return;
     // Cap concurrent unanswered asks: a hostile/looping engine spamming
     // distinct permission ids can't grow this map + its timers without bound
     // (audit 2026-08-13 hardening). Beyond the cap the ask is auto-denied at
     // the engine — the same deny-by-default the timeout applies, just now.
     if (this.pendingPermissions.size >= MAX_PENDING_PERMISSIONS) {
-      if (this.sessionID) void this.transport.replyPermission(this.sessionID, ask.id, "reject").catch(() => {});
+      void this.transport.replyPermission(ask.id, "reject").catch(() => {});
       return;
     }
     // Deny-by-default: an unanswered ask must not pin the turn open forever.
+    // A SUBAGENT's ask (parentId set — SA.3) rides the same bar, same timer,
+    // same deny-by-default; before the lane opened these were dropped whole
+    // and a gated subagent simply hung (SA.0 finding).
     const timer = setTimeout(() => {
       const pending = this.pendingPermissions.get(ask.id);
       if (pending !== undefined) this.resolvePermissionInternal(ask.id, false, pending, true);
     }, this.permissionTimeoutMs);
     this.pendingPermissions.set(ask.id, timer);
-    this.emit({ type: "permission_request", tool: ask.permission, detail: ask.detail, id: ask.id });
+    this.emit({
+      type: "permission_request",
+      tool: ask.permission,
+      detail: ask.detail,
+      id: ask.id,
+      ...(ask.parentId ? { parentId: ask.parentId } : {}),
+    });
   }
 
   /** protocol.ts contract: permission_request MUST resolve visibly on EVERY
@@ -565,9 +579,9 @@ export class OpenCodeSession implements AgentSession {
   ) {
     clearTimeout(timer);
     this.pendingPermissions.delete(id);
-    if (replyToEngine && this.sessionID) {
+    if (replyToEngine) {
       void this.transport
-        .replyPermission(this.sessionID, id, allow ? "once" : "reject")
+        .replyPermission(id, allow ? "once" : "reject")
         .catch((err) => {
           if (!this.closed)
             this.emit({ type: "error", message: `permission reply failed: ${errText(err)}` });

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -177,6 +177,12 @@ export function capOutput(text: string): { text: string; truncatedBytes?: number
 // explicit marker, never a silent cut. Agent-neutral, shared by every
 // adapter that forwards a subagent lane.
 const SUBAGENT_TEXT_CAP_BYTES = envInt("SUBAGENT_TEXT_CAP_BYTES", 64_000);
+// Ceiling on DISTINCT subagents tracked per turn — flood insurance in the
+// part-cap spirit (audit 2026-08-14): a hostile/looping engine fabricating
+// unlimited parent ids must not grow the ledger without bound. A real turn
+// spawns a handful; past the cap a NEW subagent's prose is dropped silently,
+// exactly how the other per-turn caps degrade.
+const MAX_SUBAGENTS_PER_TURN = 2_000;
 
 export const SUBAGENT_PROSE_ELIDED = (cap: number) =>
   `\n(… subagent narration cap reached (${cap} bytes) — further prose elided …)`;
@@ -184,14 +190,21 @@ export const SUBAGENT_PROSE_ELIDED = (cap: number) =>
 export class SubagentProseBudget {
   private used = new Map<string, number>();
   private capped = new Set<string>();
-  constructor(private readonly cap = SUBAGENT_TEXT_CAP_BYTES) {}
+  constructor(
+    private readonly cap = SUBAGENT_TEXT_CAP_BYTES,
+    private readonly maxParents = MAX_SUBAGENTS_PER_TURN,
+  ) {}
 
   /** The text to emit for this chunk: the chunk itself while the subagent's
    *  budget holds, a byte-bounded head plus the one elision marker at
    *  exhaustion, and "" (emit nothing) thereafter. */
   take(parentId: string, text: string): string {
     if (this.capped.has(parentId)) return "";
-    const used = this.used.get(parentId) ?? 0;
+    let used = this.used.get(parentId);
+    if (used === undefined) {
+      if (this.used.size >= this.maxParents) return "";
+      used = 0;
+    }
     const bytes = Buffer.byteLength(text, "utf8");
     if (used + bytes <= this.cap) {
       this.used.set(parentId, used + bytes);

--- a/server/adapters/types.ts
+++ b/server/adapters/types.ts
@@ -171,6 +171,48 @@ export function capOutput(text: string): { text: string; truncatedBytes?: number
   return { text: kept, truncatedBytes: total - OUTPUT_CAP_BYTES };
 }
 
+// SA.2: per-subagent narration budget — bounds what any ONE subagent's prose
+// (text + thinking) can add to the wire, the replay ring, and relay bytes.
+// Byte-based like the tool cap, honest like it too: exhaustion emits one
+// explicit marker, never a silent cut. Agent-neutral, shared by every
+// adapter that forwards a subagent lane.
+const SUBAGENT_TEXT_CAP_BYTES = envInt("SUBAGENT_TEXT_CAP_BYTES", 64_000);
+
+export const SUBAGENT_PROSE_ELIDED = (cap: number) =>
+  `\n(… subagent narration cap reached (${cap} bytes) — further prose elided …)`;
+
+export class SubagentProseBudget {
+  private used = new Map<string, number>();
+  private capped = new Set<string>();
+  constructor(private readonly cap = SUBAGENT_TEXT_CAP_BYTES) {}
+
+  /** The text to emit for this chunk: the chunk itself while the subagent's
+   *  budget holds, a byte-bounded head plus the one elision marker at
+   *  exhaustion, and "" (emit nothing) thereafter. */
+  take(parentId: string, text: string): string {
+    if (this.capped.has(parentId)) return "";
+    const used = this.used.get(parentId) ?? 0;
+    const bytes = Buffer.byteLength(text, "utf8");
+    if (used + bytes <= this.cap) {
+      this.used.set(parentId, used + bytes);
+      return text;
+    }
+    this.capped.add(parentId);
+    // Decode a byte-bounded slice; a trailing partial char becomes U+FFFD
+    // (same approach as capOutput above).
+    const kept = new TextDecoder().decode(
+      Buffer.from(text, "utf8").subarray(0, Math.max(0, this.cap - used)),
+    );
+    return kept + SUBAGENT_PROSE_ELIDED(this.cap);
+  }
+
+  /** Turn boundary: spawns don't outlive their turn, so the ledger resets. */
+  clear() {
+    this.used.clear();
+    this.capped.clear();
+  }
+}
+
 /** One entry of the live checklist component (T2.5); adapter-neutral shape. */
 export type TodoItem = { content: string; status: "pending" | "in_progress" | "completed" };
 

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -56,7 +56,13 @@ export type PromptOption = {
 export type WireMsg = WireMsgBody & { seq?: number; replay?: true };
 
 type WireMsgBody =
-  | { type: "text_delta"; text: string }
+  // `parentId` (SA.2, additive like tool_use's): when set, this prose is a
+  // SUBAGENT's, grouped under the spawn record whose wire id it names. The
+  // handle is OPAQUE and adapter-chosen — shared code only ever groups by
+  // it, never parses or dereferences it (for Claude Code it happens to be
+  // the spawn tool_use id; the protocol does not promise that). Old clients
+  // ignore the field and render the prose inline, exactly as before.
+  | { type: "text_delta"; text: string; parentId?: string }
   // Phase UX.1: the selected provider's live prompt-completion catalog.
   // This is shell data, not agent-authored UI: the browser opens it as soon
   // as the trigger is typed, before anything is sent to the provider. A new
@@ -229,8 +235,9 @@ type WireMsgBody =
     }
   // Phase T2.1: the model's reasoning stream, full fidelity. Renders as a
   // dim block that folds to one line once the turn's real output starts —
-  // collapse-on-finalize, never dropped.
-  | { type: "thinking_delta"; text: string }
+  // collapse-on-finalize, never dropped. `parentId` rides here too, exactly
+  // as on text_delta (SA.2): a subagent's reasoning, grouped under its card.
+  | { type: "thinking_delta"; text: string; parentId?: string }
   // Phase F.2: a service-status line — an event the terminal shows and the
   // adapter would otherwise drop, so the UI never lies in degraded service:
   // an API retry (terminal shows "retrying…"; we'd sit on "thinking…" looking

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -240,7 +240,7 @@ type WireMsgBody =
   // Phase T2.1: the model's reasoning stream, full fidelity. Renders as a
   // dim block that folds to one line once the turn's real output starts —
   // collapse-on-finalize, never dropped. `parentId` rides here too, exactly
-  // as on text_delta (SA.2): a subagent's reasoning, grouped under its card.
+  // as on text_delta (SA.2): a subagent's reasoning, grouped under its deck.
   | { type: "thinking_delta"; text: string; parentId?: string }
   // Phase F.2: a service-status line — an event the terminal shows and the
   // adapter would otherwise drop, so the UI never lies in degraded service:

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -122,7 +122,11 @@ type WireMsgBody =
     }
   // Phase T.3: the turn is paused on a gated tool call until the browser
   // answers (or the server times out to deny). Drawn by the trusted shell.
-  | { type: "permission_request"; tool: string; detail: string; id: string }
+  // `parentId` (SA.3, additive): set when the ASKER is a subagent — the
+  // same opaque spawn handle the tool/prose lanes group by. The shell shows
+  // a dim "subagent" chip; the ask itself is answered exactly like any
+  // other. Old clients ignore the field.
+  | { type: "permission_request"; tool: string; detail: string; id: string; parentId?: string }
   // 2026-07-28: the ask above RESOLVED — answered from ANY viewport, or
   // auto-denied by the adapter's timeout/interrupt. Broadcast on the session
   // stream so every attached viewport (and the replay buffer) drops the bar

--- a/server/sessions/registry.test.ts
+++ b/server/sessions/registry.test.ts
@@ -400,6 +400,23 @@ test("coalescing: any non-delta message flushes the window first — order prese
   reg.end(entry.id);
 });
 
+test("coalescing: a different parentId flushes — one subagent's prose never merges into another's (SA.2)", () => {
+  const { reg, entry, seen } = coalescingSession(60_000);
+  reg.broadcast(entry, { type: "text_delta", text: "parent " });
+  reg.broadcast(entry, { type: "text_delta", text: "prose" });
+  reg.broadcast(entry, { type: "text_delta", text: "child A", parentId: "taskA" });
+  reg.broadcast(entry, { type: "text_delta", text: " more A", parentId: "taskA" });
+  reg.broadcast(entry, { type: "text_delta", text: "child B", parentId: "taskB" });
+  reg.broadcast(entry, { type: "turn_end" });
+  assert.deepEqual(seen, [
+    { type: "text_delta", text: "parent prose", seq: 1 },
+    { type: "text_delta", text: "child A more A", parentId: "taskA", seq: 2 },
+    { type: "text_delta", text: "child B", parentId: "taskB", seq: 3 },
+    { type: "turn_end", seq: 4 },
+  ]);
+  reg.end(entry.id);
+});
+
 test("coalescing: a delta of the OTHER type flushes too — thinking and text never merge together", () => {
   const { reg, entry, seen } = coalescingSession(60_000);
   reg.broadcast(entry, { type: "thinking_delta", text: "hm" });

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -586,12 +586,19 @@ export class SessionRegistry {
       (msg.type === "text_delta" || msg.type === "thinking_delta")
     ) {
       const pending = entry.pendingDelta;
-      if (pending && pending.type === msg.type) {
+      // The merge key is (type, parentId) — SA.2: with parallel subagents
+      // streaming, merging on type alone would concatenate one agent's prose
+      // into another's (or into the parent's) inside a single message.
+      if (pending && pending.type === msg.type && pending.parentId === msg.parentId) {
         pending.text += msg.text;
         return;
       }
       this.flushDeltas(entry);
-      entry.pendingDelta = { type: msg.type, text: msg.text };
+      entry.pendingDelta = {
+        type: msg.type,
+        text: msg.text,
+        ...(msg.parentId !== undefined ? { parentId: msg.parentId } : {}),
+      };
       entry.deltaTimer = setTimeout(() => this.flushDeltas(entry), this.deltaCoalesceMs);
       entry.deltaTimer.unref();
       return;

--- a/server/sessions/session-store.test.ts
+++ b/server/sessions/session-store.test.ts
@@ -237,6 +237,12 @@ test("UX.8: strict checkpoint decoding accepts every persistable transcript fram
     { type: "artifact", html: "<p>safe</p>", id: "a1", title: "Artifact" },
     { type: "usage", model: "model", inputTokens: 2, outputTokens: 3, costUsd: 0.01 },
     { type: "thinking_delta", text: "hmm" },
+    // The subagent lane's parented variants (SA.2/SA.3): a reverted schema
+    // widening would silently strip a deck's replay — pinned here
+    // (test-audit 2026-08-14).
+    { type: "text_delta", text: "child narration", parentId: "t1" },
+    { type: "thinking_delta", text: "child reasoning", parentId: "t1" },
+    { type: "permission_request", tool: "bash", detail: "touch x", id: "p2", parentId: "t1" },
     { type: "notice", text: "retrying", kind: "retry", source: "codex" },
     { type: "bang_start", command: "echo ok", id: "b1" },
     { type: "bang_output", data: "ok\n", id: "b1" },

--- a/server/sessions/session-store.ts
+++ b/server/sessions/session-store.ts
@@ -142,6 +142,8 @@ const storedWireMessageSchema = z.discriminatedUnion("type", [
       tool: z.string(),
       detail: z.string(),
       id: idSchema,
+      // SA.3: set when the asker is a subagent (opaque spawn handle).
+      parentId: idSchema.optional(),
       seq: sequenceSchema,
     })
     .strict(),

--- a/server/sessions/session-store.ts
+++ b/server/sessions/session-store.ts
@@ -76,7 +76,15 @@ const pickerRowSchema = z
 // Every object is strict and sequenced: a locally tampered/corrupt record can
 // never smuggle an arbitrary frame back into the trusted browser shell.
 const storedWireMessageSchema = z.discriminatedUnion("type", [
-  z.object({ type: z.literal("text_delta"), text: z.string(), seq: sequenceSchema }).strict(),
+  // `parentId` (SA.2): a subagent's prose, grouped under its spawn record.
+  z
+    .object({
+      type: z.literal("text_delta"),
+      text: z.string(),
+      parentId: idSchema.optional(),
+      seq: sequenceSchema,
+    })
+    .strict(),
   z
     .object({
       type: z.literal("status"),
@@ -165,7 +173,15 @@ const storedWireMessageSchema = z.discriminatedUnion("type", [
       seq: sequenceSchema,
     })
     .strict(),
-  z.object({ type: z.literal("thinking_delta"), text: z.string(), seq: sequenceSchema }).strict(),
+  // `parentId` (SA.2): a subagent's reasoning, grouped under its spawn record.
+  z
+    .object({
+      type: z.literal("thinking_delta"),
+      text: z.string(),
+      parentId: idSchema.optional(),
+      seq: sequenceSchema,
+    })
+    .strict(),
   z
     .object({
       type: z.literal("notice"),

--- a/server/sessions/session.itest.ts
+++ b/server/sessions/session.itest.ts
@@ -149,16 +149,22 @@ test("checklist hook: one render id, statuses progressing in place", async () =>
   assert.deepEqual(statuses(frames[4]), ["completed", "completed", "completed", "completed"]);
 });
 
-test("subagent hook: inner calls nest under the Task id", async () => {
+test("subagent hook: a parallel fan-out — children nest under their own spawn, finishes out of order (SA.1)", async () => {
   const turn = await runTurn(c, "delegate this to a subagent");
-  const task = turn.find((m) => m.type === "tool_use" && m.name === "Task")!;
-  assert.equal(task.parentId, undefined);
-  const inner = turn.filter((m) => m.type === "tool_use" && m.id !== task.id);
-  assert.ok(inner.length >= 3);
-  for (const t of inner) assert.equal(t.parentId, task.id);
-  // The Task itself resolves last, un-nested.
-  const results = turn.filter((m) => m.type === "tool_result");
-  assert.equal(results[results.length - 1].id, task.id);
+  const tasks = turn.filter((m) => m.type === "tool_use" && m.name === "Task");
+  assert.equal(tasks.length, 3);
+  for (const t of tasks) assert.equal(t.parentId, undefined);
+  const taskIds = new Set(tasks.map((t) => t.id));
+  const inner = turn.filter((m) => m.type === "tool_use" && !taskIds.has(m.id));
+  assert.ok(inner.length >= 9);
+  for (const t of inner) assert.ok(taskIds.has(t.parentId), "child tags its own spawn");
+  // Each spawn resolves with its own report…
+  const settles = turn.filter((m) => m.type === "tool_result" && taskIds.has(m.id));
+  assert.equal(settles.length, 3);
+  // …and NOT in spawn order: the second-spawned (fastest) settles first —
+  // the out-of-order truth the cards render.
+  assert.notDeepEqual(settles.map((r) => r.id), tasks.map((t) => t.id));
+  assert.equal(settles[0].id, tasks[1].id);
 });
 
 test("huge-output hook: the cap reports truncatedBytes, never a silent cut", async () => {

--- a/server/sessions/session.itest.ts
+++ b/server/sessions/session.itest.ts
@@ -165,6 +165,15 @@ test("subagent hook: a parallel fan-out — children nest under their own spawn,
   // the out-of-order truth the cards render.
   assert.notDeepEqual(settles.map((r) => r.id), tasks.map((t) => t.id));
   assert.equal(settles[0].id, tasks[1].id);
+  // The narration lane over the REAL daemon broadcast (test-audit
+  // 2026-08-14: this path was only e2e-covered): each spawn's prose rides
+  // parented, and the registry's coalescer never merged one agent's words
+  // into another's — every parented delta names a real spawn, and each
+  // agent's own narration arrives intact.
+  const prose = turn.filter((m) => m.type === "text_delta" && m.parentId !== undefined);
+  assert.equal(prose.length, 3, "one narration per subagent rode the wire");
+  for (const p of prose) assert.ok(taskIds.has(p.parentId), "prose names a real spawn");
+  assert.equal(new Set(prose.map((p) => p.parentId)).size, 3, "no cross-parent merge");
 });
 
 test("huge-output hook: the cap reports truncatedBytes, never a silent cut", async () => {

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -579,7 +579,7 @@ test("onboarding → a full mock turn renders in the DOM", async () => {
   await page.waitForSelector("text=Plan complete — all four steps done.", { timeout: 30_000 });
 });
 
-test("SA.1: a parallel fan-out renders three live subagent cards, out of order, expandable", async () => {
+test("SA.1: a parallel fan-out renders three live subagent decks, out of order, expandable", async () => {
   await withFreshMockSession("sa1-cards-7fd1", async (p) => {
     await p.locator("textarea").click();
     await p.keyboard.type("delegate the research");
@@ -587,7 +587,7 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
 
     // Three cards appear as their spawns land (350/430/510ms in the mock).
     await p.waitForFunction(
-      () => document.querySelectorAll(".subagent-card").length === 3,
+      () => document.querySelectorAll(".subagent-deck").length === 3,
       undefined,
       { timeout: 15_000 },
     );
@@ -595,11 +595,11 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
     // While running: a live card ticks — elapsed seconds in the meta line and
     // a current action in the live slot. Grab the slow "trace the token path"
     // card, which runs the longest.
-    const tokenCard = p.locator(".subagent-card", { hasText: "trace the token path" });
+    const tokenCard = p.locator(".subagent-deck", { hasText: "trace the token path" });
     await p.waitForFunction(
       () => {
-        const cards = [...document.querySelectorAll(".subagent-card-running")];
-        return cards.some((c) => /·\s*\d+s/.test(c.querySelector(".subagent-card-meta")?.textContent ?? ""));
+        const cards = [...document.querySelectorAll(".subagent-deck-running")];
+        return cards.some((c) => /·\s*\d+s/.test(c.querySelector(".subagent-deck-meta")?.textContent ?? ""));
       },
       undefined,
       { timeout: 10_000 },
@@ -611,12 +611,12 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
       () => {
         // No const-assigned arrows in here: esbuild's keepNames would inject
         // a __name helper the browser page doesn't have.
-        const cards = [...document.querySelectorAll(".subagent-card")];
+        const cards = [...document.querySelectorAll(".subagent-deck")];
         const settled = cards.find((c) => c.textContent?.includes("map session handling"));
         const slow = cards.find((c) => c.textContent?.includes("trace the token path"));
         return (
-          settled?.classList.contains("subagent-card-done") === true &&
-          slow?.classList.contains("subagent-card-running") === true
+          settled?.classList.contains("subagent-deck-done") === true &&
+          slow?.classList.contains("subagent-deck-running") === true
         );
       },
       undefined,
@@ -626,9 +626,9 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
     // The turn concludes; all three cards settle, elapsed stops being shown
     // (client-side timing is only honest while live), result lines ride.
     await p.waitForSelector("text=All three subagents reported back", { timeout: 30_000 });
-    assert.equal(await p.locator(".subagent-card-done").count(), 3);
-    assert.equal(await p.locator(".subagent-card-running").count(), 0);
-    const doneMeta = await tokenCard.locator(".subagent-card-meta").innerText();
+    assert.equal(await p.locator(".subagent-deck-done").count(), 3);
+    assert.equal(await p.locator(".subagent-deck-running").count(), 0);
+    const doneMeta = await tokenCard.locator(".subagent-deck-meta").innerText();
     assert.doesNotMatch(doneMeta, /·\s*\d+s/);
     assert.match(doneMeta, /4 tools/);
     assert.match(doneMeta, /never leaves the daemon/);
@@ -636,7 +636,7 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
     // Expand → the nested calls are all there, AND the subagent's own words
     // (SA.2: narration + reasoning, interleaved, inert plain text — the
     // narration precedes the first tool row, true stream order).
-    await tokenCard.locator(".subagent-card-head").click();
+    await tokenCard.locator(".subagent-deck-head").click();
     assert.equal(await tokenCard.locator(".subagent-calls .tool-block").count(), 4);
     const prose = tokenCard.locator(".subagent-prose");
     assert.match(await prose.first().innerText(), /Following the cookie from auth\.ts/);
@@ -653,16 +653,16 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
     );
     // The prose is NOT rendered as markdown — no <p>/<em> children, raw text.
     assert.equal(await prose.first().locator("p, em, strong, a, code").count(), 0);
-    await tokenCard.locator(".subagent-card-head").click();
+    await tokenCard.locator(".subagent-deck-head").click();
     assert.equal(await tokenCard.locator(".subagent-calls").count(), 0);
 
-    await assertAxeClean(p, "subagent cards");
+    await assertAxeClean(p, "subagent decks");
     await noSideScroll(p);
 
     // Phone width: the same cards stack — no pane, no side scroll, drill-in
     // untouched (the transcript is the same DOM at every width).
     await p.setViewportSize({ width: 390, height: 844 });
-    assert.equal(await p.locator(".subagent-card").count(), 3);
+    assert.equal(await p.locator(".subagent-deck").count(), 3);
     await noSideScroll(p);
   });
 });

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -579,6 +579,77 @@ test("onboarding → a full mock turn renders in the DOM", async () => {
   await page.waitForSelector("text=Plan complete — all four steps done.", { timeout: 30_000 });
 });
 
+test("SA.1: a parallel fan-out renders three live subagent cards, out of order, expandable", async () => {
+  await withFreshMockSession("sa1-cards-7fd1", async (p) => {
+    await p.locator("textarea").click();
+    await p.keyboard.type("delegate the research");
+    await p.keyboard.press("Enter");
+
+    // Three cards appear as their spawns land (350/430/510ms in the mock).
+    await p.waitForFunction(
+      () => document.querySelectorAll(".subagent-card").length === 3,
+      undefined,
+      { timeout: 15_000 },
+    );
+
+    // While running: a live card ticks — elapsed seconds in the meta line and
+    // a current action in the live slot. Grab the slow "trace the token path"
+    // card, which runs the longest.
+    const tokenCard = p.locator(".subagent-card", { hasText: "trace the token path" });
+    await p.waitForFunction(
+      () => {
+        const cards = [...document.querySelectorAll(".subagent-card-running")];
+        return cards.some((c) => /·\s*\d+s/.test(c.querySelector(".subagent-card-meta")?.textContent ?? ""));
+      },
+      undefined,
+      { timeout: 10_000 },
+    );
+
+    // OUT OF ORDER: "map session handling" (spawned second, fastest pace)
+    // finishes while "trace the token path" is still running.
+    await p.waitForFunction(
+      () => {
+        // No const-assigned arrows in here: esbuild's keepNames would inject
+        // a __name helper the browser page doesn't have.
+        const cards = [...document.querySelectorAll(".subagent-card")];
+        const settled = cards.find((c) => c.textContent?.includes("map session handling"));
+        const slow = cards.find((c) => c.textContent?.includes("trace the token path"));
+        return (
+          settled?.classList.contains("subagent-card-done") === true &&
+          slow?.classList.contains("subagent-card-running") === true
+        );
+      },
+      undefined,
+      { timeout: 15_000 },
+    );
+
+    // The turn concludes; all three cards settle, elapsed stops being shown
+    // (client-side timing is only honest while live), result lines ride.
+    await p.waitForSelector("text=All three subagents reported back", { timeout: 30_000 });
+    assert.equal(await p.locator(".subagent-card-done").count(), 3);
+    assert.equal(await p.locator(".subagent-card-running").count(), 0);
+    const doneMeta = await tokenCard.locator(".subagent-card-meta").innerText();
+    assert.doesNotMatch(doneMeta, /·\s*\d+s/);
+    assert.match(doneMeta, /4 tools/);
+    assert.match(doneMeta, /never leaves the daemon/);
+
+    // Expand → the nested calls are all there; collapse returns to calm.
+    await tokenCard.locator(".subagent-card-head").click();
+    assert.equal(await tokenCard.locator(".subagent-calls .tool-block").count(), 4);
+    await tokenCard.locator(".subagent-card-head").click();
+    assert.equal(await tokenCard.locator(".subagent-calls").count(), 0);
+
+    await assertAxeClean(p, "subagent cards");
+    await noSideScroll(p);
+
+    // Phone width: the same cards stack — no pane, no side scroll, drill-in
+    // untouched (the transcript is the same DOM at every width).
+    await p.setViewportSize({ width: 390, height: 844 });
+    assert.equal(await p.locator(".subagent-card").count(), 3);
+    await noSideScroll(p);
+  });
+});
+
 test("A.1: announcer regions exist, spoke the turn, and the transcript is silent", async () => {
   // The two shell-owned announcer regions (Announcer.tsx): polite for turn
   // progress, assertive reserved for errors/permissions. `.sr-only` hides

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -633,9 +633,26 @@ test("SA.1: a parallel fan-out renders three live subagent cards, out of order, 
     assert.match(doneMeta, /4 tools/);
     assert.match(doneMeta, /never leaves the daemon/);
 
-    // Expand → the nested calls are all there; collapse returns to calm.
+    // Expand → the nested calls are all there, AND the subagent's own words
+    // (SA.2: narration + reasoning, interleaved, inert plain text — the
+    // narration precedes the first tool row, true stream order).
     await tokenCard.locator(".subagent-card-head").click();
     assert.equal(await tokenCard.locator(".subagent-calls .tool-block").count(), 4);
+    const prose = tokenCard.locator(".subagent-prose");
+    assert.match(await prose.first().innerText(), /Following the cookie from auth\.ts/);
+    assert.match(
+      await tokenCard.locator(".subagent-prose-thinking").innerText(),
+      /confirming the browser side/,
+    );
+    const expandedTexts = await tokenCard
+      .locator(".subagent-calls > *")
+      .evaluateAll((nodes) => nodes.map((n) => n.className));
+    assert.ok(
+      expandedTexts[0].includes("subagent-prose"),
+      "narration precedes the first tool row in stream order",
+    );
+    // The prose is NOT rendered as markdown — no <p>/<em> children, raw text.
+    assert.equal(await prose.first().locator("p, em, strong, a, code").count(), 0);
     await tokenCard.locator(".subagent-card-head").click();
     assert.equal(await tokenCard.locator(".subagent-calls").count(), 0);
 

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -623,6 +623,18 @@ test("SA.1: a parallel fan-out renders three live subagent decks, out of order, 
       { timeout: 15_000 },
     );
 
+    // Child tool churn must not steer the ROOT activity line — each deck
+    // shows its own current action (bughunt 2026-08-14 r2). The label may
+    // legitimately read the spawn state or the generic fallback (a FINISHED
+    // spawn clears its own name), but never a child's tool. Sampled across
+    // the still-running slow agent's ~640ms tool cadence so a pre-fix
+    // child-name label cannot slip between reads.
+    for (let sample = 0; sample < 8; sample++) {
+      const activityText = await p.locator(".activity-label").innerText();
+      assert.match(activityText, /^(Task|working)…$/);
+      await new Promise((resolve) => setTimeout(resolve, 150));
+    }
+
     // The turn concludes; all three cards settle, elapsed stops being shown
     // (client-side timing is only honest while live), result lines ride.
     await p.waitForSelector("text=All three subagents reported back", { timeout: 30_000 });

--- a/server/testing/opencode-subagent-fixture.ts
+++ b/server/testing/opencode-subagent-fixture.ts
@@ -1,0 +1,1429 @@
+// Captured 2026-08-14 from a REAL `opencode serve` 1.18.18 run (SA.0 probe):
+// a scripted parent turn calls the `task` tool (subagent_type "general"),
+// the child session runs a permission-gated bash, the ask is answered, the
+// child finishes, and the parent completes. Raw global /event payloads in
+// arrival order, filtered to the session-relevant types (server.connected,
+// plugin.added, catalog/reference/integration.updated, session.diff and
+// session.updated noise dropped; ids and casing untouched).
+//
+// Load-bearing truths this sequence pins (see PLAN.md Phase SA, SA.0):
+//  - parent `task` tool part (pending) precedes child session.created
+//  - the join key parent->child is task part state.metadata.sessionId
+//    (lowercase d) alongside parentSessionId; Session.parentID on the child
+//  - child text/tool/step parts + token-grain message.part.delta ride the
+//    SAME global stream, tagged with the child sessionID
+//  - the child permission.asked carries the CHILD sessionID; the deprecated
+//    per-session reply endpoint accepted a reply addressed with the ROOT
+//    session id (no ownership validation, engine 1.18.18)
+//  - child session.idle fires BEFORE the parent task part completes and
+//    long before parent session.idle
+
+/** The two session ids the capture uses. */
+export const SUBAGENT_FIXTURE_IDS = {
+  root: "ses_sa0probe00000000000root",
+  child: "ses_sa0probe0000000000child",
+} as const;
+
+/** The captured sequence, in arrival order. */
+export const OPENCODE_SUBAGENT_EVENTS: {
+  type: string;
+  properties: Record<string, unknown>;
+  /** Some 1.18.18 envelopes also carry a top-level event id — kept verbatim. */
+  id?: string;
+}[] = [
+  {
+    "id": "evt_0003b95e7001TYpHgjMC1DZsAC",
+    "type": "session.created",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "ses_sa0probe00000000000root",
+        "slug": "playful-pixel",
+        "version": "1.18.18",
+        "projectID": "global",
+        "directory": "/tmp/sa0-work-5KEWn0",
+        "path": "tmp/sa0-work-5KEWn0",
+        "title": "New session - 2026-08-14T12:25:00.134Z",
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "time": {
+          "created": 1786710300134,
+          "updated": 1786710300134
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b966d001MwzEhz5B9p47DH",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "user",
+        "sessionID": "ses_sa0probe00000000000root",
+        "time": {
+          "created": 1786710300251
+        },
+        "agent": "build",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b998a001v5UIim8ukfGBeu",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "type": "text",
+        "text": "spawn the probe subagent",
+        "messageID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "sessionID": "ses_sa0probe00000000000root",
+        "id": "prt_0003b966b001rBPTE4NQUTRSul"
+      },
+      "time": 1786710301065
+    }
+  },
+  {
+    "id": "evt_0003b999d001zQnubnMmjOkHsM",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b99a40019z3KqkeMbT0Oer",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710301092
+        },
+        "sessionID": "ses_sa0probe00000000000root"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b99f5001GaoFqn0MeJtAaI",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710300251
+        },
+        "agent": "build",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "id": "msg_0003b965b001gSbeLPM7axRjo6",
+        "sessionID": "ses_sa0probe00000000000root",
+        "summary": {
+          "diffs": []
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9ccd0018q2wp88hA5sX6D",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9ce4001Rd5FiFj3HWaWLO",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003b9ce4001qpqZfIB6n6fzxn",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "step-start"
+      },
+      "time": 1786710301924
+    }
+  },
+  {
+    "id": "evt_0003b9cea001Jh6cF0gfruzOou",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003b9ce9001BFkcKfmqQBXEkW",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "tool",
+        "tool": "task",
+        "callID": "call_2",
+        "state": {
+          "status": "pending",
+          "input": {},
+          "raw": ""
+        }
+      },
+      "time": 1786710301930
+    }
+  },
+  {
+    "id": "evt_0003b9cff0010aIngXr2ItTvAR",
+    "type": "session.created",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "ses_sa0probe0000000000child",
+        "slug": "eager-sailor",
+        "version": "1.18.18",
+        "projectID": "global",
+        "directory": "/tmp/sa0-work-5KEWn0",
+        "path": "tmp/sa0-work-5KEWn0",
+        "parentID": "ses_sa0probe00000000000root",
+        "title": "sa0 probe child (@general subagent)",
+        "agent": "general",
+        "permission": [
+          {
+            "permission": "task",
+            "pattern": "*",
+            "action": "deny"
+          }
+        ],
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "time": {
+          "created": 1786710301950,
+          "updated": 1786710301950
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9d09001cTT1IUD6oA7alW",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "type": "tool",
+        "tool": "task",
+        "callID": "call_2",
+        "state": {
+          "title": "sa0 probe child",
+          "metadata": {
+            "parentSessionId": "ses_sa0probe00000000000root",
+            "sessionId": "ses_sa0probe0000000000child",
+            "model": {
+              "modelID": "fake-model",
+              "providerID": "fake"
+            }
+          },
+          "status": "running",
+          "input": {
+            "description": "sa0 probe child",
+            "prompt": "CHILD_TASK: run the probe command exactly once.",
+            "subagent_type": "general"
+          },
+          "time": {
+            "start": 1786710301961
+          }
+        },
+        "id": "prt_0003b9ce9001BFkcKfmqQBXEkW",
+        "sessionID": "ses_sa0probe00000000000root",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3"
+      },
+      "time": 1786710301961
+    }
+  },
+  {
+    "id": "evt_0003b9d1c001YRBL2A5m96Jo8t",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "user",
+        "sessionID": "ses_sa0probe0000000000child",
+        "time": {
+          "created": 1786710301973
+        },
+        "agent": "general",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9d1f0011L8StOutGnKjW4",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "type": "text",
+        "text": "CHILD_TASK: run the probe command exactly once.",
+        "messageID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "sessionID": "ses_sa0probe0000000000child",
+        "id": "prt_0003b9d1b001i2PluJW6H9h1tX"
+      },
+      "time": 1786710301983
+    }
+  },
+  {
+    "id": "evt_0003b9d33001ufKGlzK7wN8r8R",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "type": "tool",
+        "tool": "task",
+        "callID": "call_2",
+        "state": {
+          "title": "sa0 probe child",
+          "metadata": {
+            "parentSessionId": "ses_sa0probe00000000000root",
+            "sessionId": "ses_sa0probe0000000000child",
+            "model": {
+              "modelID": "fake-model",
+              "providerID": "fake"
+            }
+          },
+          "status": "running",
+          "input": {
+            "description": "sa0 probe child",
+            "prompt": "CHILD_TASK: run the probe command exactly once.",
+            "subagent_type": "general"
+          },
+          "time": {
+            "start": 1786710301961
+          }
+        },
+        "id": "prt_0003b9ce9001BFkcKfmqQBXEkW",
+        "sessionID": "ses_sa0probe00000000000root",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3"
+      },
+      "time": 1786710302003
+    }
+  },
+  {
+    "id": "evt_0003b9d3b0011mPgxdyd7iQpRW",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9d3d001ym1OtcI2ZtKPgB",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302013
+        },
+        "sessionID": "ses_sa0probe0000000000child"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9e5c001BUcy05UVk7cSdQ",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710301973
+        },
+        "agent": "general",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "id": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "sessionID": "ses_sa0probe0000000000child",
+        "summary": {
+          "diffs": []
+        }
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9e800012xgZfFF5fGm6r3",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9e9d0013WGYaMcorUy5vQ",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003b9e9d001TVFXq515YfLN4Z",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "step-start"
+      },
+      "time": 1786710302365
+    }
+  },
+  {
+    "id": "evt_0003b9ea1001j2jA0ORSF77je7",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003b9ea1001128sL6LhvFFbhs",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "tool",
+        "tool": "bash",
+        "callID": "call_3",
+        "state": {
+          "status": "pending",
+          "input": {},
+          "raw": ""
+        }
+      },
+      "time": 1786710302369
+    }
+  },
+  {
+    "id": "evt_0003b9eb0001nDBpk7v0WnmWEl",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "type": "tool",
+        "tool": "bash",
+        "callID": "call_3",
+        "state": {
+          "status": "running",
+          "input": {
+            "command": "echo child-probe",
+            "description": "sa0 child probe"
+          },
+          "time": {
+            "start": 1786710302384
+          }
+        },
+        "id": "prt_0003b9ea1001128sL6LhvFFbhs",
+        "sessionID": "ses_sa0probe0000000000child",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H"
+      },
+      "time": 1786710302384
+    }
+  },
+  {
+    "id": "evt_0003b9f65002552q9ciSnlX3xK",
+    "type": "permission.asked",
+    "properties": {
+      "id": "per_0003b9f65001yQ0rDdeN7HiAmE",
+      "sessionID": "ses_sa0probe0000000000child",
+      "permission": "bash",
+      "patterns": [
+        "echo child-probe"
+      ],
+      "metadata": {
+        "command": "echo child-probe"
+      },
+      "always": [
+        "echo *"
+      ],
+      "tool": {
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "callID": "call_3"
+      }
+    }
+  },
+  {
+    "id": "evt_0003b9fbf001gXj1p7bUWWeplj",
+    "type": "permission.replied",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "requestID": "per_0003b9f65001yQ0rDdeN7HiAmE",
+      "reply": "once"
+    }
+  },
+  {
+    "id": "evt_0003b9fc90014fbQDu50KSlzK8",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "type": "tool",
+        "tool": "bash",
+        "callID": "call_3",
+        "state": {
+          "metadata": {
+            "output": ""
+          },
+          "status": "running",
+          "input": {
+            "command": "echo child-probe",
+            "description": "sa0 child probe"
+          },
+          "time": {
+            "start": 1786710302664
+          }
+        },
+        "id": "prt_0003b9ea1001128sL6LhvFFbhs",
+        "sessionID": "ses_sa0probe0000000000child",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H"
+      },
+      "time": 1786710302664
+    }
+  },
+  {
+    "id": "evt_0003ba015001iidPjC0l50hDLS",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "type": "tool",
+        "tool": "bash",
+        "callID": "call_3",
+        "state": {
+          "metadata": {
+            "output": "child-probe\n"
+          },
+          "status": "running",
+          "input": {
+            "command": "echo child-probe",
+            "description": "sa0 child probe"
+          },
+          "time": {
+            "start": 1786710302740
+          }
+        },
+        "id": "prt_0003b9ea1001128sL6LhvFFbhs",
+        "sessionID": "ses_sa0probe0000000000child",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H"
+      },
+      "time": 1786710302740
+    }
+  },
+  {
+    "id": "evt_0003ba0290011z5e8hUKiFdhUL",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "type": "tool",
+        "tool": "bash",
+        "callID": "call_3",
+        "state": {
+          "status": "completed",
+          "input": {
+            "command": "echo child-probe",
+            "description": "sa0 child probe"
+          },
+          "output": "child-probe\n",
+          "metadata": {
+            "output": "child-probe\n",
+            "exit": 0,
+            "truncated": false
+          },
+          "title": "echo child-probe",
+          "time": {
+            "start": 1786710302740,
+            "end": 1786710302761
+          }
+        },
+        "id": "prt_0003b9ea1001128sL6LhvFFbhs",
+        "sessionID": "ses_sa0probe0000000000child",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H"
+      },
+      "time": 1786710302761
+    }
+  },
+  {
+    "id": "evt_0003ba033001vLnpuxLognpKZw",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003ba032001vPGZns7HV0JuiW",
+        "reason": "tool-calls",
+        "messageID": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "step-finish",
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "cost": 0
+      },
+      "time": 1786710302771
+    }
+  },
+  {
+    "id": "evt_0003ba038001GXnMlHDFC7rINY",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302013,
+          "completed": 1786710302782
+        },
+        "sessionID": "ses_sa0probe0000000000child",
+        "finish": "tool-calls"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba03f001ih63DvgWgxtgXm",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003b9d3d001xb51TiRjXmV80H",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302013,
+          "completed": 1786710302782
+        },
+        "sessionID": "ses_sa0probe0000000000child",
+        "finish": "tool-calls"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba042001IEMP1Y0WWgrfST",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba045001I3G6Vr6vKjaNj0",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003ba045001y2RoS2m46oH2A6",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302789
+        },
+        "sessionID": "ses_sa0probe0000000000child"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba06c0018uBERPtHhDJLSQ",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710301973
+        },
+        "agent": "general",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "summary": {
+          "diffs": []
+        },
+        "id": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "sessionID": "ses_sa0probe0000000000child"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba09c001zyklDye28t6gHr",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0c3001KwTDWMfi07oe5L",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003ba0c3001pgmk772bQyRFG5",
+        "messageID": "msg_0003ba045001y2RoS2m46oH2A6",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "step-start"
+      },
+      "time": 1786710302915
+    }
+  },
+  {
+    "id": "evt_0003ba0c90011OCPgbjM49X7jG",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003ba0c90010o20gyZ7Cv49od",
+        "messageID": "msg_0003ba045001y2RoS2m46oH2A6",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "text",
+        "text": "",
+        "time": {
+          "start": 1786710302921
+        }
+      },
+      "time": 1786710302921
+    }
+  },
+  {
+    "id": "evt_0003ba0cd001SnYmcGRGP1rQps",
+    "type": "message.part.delta",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "messageID": "msg_0003ba045001y2RoS2m46oH2A6",
+      "partID": "prt_0003ba0c90010o20gyZ7Cv49od",
+      "field": "text",
+      "delta": "CHILD DONE \u2014 the token never left the daemon."
+    }
+  },
+  {
+    "id": "evt_0003ba0ce001a6AvXeg4UeL0tz",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003ba0c90010o20gyZ7Cv49od",
+        "messageID": "msg_0003ba045001y2RoS2m46oH2A6",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "text",
+        "text": "CHILD DONE \u2014 the token never left the daemon.",
+        "time": {
+          "start": 1786710302921,
+          "end": 1786710302926
+        }
+      },
+      "time": 1786710302926
+    }
+  },
+  {
+    "id": "evt_0003ba0d4001WU0MIGvnj0g713",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "part": {
+        "id": "prt_0003ba0d4001KObePtlXgbrnQW",
+        "reason": "stop",
+        "messageID": "msg_0003ba045001y2RoS2m46oH2A6",
+        "sessionID": "ses_sa0probe0000000000child",
+        "type": "step-finish",
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "cost": 0
+      },
+      "time": 1786710302932
+    }
+  },
+  {
+    "id": "evt_0003ba0d8001dBCxD9g6V1cKLs",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003ba045001y2RoS2m46oH2A6",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302789,
+          "completed": 1786710302941
+        },
+        "sessionID": "ses_sa0probe0000000000child",
+        "finish": "stop"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0dd001IMXdC3y7CBpKui",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "id": "msg_0003ba045001y2RoS2m46oH2A6",
+        "parentID": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "role": "assistant",
+        "mode": "general",
+        "agent": "general",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302789,
+          "completed": 1786710302941
+        },
+        "sessionID": "ses_sa0probe0000000000child",
+        "finish": "stop"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0e0001UP0i7J0LB9vWVv",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0e7001tA7VU2f6MBUiUB",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "status": {
+        "type": "idle"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0e7002NHqW8oR7Rsalc3",
+    "type": "session.idle",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child"
+    }
+  },
+  {
+    "id": "evt_0003ba0ee0011RXwaHhR9Mi5hh",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "type": "tool",
+        "tool": "task",
+        "callID": "call_2",
+        "state": {
+          "status": "completed",
+          "input": {
+            "description": "sa0 probe child",
+            "prompt": "CHILD_TASK: run the probe command exactly once.",
+            "subagent_type": "general"
+          },
+          "output": "<task id=\"CHILD\" state=\"completed\">\n<task_result>\nCHILD DONE \u2014 the token never left the daemon.\n</task_result>\n</task>",
+          "metadata": {
+            "parentSessionId": "ses_sa0probe00000000000root",
+            "sessionId": "ses_sa0probe0000000000child",
+            "model": {
+              "modelID": "fake-model",
+              "providerID": "fake"
+            },
+            "truncated": false
+          },
+          "title": "sa0 probe child",
+          "time": {
+            "start": 1786710301961,
+            "end": 1786710302958
+          }
+        },
+        "id": "prt_0003b9ce9001BFkcKfmqQBXEkW",
+        "sessionID": "ses_sa0probe00000000000root",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3"
+      },
+      "time": 1786710302958
+    }
+  },
+  {
+    "id": "evt_0003ba0f3001lfB6gxTxuxIfKa",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003ba0f3001QfUqkc0VX01xMu",
+        "reason": "tool-calls",
+        "messageID": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "step-finish",
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "cost": 0
+      },
+      "time": 1786710302963
+    }
+  },
+  {
+    "id": "evt_0003ba0f70019KTx59Av5IEL2K",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710301092,
+          "completed": 1786710302971
+        },
+        "sessionID": "ses_sa0probe00000000000root",
+        "finish": "tool-calls"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0fb001ThZ2r9PhvnJsNG",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003b99a4001HqWhWR7p8R1Qb3",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710301092,
+          "completed": 1786710302971
+        },
+        "sessionID": "ses_sa0probe00000000000root",
+        "finish": "tool-calls"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba0fe001ZCzvdS2JOpLeNB",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba101001IBh6gSimBkm4Uh",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "input": 0,
+          "output": 0,
+          "reasoning": 0,
+          "cache": {
+            "read": 0,
+            "write": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302977
+        },
+        "sessionID": "ses_sa0probe00000000000root"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba10f001ps6tOvSAh9YCmm",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe0000000000child",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710301973
+        },
+        "agent": "general",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "summary": {
+          "diffs": []
+        },
+        "id": "msg_0003b9d12001sv3mzRwub3W4ZM",
+        "sessionID": "ses_sa0probe0000000000child"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba119001X5w0dMVCMvnKSI",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710300251
+        },
+        "agent": "build",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "summary": {
+          "diffs": []
+        },
+        "id": "msg_0003b965b001gSbeLPM7axRjo6",
+        "sessionID": "ses_sa0probe00000000000root"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba132001UN1ppUpP3BUXfn",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba13d0012l1N8xfzI0nDfz",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003ba13d0012TAGb2PS1pT6eo",
+        "messageID": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "step-start"
+      },
+      "time": 1786710303037
+    }
+  },
+  {
+    "id": "evt_0003ba141001VDjzrHttonM3cV",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003ba141001jgjQVR3VGmB6CQ",
+        "messageID": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "text",
+        "text": "",
+        "time": {
+          "start": 1786710303041
+        }
+      },
+      "time": 1786710303041
+    }
+  },
+  {
+    "id": "evt_0003ba146001KCZcFBSq7V0mTm",
+    "type": "message.part.delta",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "messageID": "msg_0003ba101001gT4KSgYu8NdxWc",
+      "partID": "prt_0003ba141001jgjQVR3VGmB6CQ",
+      "field": "text",
+      "delta": "PARENT DONE"
+    }
+  },
+  {
+    "id": "evt_0003ba1470012wqWvQv1DIxuL4",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003ba141001jgjQVR3VGmB6CQ",
+        "messageID": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "text",
+        "text": "PARENT DONE",
+        "time": {
+          "start": 1786710303041,
+          "end": 1786710303047
+        }
+      },
+      "time": 1786710303047
+    }
+  },
+  {
+    "id": "evt_0003ba14b001XUb72UupVOtO8E",
+    "type": "message.part.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "part": {
+        "id": "prt_0003ba14b001x61yIaF1KVeJ8Z",
+        "reason": "stop",
+        "messageID": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "sessionID": "ses_sa0probe00000000000root",
+        "type": "step-finish",
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "cost": 0
+      },
+      "time": 1786710303051
+    }
+  },
+  {
+    "id": "evt_0003ba14e001giadp0hPdHnpW9",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302977,
+          "completed": 1786710303058
+        },
+        "sessionID": "ses_sa0probe00000000000root",
+        "finish": "stop"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba152001GEi5UzZzkGeo46",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "id": "msg_0003ba101001gT4KSgYu8NdxWc",
+        "parentID": "msg_0003b965b001gSbeLPM7axRjo6",
+        "role": "assistant",
+        "mode": "build",
+        "agent": "build",
+        "path": {
+          "cwd": "/tmp/sa0-work-5KEWn0",
+          "root": "/"
+        },
+        "cost": 0,
+        "tokens": {
+          "total": 14,
+          "input": 10,
+          "output": 4,
+          "reasoning": 0,
+          "cache": {
+            "write": 0,
+            "read": 0
+          }
+        },
+        "modelID": "fake-model",
+        "providerID": "fake",
+        "time": {
+          "created": 1786710302977,
+          "completed": 1786710303058
+        },
+        "sessionID": "ses_sa0probe00000000000root",
+        "finish": "stop"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba155001c3W1btmE5MlueZ",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "busy"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba158001QOuKA3CQY74L7e",
+    "type": "session.status",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "status": {
+        "type": "idle"
+      }
+    }
+  },
+  {
+    "id": "evt_0003ba159001e1QABHhmnA4cco",
+    "type": "session.idle",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root"
+    }
+  },
+  {
+    "id": "evt_0003ba15f001z0xVphY1nG6I3k",
+    "type": "message.updated",
+    "properties": {
+      "sessionID": "ses_sa0probe00000000000root",
+      "info": {
+        "role": "user",
+        "time": {
+          "created": 1786710300251
+        },
+        "agent": "build",
+        "model": {
+          "providerID": "fake",
+          "modelID": "fake-model"
+        },
+        "summary": {
+          "diffs": []
+        },
+        "id": "msg_0003b965b001gSbeLPM7axRjo6",
+        "sessionID": "ses_sa0probe00000000000root"
+      }
+    }
+  }
+];

--- a/server/testing/resilience.e2e.ts
+++ b/server/testing/resilience.e2e.ts
@@ -1,8 +1,30 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+
+/** True once any checkpointed session buffer holds a parented text_delta. */
+async function waitForStoredNarration(dir: string): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  for (;;) {
+    const stored = readdirSync(dir)
+      .filter((f) => f.endsWith(".json"))
+      .some((f) => {
+        try {
+          const session = JSON.parse(readFileSync(path.join(dir, f), "utf8")) as {
+            buffer?: { type?: string; parentId?: string }[];
+          };
+          return (session.buffer ?? []).some((m) => m.type === "text_delta" && m.parentId);
+        } catch {
+          return false; // a checkpoint write raced the read — poll again
+        }
+      });
+    if (stored) return;
+    if (Date.now() > deadline) throw new Error("narration never reached the checkpoint store");
+    await new Promise((r) => setTimeout(r, 100));
+  }
+}
 import { type Browser, type Page } from "playwright-core";
 import { startDaemon, type Daemon } from "./itest-harness";
 import { launchChrome } from "./e2e-harness";
@@ -59,4 +81,48 @@ test("mid-turn daemon death clears working state; restart reopens the saved sess
   assert.equal(page.url(), oldUrl);
   assert.equal(await page.locator(".turn-user", { hasText: "hello resilience" }).count(), 1);
   assert.equal(await page.locator(".session-notice").count(), 0, "fell back to a blank session");
+});
+
+test("subagent narration survives a mid-turn reconnect replay (bughunt 2026-08-14 r2)", async () => {
+  // A fresh session in the same durable store (?new=1 — the registry is not
+  // empty, so bare / would reopen the first test's session); the slow hook
+  // opens a subagent prose run and then idles for seconds — the
+  // deterministic window in which the transcript is reset mid-turn.
+  await page.goto(`http://127.0.0.1:${d.port}/?new=1`);
+  await page.locator(".onb-agent", { hasText: "Claude Code" }).click();
+  await page.waitForURL(/\/s\/[\w-]+/);
+  await page.locator("textarea").click();
+  await page.keyboard.type("delegate slowly");
+  await page.keyboard.press("Enter");
+  // The deck is up and its narration has streamed (spawn at 300ms, prose at
+  // 700ms, first tool not until 9s) — the subtext run is open NOW.
+  await page.waitForSelector(".subagent-deck", { timeout: 15_000 });
+  await page.locator(".subagent-deck-head").click();
+  await page.waitForSelector("text=Surveying the workspace layout", { timeout: 10_000 });
+
+  // The narration must be DURABLE before the kill: interior frames ride a
+  // 250ms checkpoint debounce, and killing inside it loses the tail server-
+  // side (an honest, pre-existing bound — the turn is marked interrupted).
+  // Poll the store until the parented delta is on disk, so this test always
+  // exercises the CLIENT's replay path, never the debounce race.
+  await waitForStoredNarration(sessionDir);
+
+  // Kill and restart the daemon inside the window: the client reattaches to
+  // the same page (no reload), gets zone_reset, and replays the checkpoint.
+  // A stale open-subtext key would swallow the replayed narration into an
+  // entry id that no longer exists — the deck would come back empty-handed.
+  const port = d.port;
+  await d.stop();
+  d = await startDaemon({
+    MIRAFOLD_TOKEN: "",
+    MIRAFOLD_SESSION_DIR: sessionDir,
+    PORT: String(port),
+  });
+  assert.equal(d.port, port, "restart re-bound a different port; test cannot proceed");
+  await page.locator(".notice-line", { hasText: "turn was interrupted" }).waitFor({ timeout: 30_000 });
+
+  // The replayed deck still holds the subagent's words.
+  await page.waitForSelector(".subagent-deck", { timeout: 10_000 });
+  await page.locator(".subagent-deck-head").click();
+  await page.waitForSelector("text=Surveying the workspace layout", { timeout: 10_000 });
 });

--- a/web/src/components/PermBar.tsx
+++ b/web/src/components/PermBar.tsx
@@ -3,7 +3,13 @@ import { ModalCard } from "./ModalCard";
 
 const TITLE_ID = "perm-modal-title";
 
-export type PermAsk = { tool: string; detail: string; id: string };
+export type PermAsk = {
+  tool: string;
+  detail: string;
+  id: string;
+  /** SA.3: set when the asker is a subagent — the bar shows a dim chip. */
+  parentId?: string;
+};
 
 /**
  * The permission strip and its full-command card. SHELL-OWNED UI: the agent
@@ -36,6 +42,7 @@ export function PermBar({
           title="Show the full command"
         >
           <span className="perm-badge">permission</span>
+          {asks[0].parentId && <span className="perm-subagent">subagent</span>}
           <span className="perm-tool">{asks[0].tool}</span>
           <code className="perm-detail">{asks[0].detail}</code>
           {asks.length > 1 && <span className="perm-more">+{asks.length - 1}</span>}

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useReducer,
   useRef,
   useState,
 } from "react";
@@ -20,7 +21,8 @@ import { PickerBlock, type PickerRow } from "./PickerBlock";
 import { GearGlyph } from "./GearGlyph";
 import { useFollowTail } from "../use-follow-tail";
 import { queueDelta, type QueuedDelta } from "../delta-queue";
-import { groupSettledTools, type FoldedActivity } from "../tool-visibility";
+import { groupSettledTools, type ActivityItem, type FoldedActivity } from "../tool-visibility";
+import { subagentSummary } from "../subagent-card";
 import { shouldFocusPromptFromTranscriptPointer } from "../transcript-focus";
 
 // The scrollback is a flat list of entries: text blocks and rendered
@@ -47,6 +49,10 @@ type Entry =
       isError?: boolean;
       batchId: number; // user-turn batch; successful calls fold together at its end
       settled: boolean;
+      // SA.1: when this client appended the record — the subagent card's
+      // elapsed ticker. Client-side and honest only while live (a replay
+      // burst collapses it), so the card shows elapsed ONLY while running.
+      startedAt: number;
     }
   | {
       kind: "artifact";
@@ -168,22 +174,67 @@ function ToolCallList({ calls, className }: { calls: ToolCall[]; className: stri
   );
 }
 
-function SubagentGroup({ calls }: { calls: ToolCall[] }) {
+/** SA.1: a spawn whose wire id other records reference as parentId becomes a
+ * live subagent card — calm summary (agent type, the spawn's own description,
+ * state, tool count, elapsed while running, current action), expandable to
+ * the nested calls. Everything shown is the engine's own data rendered as
+ * inert plain text; the card itself is shell chrome. Elapsed ticks only
+ * while running — a settled or replayed card never shows a stale duration. */
+const SubagentCard = memo(function SubagentCard({
+  task,
+  calls,
+}: {
+  task: ToolCall;
+  calls: ToolCall[];
+}) {
   const [open, setOpen] = useState(false);
-  const pending = calls.some((c) => c.output === undefined);
+  const s = subagentSummary(task, calls);
+  const running = s.state === "running";
+  const [, tick] = useReducer((n: number) => n + 1, 0);
+  useEffect(() => {
+    if (!running) return;
+    const timer = setInterval(tick, 1_000);
+    return () => clearInterval(timer);
+  }, [running]);
+  const elapsed = Math.max(0, Math.floor((Date.now() - task.startedAt) / 1_000));
   return (
-    <div className="subagent-group">
-      <button className="subagent-head" onClick={() => setOpen(!open)}>
-        <span className="subagent-caret">{open ? "▾" : "▸"}</span>
-        <span className="subagent-label">
-          <GearGlyph size="1em" /> subagent · {calls.length} call{calls.length === 1 ? "" : "s"}
-          {pending ? " …" : ""}
+    <div
+      className={
+        "subagent-card" +
+        (running
+          ? " subagent-card-running"
+          : s.state === "failed"
+            ? " subagent-card-failed"
+            : " subagent-card-done")
+      }
+      role="group"
+      aria-label={`subagent: ${s.description} (${s.state})`}
+    >
+      <button
+        className="subagent-card-head"
+        onClick={() => setOpen(!open)}
+        aria-expanded={open}
+        title={open ? "Collapse subagent activity" : "Expand subagent activity"}
+      >
+        <span className="subagent-dot" aria-hidden="true" />
+        {s.agentType && <span className="subagent-type">{s.agentType}</span>}
+        <span className="subagent-desc">{s.description}</span>
+        <span className="subagent-live">
+          {running ? s.currentAction : s.state === "failed" ? "failed" : "done"}
         </span>
+        <span className="subagent-caret">{open ? "▾" : "▸"}</span>
       </button>
+      <div className="subagent-card-meta">
+        <GearGlyph size="1em" /> {s.toolCount} tool{s.toolCount === 1 ? "" : "s"}
+        {running ? ` · ${elapsed}s` : ""}
+        {!running && s.resultLine ? (
+          <span className="subagent-result"> · {s.resultLine}</span>
+        ) : null}
+      </div>
       {open && <ToolCallList calls={calls} className="subagent-calls" />}
     </div>
   );
-}
+});
 
 /** A completed turn's successful engine activity: one terminal-sized line by
  * default, with every normalized call still available on demand. The fold can
@@ -418,6 +469,7 @@ export function RenderZone({
                 parentId: msg.parentId,
                 batchId,
                 settled: false,
+                startedAt: Date.now(),
               },
             ]);
             break;
@@ -648,15 +700,24 @@ export function RenderZone({
   const compactedTools = useMemo(
     () =>
       groupSettledTools(
-        entries.map((entry) =>
+        entries.flatMap((entry): Array<ActivityItem<ToolCall, ThinkingEntry>> =>
           entry.kind === "tool"
-            ? { kind: "tool" as const, tool: entry }
+            ? entry.parentId && !entry.isError
+              ? // A subagent's call lives inside its card — invisible to the
+                // fold, and OMITTED (not a boundary) so a parent-level run is
+                // not split by child traffic it never displaces (SA.1).
+                []
+              : childrenByParent.has(entry.toolId)
+                ? // A subagent card is a visible block: folding across it
+                  // would move later work ahead of it. Hard boundary.
+                  [null]
+                : [{ kind: "tool" as const, tool: entry }]
             : entry.kind === "thinking"
-              ? { kind: "thinking" as const, thinking: entry }
-              : null,
+              ? [{ kind: "thinking" as const, thinking: entry }]
+              : [null],
         ),
       ),
-    [entries],
+    [entries, childrenByParent],
   );
 
   const handleTranscriptPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -851,14 +912,16 @@ function ZoneEntry({
     const compacted = compactedTools.anchors.get(entry.id);
     if (compacted) return <ToolActivityGroup items={compacted} onToggleThinking={toggleThinking} />;
     if (compactedTools.hidden.has(entry.id)) return null;
-    // Subagent calls are rendered nested under their Task (below),
+    // Subagent calls are rendered nested inside their card (below),
     // not at the top level.
     if (entry.parentId && !entry.isError) return null;
     const children = childrenByParent.get(entry.toolId);
+    // A spawn with visible children IS the card — the anchor is the
+    // referenced-as-parentId relationship, never the tool's name (SA.1).
+    if (children && children.length > 0) return <SubagentCard task={entry} calls={children} />;
     return (
       <div className="tool-group">
         <ToolBlock {...toolBlockProps(entry)} />
-        {children && children.length > 0 && <SubagentGroup calls={children} />}
       </div>
     );
   }

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -22,7 +22,7 @@ import { GearGlyph } from "./GearGlyph";
 import { useFollowTail } from "../use-follow-tail";
 import { queueDelta, type QueuedDelta } from "../delta-queue";
 import { groupSettledTools, type ActivityItem, type FoldedActivity } from "../tool-visibility";
-import { subagentSummary } from "../subagent-card";
+import { subagentSummary } from "../subagent-deck";
 import { shouldFocusPromptFromTranscriptPointer } from "../transcript-focus";
 
 // The scrollback is a flat list of entries: text blocks and rendered
@@ -49,19 +49,19 @@ type Entry =
       isError?: boolean;
       batchId: number; // user-turn batch; successful calls fold together at its end
       settled: boolean;
-      // SA.1: when this client appended the record — the subagent card's
+      // SA.1: when this client appended the record — the subagent deck's
       // elapsed ticker. Client-side and honest only while live (a replay
-      // burst collapses it), so the card shows elapsed ONLY while running.
+      // burst collapses it), so the deck shows elapsed ONLY while running.
       startedAt: number;
     }
   | {
       // SA.2: a subagent's narration or reasoning — prose the wire tags with
-      // a parentId. Lives inside its card's expansion, never at top level,
+      // a parentId. Lives inside its deck's expansion, never at top level,
       // and renders as INERT PLAIN TEXT (trusted-shell rule: subagent words
       // never get markdown inside shell chrome).
       kind: "subtext";
       id: number;
-      parentId: string; // the spawn wire id whose card holds this
+      parentId: string; // the spawn wire id whose deck holds this
       variant: "text" | "thinking";
       text: string;
     }
@@ -186,7 +186,7 @@ function ToolCallList({ calls, className }: { calls: ToolCall[]; className: stri
   );
 }
 
-/** The card's full activity, in true stream order (SA.2): tool rows plus the
+/** The deck's full activity, in true stream order (SA.2): tool rows plus the
  *  subagent's own narration and reasoning. Prose is INERT PLAIN TEXT —
  *  subagent words never render as markdown inside shell chrome. */
 function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) {
@@ -211,12 +211,12 @@ function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) 
 }
 
 /** SA.1: a spawn whose wire id other records reference as parentId becomes a
- * live subagent card — calm summary (agent type, the spawn's own description,
+ * live subagent deck — calm summary (agent type, the spawn's own description,
  * state, tool count, elapsed while running, current action), expandable to
  * the nested calls. Everything shown is the engine's own data rendered as
- * inert plain text; the card itself is shell chrome. Elapsed ticks only
+ * inert plain text; the deck itself is shell chrome. Elapsed ticks only
  * while running — a settled or replayed card never shows a stale duration. */
-const SubagentCard = memo(function SubagentCard({
+const SubagentDeck = memo(function SubagentDeck({
   task,
   calls,
   items,
@@ -238,18 +238,18 @@ const SubagentCard = memo(function SubagentCard({
   return (
     <div
       className={
-        "subagent-card" +
+        "subagent-deck" +
         (running
-          ? " subagent-card-running"
+          ? " subagent-deck-running"
           : s.state === "failed"
-            ? " subagent-card-failed"
-            : " subagent-card-done")
+            ? " subagent-deck-failed"
+            : " subagent-deck-done")
       }
       role="group"
       aria-label={`subagent: ${s.description} (${s.state})`}
     >
       <button
-        className="subagent-card-head"
+        className="subagent-deck-head"
         onClick={() => setOpen(!open)}
         aria-expanded={open}
         title={open ? "Collapse subagent activity" : "Expand subagent activity"}
@@ -262,7 +262,7 @@ const SubagentCard = memo(function SubagentCard({
         </span>
         <span className="subagent-caret">{open ? "▾" : "▸"}</span>
       </button>
-      <div className="subagent-card-meta">
+      <div className="subagent-deck-meta">
         <GearGlyph size="1em" /> {s.toolCount} tool{s.toolCount === 1 ? "" : "s"}
         {running ? ` · ${elapsed}s` : ""}
         {!running && s.resultLine ? (
@@ -357,7 +357,7 @@ export function RenderZone({
   const streamingId = useRef<number | null>(null);
   // SA.2: the open subtext entry per (parentId|variant) — a subagent's
   // consecutive prose extends in place; its own next tool call closes it so
-  // the card's expansion keeps true stream order.
+  // the deck's expansion keeps true stream order.
   const subtextIds = useRef(new Map<string, number>());
   // The thinking block currently receiving deltas (T2.1).
   const thinkingId = useRef<number | null>(null);
@@ -370,7 +370,7 @@ export function RenderZone({
   useEffect(
     () => {
       const apply = (msg: ZoneMsg) => {
-        // SA.2: a subagent's prose routes to its card BEFORE the fold/close
+        // SA.2: a subagent's prose routes to its deck BEFORE the fold/close
         // logic below — a child streaming must not fold the parent's open
         // thinking or close the parent's streaming text block. Consecutive
         // same-parent same-variant deltas extend one subtext entry, so the
@@ -770,8 +770,8 @@ export function RenderZone({
     return byParent;
   }, [entries]);
 
-  // SA.2: everything a card's expansion shows — child calls AND the
-  // subagent's prose — in true stream order. Also the card's anchor test:
+  // SA.2: everything a deck's expansion shows — child calls AND the
+  // subagent's prose — in true stream order. Also the deck's anchor test:
   // narration can arrive before the first child tool call, and a spawn with
   // only prose is still a card.
   const cardItemsByParent = useMemo(() => {
@@ -793,19 +793,19 @@ export function RenderZone({
         entries.flatMap((entry): Array<ActivityItem<ToolCall, ThinkingEntry>> =>
           entry.kind === "tool"
             ? entry.parentId && !entry.isError
-              ? // A subagent's call lives inside its card — invisible to the
+              ? // A subagent's call lives inside its deck — invisible to the
                 // fold, and OMITTED (not a boundary) so a parent-level run is
                 // not split by child traffic it never displaces (SA.1).
                 []
               : cardItemsByParent.has(entry.toolId)
-                ? // A subagent card is a visible block: folding across it
+                ? // A subagent deck is a visible block: folding across it
                   // would move later work ahead of it. Hard boundary.
                   [null]
                 : [{ kind: "tool" as const, tool: entry }]
             : entry.kind === "thinking"
               ? [{ kind: "thinking" as const, thinking: entry }]
               : entry.kind === "subtext"
-                ? // Inside its card — invisible to folding, like child calls.
+                ? // Inside its deck — invisible to folding, like child calls.
                   []
                 : [null],
         ),
@@ -952,7 +952,7 @@ function ZoneEntry({
   pinned: string[];
   togglePin: (renderId: string) => void;
 }) {
-  // A subagent's prose lives inside its card's expansion, never top-level.
+  // A subagent's prose lives inside its deck's expansion, never top-level.
   if (entry.kind === "subtext") return null;
   if (entry.kind === "thinking") {
     // Narration absorbed into a "worked" fold renders inside that fold.
@@ -1010,15 +1010,15 @@ function ZoneEntry({
     const compacted = compactedTools.anchors.get(entry.id);
     if (compacted) return <ToolActivityGroup items={compacted} onToggleThinking={toggleThinking} />;
     if (compactedTools.hidden.has(entry.id)) return null;
-    // Subagent calls are rendered nested inside their card (below),
+    // Subagent calls are rendered nested inside their deck (below),
     // not at the top level.
     if (entry.parentId && !entry.isError) return null;
     const items = cardItemsByParent.get(entry.toolId);
-    // A spawn with visible children IS the card — the anchor is the
+    // A spawn with visible children IS the deck — the anchor is the
     // referenced-as-parentId relationship, never the tool's name (SA.1).
     if (items && items.length > 0)
       return (
-        <SubagentCard
+        <SubagentDeck
           task={entry}
           calls={childrenByParent.get(entry.toolId) ?? []}
           items={items}

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -22,7 +22,7 @@ import { GearGlyph } from "./GearGlyph";
 import { useFollowTail } from "../use-follow-tail";
 import { queueDelta, type QueuedDelta } from "../delta-queue";
 import { groupSettledTools, type ActivityItem, type FoldedActivity } from "../tool-visibility";
-import { subagentSummary } from "../subagent-deck";
+import { deckElapsedSeconds, subagentSummary } from "../subagent-deck";
 import { shouldFocusPromptFromTranscriptPointer } from "../transcript-focus";
 
 // The scrollback is a flat list of entries: text blocks and rendered
@@ -50,9 +50,12 @@ type Entry =
       batchId: number; // user-turn batch; successful calls fold together at its end
       settled: boolean;
       // SA.1: when this client appended the record — the subagent deck's
-      // elapsed ticker. Client-side and honest only while live (a replay
-      // burst collapses it), so the deck shows elapsed ONLY while running.
+      // elapsed ticker. Only honest for a record seen arriving LIVE, so the
+      // deck shows elapsed only while running AND not replayed (a replayed
+      // record's stamp is the attach moment, not the spawn — bughunt
+      // 2026-08-14).
       startedAt: number;
+      replayed?: boolean;
     }
   | {
       // SA.2: a subagent's narration or reasoning — prose the wire tags with
@@ -221,7 +224,7 @@ const SubagentDeck = memo(function SubagentDeck({
     const timer = setInterval(tick, 1_000);
     return () => clearInterval(timer);
   }, [running]);
-  const elapsed = Math.max(0, Math.floor((Date.now() - task.startedAt) / 1_000));
+  const elapsed = deckElapsedSeconds(task, running, Date.now());
   return (
     <div
       className={
@@ -251,7 +254,7 @@ const SubagentDeck = memo(function SubagentDeck({
       </button>
       <div className="subagent-deck-meta">
         <GearGlyph size="1em" /> {s.toolCount} tool{s.toolCount === 1 ? "" : "s"}
-        {running ? ` · ${elapsed}s` : ""}
+        {elapsed !== undefined ? ` · ${elapsed}s` : ""}
         {!running && s.resultLine ? (
           <span className="subagent-result"> · {s.resultLine}</span>
         ) : null}
@@ -529,6 +532,7 @@ export function RenderZone({
                 batchId,
                 settled: false,
                 startedAt: Date.now(),
+                ...(msg.replay ? { replayed: true } : {}),
               },
             ]);
             break;

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -55,6 +55,17 @@ type Entry =
       startedAt: number;
     }
   | {
+      // SA.2: a subagent's narration or reasoning — prose the wire tags with
+      // a parentId. Lives inside its card's expansion, never at top level,
+      // and renders as INERT PLAIN TEXT (trusted-shell rule: subagent words
+      // never get markdown inside shell chrome).
+      kind: "subtext";
+      id: number;
+      parentId: string; // the spawn wire id whose card holds this
+      variant: "text" | "thinking";
+      text: string;
+    }
+  | {
       kind: "artifact";
       id: number;
       artifactId: string; // wire id — re-sends with this id replace the html
@@ -97,6 +108,7 @@ type Entry =
       hint?: string;
     };
 type ToolCall = Extract<Entry, { kind: "tool" }>;
+type SubtextEntry = Extract<Entry, { kind: "subtext" }>;
 
 /** The transcript fields ToolBlock renders, picked off any tool-shaped
  *  record — the one spread all three ToolBlock sites share. */
@@ -174,6 +186,30 @@ function ToolCallList({ calls, className }: { calls: ToolCall[]; className: stri
   );
 }
 
+/** The card's full activity, in true stream order (SA.2): tool rows plus the
+ *  subagent's own narration and reasoning. Prose is INERT PLAIN TEXT —
+ *  subagent words never render as markdown inside shell chrome. */
+function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) {
+  return (
+    <div className="subagent-calls">
+      {items.map((item) =>
+        item.kind === "tool" ? (
+          <ToolBlock key={item.id} {...toolBlockProps(item)} />
+        ) : (
+          <div
+            key={item.id}
+            className={
+              "subagent-prose" + (item.variant === "thinking" ? " subagent-prose-thinking" : "")
+            }
+          >
+            ✳ {item.text}
+          </div>
+        ),
+      )}
+    </div>
+  );
+}
+
 /** SA.1: a spawn whose wire id other records reference as parentId becomes a
  * live subagent card — calm summary (agent type, the spawn's own description,
  * state, tool count, elapsed while running, current action), expandable to
@@ -183,9 +219,11 @@ function ToolCallList({ calls, className }: { calls: ToolCall[]; className: stri
 const SubagentCard = memo(function SubagentCard({
   task,
   calls,
+  items,
 }: {
   task: ToolCall;
   calls: ToolCall[];
+  items: Array<ToolCall | SubtextEntry>;
 }) {
   const [open, setOpen] = useState(false);
   const s = subagentSummary(task, calls);
@@ -231,7 +269,7 @@ const SubagentCard = memo(function SubagentCard({
           <span className="subagent-result"> · {s.resultLine}</span>
         ) : null}
       </div>
-      {open && <ToolCallList calls={calls} className="subagent-calls" />}
+      {open && <SubagentActivity items={items} />}
     </div>
   );
 });
@@ -317,6 +355,10 @@ export function RenderZone({
   // The text block currently receiving deltas. Kept in a ref so a user prompt
   // sent mid-stream can't detach the tail of the reply.
   const streamingId = useRef<number | null>(null);
+  // SA.2: the open subtext entry per (parentId|variant) — a subagent's
+  // consecutive prose extends in place; its own next tool call closes it so
+  // the card's expansion keeps true stream order.
+  const subtextIds = useRef(new Map<string, number>());
   // The thinking block currently receiving deltas (T2.1).
   const thinkingId = useRef<number | null>(null);
   // User prompts may queue while a turn is running. Tool events still belong
@@ -328,6 +370,30 @@ export function RenderZone({
   useEffect(
     () => {
       const apply = (msg: ZoneMsg) => {
+        // SA.2: a subagent's prose routes to its card BEFORE the fold/close
+        // logic below — a child streaming must not fold the parent's open
+        // thinking or close the parent's streaming text block. Consecutive
+        // same-parent same-variant deltas extend one subtext entry, so the
+        // card reads as prose, not confetti.
+        if ((msg.type === "text_delta" || msg.type === "thinking_delta") && msg.parentId) {
+          const parentId = msg.parentId;
+          const text = msg.text;
+          const variant = msg.type === "text_delta" ? ("text" as const) : ("thinking" as const);
+          const key = `${parentId}|${variant}`;
+          const openId = subtextIds.current.get(key);
+          if (openId !== undefined) {
+            setEntries((es) =>
+              es.map((e) =>
+                e.kind === "subtext" && e.id === openId ? { ...e, text: e.text + text } : e,
+              ),
+            );
+          } else {
+            const newId = nextId++;
+            subtextIds.current.set(key, newId);
+            setEntries((es) => [...es, { kind: "subtext", id: newId, parentId, variant, text }]);
+          }
+          return;
+        }
         // Collapse-on-finalize (T2.1): the open thinking block folds the
         // moment the turn's real output starts.
         const foldThinking = () => {
@@ -455,6 +521,12 @@ export function RenderZone({
             // Close the streaming text block (same reason as `render`):
             // later deltas must open a new block after this record.
             streamingId.current = null;
+            // A subagent's own tool call closes ITS open prose runs, so
+            // narration after the call opens a new entry below it (SA.2).
+            if (msg.parentId) {
+              subtextIds.current.delete(`${msg.parentId}|text`);
+              subtextIds.current.delete(`${msg.parentId}|thinking`);
+            }
             const id = nextId++;
             const batchId = openToolBatches.current[0] ?? orphanToolBatch.current;
             setEntries((es) => [
@@ -489,6 +561,7 @@ export function RenderZone({
           case "turn_end": {
             const id = streamingId.current;
             streamingId.current = null;
+            subtextIds.current.clear();
             const batchId = openToolBatches.current.shift() ?? orphanToolBatch.current--;
             setEntries((es) =>
               es.map((e) => {
@@ -697,6 +770,23 @@ export function RenderZone({
     return byParent;
   }, [entries]);
 
+  // SA.2: everything a card's expansion shows — child calls AND the
+  // subagent's prose — in true stream order. Also the card's anchor test:
+  // narration can arrive before the first child tool call, and a spawn with
+  // only prose is still a card.
+  const cardItemsByParent = useMemo(() => {
+    const byParent = new Map<string, Array<ToolCall | SubtextEntry>>();
+    for (const e of entries) {
+      const parentId =
+        e.kind === "tool" && !e.isError ? e.parentId : e.kind === "subtext" ? e.parentId : undefined;
+      if (!parentId) continue;
+      const arr = byParent.get(parentId) ?? [];
+      arr.push(e as ToolCall | SubtextEntry);
+      byParent.set(parentId, arr);
+    }
+    return byParent;
+  }, [entries]);
+
   const compactedTools = useMemo(
     () =>
       groupSettledTools(
@@ -707,17 +797,20 @@ export function RenderZone({
                 // fold, and OMITTED (not a boundary) so a parent-level run is
                 // not split by child traffic it never displaces (SA.1).
                 []
-              : childrenByParent.has(entry.toolId)
+              : cardItemsByParent.has(entry.toolId)
                 ? // A subagent card is a visible block: folding across it
                   // would move later work ahead of it. Hard boundary.
                   [null]
                 : [{ kind: "tool" as const, tool: entry }]
             : entry.kind === "thinking"
               ? [{ kind: "thinking" as const, thinking: entry }]
-              : [null],
+              : entry.kind === "subtext"
+                ? // Inside its card — invisible to folding, like child calls.
+                  []
+                : [null],
         ),
       ),
-    [entries, childrenByParent],
+    [entries, cardItemsByParent],
   );
 
   const handleTranscriptPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -804,6 +897,7 @@ export function RenderZone({
             entry={entry}
             toggleThinking={toggleThinking}
             childrenByParent={childrenByParent}
+            cardItemsByParent={cardItemsByParent}
             compactedTools={compactedTools}
             activePickerId={activePickerId}
             handleAction={handleAction}
@@ -841,6 +935,7 @@ function ZoneEntry({
   entry,
   toggleThinking,
   childrenByParent,
+  cardItemsByParent,
   compactedTools,
   activePickerId,
   handleAction,
@@ -850,12 +945,15 @@ function ZoneEntry({
   entry: Entry;
   toggleThinking: (id: number) => void;
   childrenByParent: Map<string, ToolCall[]>;
+  cardItemsByParent: Map<string, Array<ToolCall | SubtextEntry>>;
   compactedTools: ReturnType<typeof groupSettledTools<ToolCall, ThinkingEntry>>;
   activePickerId: number | null;
   handleAction: (action: Action, sourceId: string) => void;
   pinned: string[];
   togglePin: (renderId: string) => void;
 }) {
+  // A subagent's prose lives inside its card's expansion, never top-level.
+  if (entry.kind === "subtext") return null;
   if (entry.kind === "thinking") {
     // Narration absorbed into a "worked" fold renders inside that fold.
     if (compactedTools.hidden.has(entry.id)) return null;
@@ -915,10 +1013,17 @@ function ZoneEntry({
     // Subagent calls are rendered nested inside their card (below),
     // not at the top level.
     if (entry.parentId && !entry.isError) return null;
-    const children = childrenByParent.get(entry.toolId);
+    const items = cardItemsByParent.get(entry.toolId);
     // A spawn with visible children IS the card — the anchor is the
     // referenced-as-parentId relationship, never the tool's name (SA.1).
-    if (children && children.length > 0) return <SubagentCard task={entry} calls={children} />;
+    if (items && items.length > 0)
+      return (
+        <SubagentCard
+          task={entry}
+          calls={childrenByParent.get(entry.toolId) ?? []}
+          items={items}
+        />
+      );
     return (
       <div className="tool-group">
         <ToolBlock {...toolBlockProps(entry)} />

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -174,18 +174,6 @@ const ThinkingBlock = memo(function ThinkingBlock({
   );
 });
 
-/** A Task's subagent tool calls (T2.4): collapsed by default — a subagent's
- *  churn shouldn't crowd the transcript — expandable to the nested rows. */
-function ToolCallList({ calls, className }: { calls: ToolCall[]; className: string }) {
-  return (
-    <div className={className}>
-      {calls.map((call) => (
-        <ToolBlock key={call.id} {...toolBlockProps(call)} />
-      ))}
-    </div>
-  );
-}
-
 /** The deck's full activity, in true stream order (SA.2): tool rows plus the
  *  subagent's own narration and reasoning. Prose is INERT PLAIN TEXT —
  *  subagent words never render as markdown inside shell chrome. */
@@ -218,14 +206,13 @@ function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) 
  * while running — a settled or replayed card never shows a stale duration. */
 const SubagentDeck = memo(function SubagentDeck({
   task,
-  calls,
   items,
 }: {
   task: ToolCall;
-  calls: ToolCall[];
   items: Array<ToolCall | SubtextEntry>;
 }) {
   const [open, setOpen] = useState(false);
+  const calls = items.filter((item) => item.kind === "tool");
   const s = subagentSummary(task, calls);
   const running = s.state === "running";
   const [, tick] = useReducer((n: number) => n + 1, 0);
@@ -754,35 +741,21 @@ export function RenderZone({
     return active;
   }, [entries]);
 
-  // Subagent calls (parentId set) grouped under their Task's wire id (T2.4).
-  const childrenByParent = useMemo(() => {
-    const byParent = new Map<string, ToolCall[]>();
-    for (const e of entries) {
-      // A failed child moves to its own expanded top-level row. Keeping it in
-      // the parent group too would show the same failure twice between result
-      // and turn_end.
-      if (e.kind === "tool" && e.parentId && !e.isError) {
-        const arr = byParent.get(e.parentId) ?? [];
-        arr.push(e);
-        byParent.set(e.parentId, arr);
-      }
-    }
-    return byParent;
-  }, [entries]);
-
-  // SA.2: everything a deck's expansion shows — child calls AND the
-  // subagent's prose — in true stream order. Also the deck's anchor test:
-  // narration can arrive before the first child tool call, and a spawn with
-  // only prose is still a card.
+  // Everything a subagent deck shows, grouped under its spawn's wire id and
+  // in true stream order: child calls (T2.4/SA.1) interleaved with the
+  // subagent's prose (SA.2). Also the deck's anchor test — narration can
+  // arrive before the first child tool call, and a spawn with only prose is
+  // still a deck. A FAILED child is excluded: it moves to its own expanded
+  // top-level row, and keeping it here too would show the same failure twice
+  // between result and turn_end.
   const cardItemsByParent = useMemo(() => {
     const byParent = new Map<string, Array<ToolCall | SubtextEntry>>();
     for (const e of entries) {
-      const parentId =
-        e.kind === "tool" && !e.isError ? e.parentId : e.kind === "subtext" ? e.parentId : undefined;
-      if (!parentId) continue;
-      const arr = byParent.get(parentId) ?? [];
-      arr.push(e as ToolCall | SubtextEntry);
-      byParent.set(parentId, arr);
+      if ((e.kind !== "tool" && e.kind !== "subtext") || !e.parentId) continue;
+      if (e.kind === "tool" && e.isError) continue;
+      const arr = byParent.get(e.parentId) ?? [];
+      arr.push(e);
+      byParent.set(e.parentId, arr);
     }
     return byParent;
   }, [entries]);
@@ -896,7 +869,6 @@ export function RenderZone({
             key={entry.id}
             entry={entry}
             toggleThinking={toggleThinking}
-            childrenByParent={childrenByParent}
             cardItemsByParent={cardItemsByParent}
             compactedTools={compactedTools}
             activePickerId={activePickerId}
@@ -934,7 +906,6 @@ export function RenderZone({
 function ZoneEntry({
   entry,
   toggleThinking,
-  childrenByParent,
   cardItemsByParent,
   compactedTools,
   activePickerId,
@@ -944,7 +915,6 @@ function ZoneEntry({
 }: {
   entry: Entry;
   toggleThinking: (id: number) => void;
-  childrenByParent: Map<string, ToolCall[]>;
   cardItemsByParent: Map<string, Array<ToolCall | SubtextEntry>>;
   compactedTools: ReturnType<typeof groupSettledTools<ToolCall, ThinkingEntry>>;
   activePickerId: number | null;
@@ -1016,14 +986,7 @@ function ZoneEntry({
     const items = cardItemsByParent.get(entry.toolId);
     // A spawn with visible children IS the deck — the anchor is the
     // referenced-as-parentId relationship, never the tool's name (SA.1).
-    if (items && items.length > 0)
-      return (
-        <SubagentDeck
-          task={entry}
-          calls={childrenByParent.get(entry.toolId) ?? []}
-          items={items}
-        />
-      );
+    if (items && items.length > 0) return <SubagentDeck task={entry} items={items} />;
     return (
       <div className="tool-group">
         <ToolBlock {...toolBlockProps(entry)} />

--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -637,6 +637,9 @@ export function RenderZone({
             // A (re)attach replays the session's history from scratch.
             streamingId.current = null;
             thinkingId.current = null;
+            // Stale open-subtext keys would swallow replayed subagent prose
+            // into entry ids that no longer exist (bughunt 2026-08-14 r2).
+            subtextIds.current.clear();
             openToolBatches.current = [];
             orphanToolBatch.current = -1;
             tail.resetTail(); // a replayed transcript lands at its end

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -310,15 +310,21 @@ export function Shell() {
           // The turn COUNTER re-derives with it (nextOpenTurns' floor rule,
           // 2026-07-29 bughunt — see turn-busy.ts).
           setBusy(true);
+          // SA.2: a SUBAGENT's prose (parentId set) still proves the turn is
+          // busy, but it is not the parent's voice — it must not steer the
+          // activity label and never lands in the turn-end announcement.
+          const subagentProse =
+            (m.type === "text_delta" || m.type === "thinking_delta") && m.parentId;
           if (m.type === "status") setActivity({ state: m.state, label: m.label });
-          else if (m.type === "thinking_delta") setActivity({ state: "thinking" });
-          else if (m.type === "tool_use") setActivity({ state: "tool", label: m.name });
+          else if (m.type === "thinking_delta") {
+            if (!subagentProse) setActivity({ state: "thinking" });
+          } else if (m.type === "tool_use") setActivity({ state: "tool", label: m.name });
           // Streamed prose means the last specific label is over; the
           // indicator falls back to the generic "working…".
-          else setActivity(null);
+          else if (!subagentProse) setActivity(null);
           // A.1: the response is announced once at turn_end, so the prose is
           // banked here rather than spoken per token.
-          if (m.type === "text_delta") turnText.current += m.text;
+          if (m.type === "text_delta" && !subagentProse) turnText.current += m.text;
           // Tool activity is the other thing a sighted user reads off the
           // transcript mid-turn; announce the name, not the arguments.
           if (m.type === "tool_use" && live) announce(`Running ${m.name}.`);

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -310,28 +310,39 @@ export function Shell() {
           // The turn COUNTER re-derives with it (nextOpenTurns' floor rule,
           // 2026-07-29 bughunt — see turn-busy.ts).
           setBusy(true);
-          // SA.2: a SUBAGENT's prose (parentId set) still proves the turn is
-          // busy, but it is not the parent's voice — it must not steer the
-          // activity label and never lands in the turn-end announcement.
-          const subagentProse =
-            (m.type === "text_delta" || m.type === "thinking_delta") && m.parentId;
+          // SA.2/SA.3: a SUBAGENT's traffic (parentId set) still proves the
+          // turn is busy, but it is not the parent's voice — child prose and
+          // child tool churn must not steer the activity label (the deck
+          // shows each subagent's own current action; bughunt 2026-08-14 r2
+          // aligned tool_use with the design after the server-side comment
+          // claimed it and the client contradicted it), and child prose
+          // never lands in the turn-end announcement. The announcer still
+          // speaks child tools — the audible peer of the deck's ticker.
+          const subagentTraffic =
+            (m.type === "text_delta" || m.type === "thinking_delta" || m.type === "tool_use") &&
+            m.parentId;
           if (m.type === "status") setActivity({ state: m.state, label: m.label });
           else if (m.type === "thinking_delta") {
-            if (!subagentProse) setActivity({ state: "thinking" });
-          } else if (m.type === "tool_use") setActivity({ state: "tool", label: m.name });
+            if (!subagentTraffic) setActivity({ state: "thinking" });
+          } else if (m.type === "tool_use") {
+            if (!subagentTraffic) setActivity({ state: "tool", label: m.name });
+          }
           // Streamed prose means the last specific label is over; the
           // indicator falls back to the generic "working…".
-          else if (!subagentProse) setActivity(null);
+          else if (!subagentTraffic) setActivity(null);
           // A.1: the response is announced once at turn_end, so the prose is
           // banked here rather than spoken per token.
-          if (m.type === "text_delta" && !subagentProse) turnText.current += m.text;
+          if (m.type === "text_delta" && !subagentTraffic) turnText.current += m.text;
           // Tool activity is the other thing a sighted user reads off the
           // transcript mid-turn; announce the name, not the arguments.
           if (m.type === "tool_use" && live) announce(`Running ${m.name}.`);
         } else if (m.type === "tool_result") {
           // A finished tool must not keep naming itself — a frozen "Bash"
           // through the next model round trip reads as "done?" (2026-07-29).
-          setActivity((a) => (a?.state === "tool" ? null : a));
+          // A CHILD's result is not the labeled tool finishing: subagent
+          // traffic never steers the root label, in either direction
+          // (bughunt 2026-08-14 r2).
+          if (!m.parentId) setActivity((a) => (a?.state === "tool" ? null : a));
         } else if (m.type === "turn_end") {
           setBusy(openTurns.current > 0);
           setActivity(null);

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -339,11 +339,18 @@ export function Shell() {
           if (live) announce(turnResponse(turnText.current));
           turnText.current = "";
         } else if (m.type === "permission_request") {
-          setAsks((a) => [...a, { tool: m.tool, detail: m.detail, id: m.id }]);
+          setAsks((a) => [
+            ...a,
+            { tool: m.tool, detail: m.detail, id: m.id, ...(m.parentId ? { parentId: m.parentId } : {}) },
+          ]);
           // Assertive: this one blocks the turn until answered. A replayed
           // ask still paints the bar (it may be genuinely pending), just
           // without re-interrupting the reader.
-          if (live) announce(`Permission needed: ${m.tool}. ${m.detail}`, true);
+          if (live)
+            announce(
+              `Permission needed${m.parentId ? " (subagent)" : ""}: ${m.tool}. ${m.detail}`,
+              true,
+            );
         } else if (m.type === "permission_resolved") {
           // The ask was answered on ANOTHER viewport, or auto-denied by the
           // daemon's timeout — drop it HERE too. Before this, the bar sat

--- a/web/src/delta-queue.test.ts
+++ b/web/src/delta-queue.test.ts
@@ -31,3 +31,18 @@ test("the queued entry is a copy — merging never mutates the wire message", ()
   assert.equal(original.text, "a");
   assert.equal(q[0].text, "ab");
 });
+
+test("SA.2: a different parentId never merges — parallel subagents keep their prose apart", () => {
+  const q: QueuedDelta[] = [];
+  queueDelta(q, { type: "text_delta", text: "parent" });
+  queueDelta(q, { type: "text_delta", text: "A1", parentId: "a" });
+  queueDelta(q, { type: "text_delta", text: "A2", parentId: "a" });
+  queueDelta(q, { type: "text_delta", text: "B1", parentId: "b" });
+  queueDelta(q, { type: "thinking_delta", text: "B-think", parentId: "b" });
+  assert.deepEqual(q, [
+    { type: "text_delta", text: "parent" },
+    { type: "text_delta", text: "A1A2", parentId: "a" },
+    { type: "text_delta", text: "B1", parentId: "b" },
+    { type: "thinking_delta", text: "B-think", parentId: "b" },
+  ]);
+});

--- a/web/src/delta-queue.ts
+++ b/web/src/delta-queue.ts
@@ -5,12 +5,21 @@ export type QueuedDelta = Extract<WireMsg, { type: "text_delta" | "thinking_delt
 
 /**
  * Append a streamed delta to the pending batch, merging it into the tail
- * entry when both are the same delta type. The batch replays in arrival
- * order, so a merged entry's text is exactly the concatenation of the
- * deltas it absorbed — the same contract the daemon's coalescer keeps.
+ * entry when both are the same delta type AND the same origin (parentId —
+ * SA.2: with parallel subagents streaming, type alone would concatenate one
+ * agent's prose into another's). The batch replays in arrival order, so a
+ * merged entry's text is exactly the concatenation of the deltas it
+ * absorbed — the same contract the daemon's coalescer keeps.
  */
 export function queueDelta(queue: QueuedDelta[], msg: QueuedDelta): void {
   const last = queue[queue.length - 1];
-  if (last && last.type === msg.type) last.text += msg.text;
-  else queue.push({ type: msg.type, text: msg.text });
+  if (last && last.type === msg.type && last.parentId === msg.parentId) {
+    last.text += msg.text;
+  } else {
+    queue.push({
+      type: msg.type,
+      text: msg.text,
+      ...(msg.parentId !== undefined ? { parentId: msg.parentId } : {}),
+    });
+  }
 }

--- a/web/src/styles/06-tools.css
+++ b/web/src/styles/06-tools.css
@@ -145,7 +145,7 @@
 /* Subagent card (SA.1, supersedes the T2.4 group): a spawn with visible
    children renders as a live card — calm one-glance summary, expandable to
    the nested calls. Shell chrome; all content inert plain text. */
-.subagent-card {
+.subagent-deck {
   margin: 4px 0;
   padding: 6px 10px;
   border: 1px solid var(--border-mid);
@@ -155,7 +155,7 @@
   font-size: 0.8em;
 }
 
-.subagent-card-head {
+.subagent-deck-head {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -178,12 +178,12 @@
   background: var(--fg-faint);
 }
 
-.subagent-card-running .subagent-dot {
+.subagent-deck-running .subagent-dot {
   background: var(--accent);
   animation: subagent-pulse 1.6s ease-in-out infinite;
 }
 
-.subagent-card-failed .subagent-dot {
+.subagent-deck-failed .subagent-dot {
   background: var(--error-fg);
 }
 
@@ -194,7 +194,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .subagent-card-running .subagent-dot {
+  .subagent-deck-running .subagent-dot {
     animation: none;
   }
 }
@@ -223,11 +223,11 @@
   font-style: italic;
 }
 
-.subagent-card-head:hover .subagent-desc {
+.subagent-deck-head:hover .subagent-desc {
   color: var(--fg-mid);
 }
 
-.subagent-card-meta {
+.subagent-deck-meta {
   display: flex;
   align-items: center;
   gap: 5px;

--- a/web/src/styles/06-tools.css
+++ b/web/src/styles/06-tools.css
@@ -138,38 +138,118 @@
   font-style: italic;
 }
 
-/* Subagent group (T2.4): a Task's inner calls, nested and collapsible so a
-   subagent's churn is present but never crowds the transcript. */
 .tool-group {
   display: contents;
 }
 
-.subagent-group {
-  margin: -8px 0 0 22px;
-  padding-left: 12px;
-  border-left: 1px solid var(--border-mid);
+/* Subagent card (SA.1, supersedes the T2.4 group): a spawn with visible
+   children renders as a live card — calm one-glance summary, expandable to
+   the nested calls. Shell chrome; all content inert plain text. */
+.subagent-card {
+  margin: 4px 0;
+  padding: 6px 10px;
+  border: 1px solid var(--border-mid);
+  border-left: 2px solid var(--border-strong);
+  border-radius: 6px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 0.8em;
 }
 
-.subagent-head {
+.subagent-card-head {
   display: flex;
   align-items: center;
-  gap: 6px;
+  gap: 8px;
   width: 100%;
-  padding: 4px 0;
+  padding: 0;
   background: none;
   border: 0;
   cursor: pointer;
   text-align: left;
-  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
-  font-size: 0.8em;
+  font: inherit;
   color: var(--fg-dim);
+  min-width: 0;
 }
 
-.subagent-head:hover .subagent-label {
+.subagent-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+}
+
+.subagent-card-running .subagent-dot {
+  background: var(--accent);
+  animation: subagent-pulse 1.6s ease-in-out infinite;
+}
+
+.subagent-card-failed .subagent-dot {
+  background: var(--error-fg);
+}
+
+@keyframes subagent-pulse {
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .subagent-card-running .subagent-dot {
+    animation: none;
+  }
+}
+
+.subagent-type {
+  flex: none;
+  color: var(--fg-mid);
+  font-weight: 600;
+}
+
+.subagent-desc {
+  color: var(--fg-dim);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subagent-live {
+  margin-left: auto;
+  flex: none;
+  max-width: 40%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--fg-faint);
+  font-style: italic;
+}
+
+.subagent-card-head:hover .subagent-desc {
   color: var(--fg-mid);
 }
 
+.subagent-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 3px 0 0 15px;
+  color: var(--fg-faint);
+  min-width: 0;
+}
+
+.subagent-result {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.subagent-calls {
+  margin: 6px 0 0 6px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border-mid);
+}
+
 .subagent-caret {
+  flex: none;
   color: var(--fg-faint);
 }
 

--- a/web/src/styles/06-tools.css
+++ b/web/src/styles/06-tools.css
@@ -248,6 +248,20 @@
   border-left: 1px solid var(--border-mid);
 }
 
+/* SA.2: the subagent's own words inside the expansion — inert plain text,
+   pre-wrapped so streamed prose keeps its line breaks, dim like thinking. */
+.subagent-prose {
+  padding: 3px 0;
+  color: var(--fg-dim);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.subagent-prose-thinking {
+  color: var(--fg-dimmer);
+  font-style: italic;
+}
+
 .subagent-caret {
   flex: none;
   color: var(--fg-faint);

--- a/web/src/styles/10-prompt.css
+++ b/web/src/styles/10-prompt.css
@@ -313,6 +313,16 @@
   flex-shrink: 0;
 }
 
+/* SA.3: the ask came from a subagent — a dim factual chip, shell-composed. */
+.perm-subagent {
+  color: var(--fg-faint);
+  border: 1px solid var(--border-mid);
+  border-radius: 4px;
+  padding: 0 4px;
+  font-size: 0.75em;
+  flex-shrink: 0;
+}
+
 .perm-tool {
   color: var(--fg-strong);
   font-weight: 600;

--- a/web/src/subagent-card.test.ts
+++ b/web/src/subagent-card.test.ts
@@ -1,0 +1,88 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { subagentSummary } from "./subagent-card";
+
+// SA.1 — the card's calm-summary derivation. Pure data in, summary out; the
+// component renders exactly what this returns, so pinning it here pins the
+// card's one-glance truth without a DOM.
+
+test("running: agent type, description, count, and the newest active call", () => {
+  const s = subagentSummary(
+    {
+      name: "Task",
+      detail: "trace the token path",
+      input: { description: "trace the token path", subagent_type: "Explore" },
+    },
+    [
+      { name: "Grep", detail: '-rn "token" .', output: "4 hits" },
+      { name: "Read", detail: "server/relay/relay.ts" }, // no output — active
+    ],
+  );
+  assert.equal(s.state, "running");
+  assert.equal(s.agentType, "Explore");
+  assert.equal(s.description, "trace the token path");
+  assert.equal(s.toolCount, 2);
+  assert.equal(s.currentAction, "Read server/relay/relay.ts");
+  assert.equal(s.resultLine, undefined);
+});
+
+test("running with no active call still says it is working", () => {
+  const s = subagentSummary(
+    { name: "Task", input: { description: "d" } },
+    [{ name: "Grep", detail: "x", output: "done" }],
+  );
+  assert.equal(s.state, "running");
+  assert.equal(s.currentAction, "working…");
+});
+
+test("the NEWEST unanswered call wins over an older one", () => {
+  const s = subagentSummary({ name: "Task", input: {} }, [
+    { name: "Read", detail: "a.ts" }, // older, still open
+    { name: "Grep", detail: "-rn foo" }, // newest open — what it's doing NOW
+  ]);
+  assert.equal(s.currentAction, "Grep -rn foo");
+});
+
+test("done: result line is the report's first line, verbatim and capped", () => {
+  const s = subagentSummary(
+    {
+      name: "Agent",
+      input: { description: "map sessions", subagent_type: "general-purpose" },
+      output: "Sessions live in one registry.\nSecond line never shows.",
+    },
+    [{ name: "Grep", detail: "x", output: "hit" }],
+  );
+  assert.equal(s.state, "done");
+  assert.equal(s.currentAction, undefined);
+  assert.equal(s.resultLine, "Sessions live in one registry.");
+  const long = subagentSummary(
+    { name: "Agent", input: {}, output: "x".repeat(300) },
+    [],
+  );
+  assert.equal(long.resultLine!.length, 121); // 120 + ellipsis
+  assert.ok(long.resultLine!.endsWith("…"));
+});
+
+test("failed: an errored spawn reads failed, never done", () => {
+  const s = subagentSummary(
+    { name: "Task", input: { description: "d" }, output: "boom", isError: true },
+    [],
+  );
+  assert.equal(s.state, "failed");
+  assert.equal(s.resultLine, undefined);
+});
+
+test("description falls back input.description → detail → name; type absent stays absent", () => {
+  assert.equal(subagentSummary({ name: "Task", detail: "the detail" }, []).description, "the detail");
+  assert.equal(subagentSummary({ name: "task" }, []).description, "task");
+  // OpenCode's task tool input uses `description` too but no subagent_type
+  // guarantee — absence must not invent a type.
+  assert.equal(subagentSummary({ name: "task", input: { description: "d" } }, []).agentType, undefined);
+});
+
+test("long action details are truncated with an explicit ellipsis", () => {
+  const s = subagentSummary({ name: "Task" }, [{ name: "Bash", detail: "y".repeat(80) }]);
+  assert.ok(s.currentAction!.startsWith("Bash "));
+  assert.ok(s.currentAction!.endsWith("…"));
+  assert.ok(s.currentAction!.length < 60);
+});

--- a/web/src/subagent-card.ts
+++ b/web/src/subagent-card.ts
@@ -1,0 +1,75 @@
+// The calm-summary derivation for a subagent card (PLAN Phase SA.1) — pure,
+// so Tier-1 can pin it without a DOM. A "card" is any tool_use that other
+// wire records reference as their parentId; the anchor is name-agnostic
+// (Claude Code's spawn tool is `Agent` in SDK 0.3.201, was `Task`; OpenCode's
+// is `task`), so nothing here reads the tool's name as meaning.
+
+export type SubagentTaskLike = {
+  name: string;
+  detail?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  isError?: boolean;
+};
+
+export type SubagentChildLike = {
+  name: string;
+  detail?: string;
+  output?: string;
+};
+
+export type SubagentSummary = {
+  /** The engine-reported agent type, verbatim (input.subagent_type). */
+  agentType?: string;
+  /** The spawn's own description of the task, verbatim — never composed. */
+  description: string;
+  state: "running" | "done" | "failed";
+  toolCount: number;
+  /** While running: the child call currently executing ("Grep -rn foo"). */
+  currentAction?: string;
+  /** Once done: the first line of the subagent's final report, verbatim. */
+  resultLine?: string;
+};
+
+const ACTION_DETAIL_MAX = 48;
+const RESULT_LINE_MAX = 120;
+
+export function subagentSummary(
+  task: SubagentTaskLike,
+  calls: SubagentChildLike[],
+): SubagentSummary {
+  const input = task.input ?? {};
+  const agentType =
+    typeof input["subagent_type"] === "string" && input["subagent_type"]
+      ? input["subagent_type"]
+      : undefined;
+  const description =
+    (typeof input["description"] === "string" && input["description"]) ||
+    task.detail ||
+    task.name;
+  const state = task.isError ? "failed" : task.output !== undefined ? "done" : "running";
+  let currentAction: string | undefined;
+  if (state === "running") {
+    // The newest un-answered call is what the subagent is doing right now;
+    // between calls (or before the first) it is still working, and the line
+    // must say so rather than go blank.
+    const active = [...calls].reverse().find((c) => c.output === undefined);
+    currentAction = active
+      ? active.name +
+        (active.detail
+          ? " " +
+            (active.detail.length > ACTION_DETAIL_MAX
+              ? active.detail.slice(0, ACTION_DETAIL_MAX) + "…"
+              : active.detail)
+          : "")
+      : "working…";
+  }
+  let resultLine: string | undefined;
+  if (state === "done" && task.output) {
+    const first = task.output.split("\n", 1)[0].trim();
+    if (first) {
+      resultLine = first.length > RESULT_LINE_MAX ? first.slice(0, RESULT_LINE_MAX) + "…" : first;
+    }
+  }
+  return { agentType, description, state, toolCount: calls.length, currentAction, resultLine };
+}

--- a/web/src/subagent-deck.test.ts
+++ b/web/src/subagent-deck.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { subagentSummary } from "./subagent-card";
+import { subagentSummary } from "./subagent-deck";
 
 // SA.1 — the card's calm-summary derivation. Pure data in, summary out; the
 // component renders exactly what this returns, so pinning it here pins the

--- a/web/src/subagent-deck.test.ts
+++ b/web/src/subagent-deck.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { subagentSummary } from "./subagent-deck";
+import { deckElapsedSeconds, subagentSummary } from "./subagent-deck";
 
 // SA.1 — the card's calm-summary derivation. Pure data in, summary out; the
 // component renders exactly what this returns, so pinning it here pins the
@@ -85,4 +85,13 @@ test("long action details are truncated with an explicit ellipsis", () => {
   assert.ok(s.currentAction!.startsWith("Bash "));
   assert.ok(s.currentAction!.endsWith("…"));
   assert.ok(s.currentAction!.length < 60);
+});
+
+test("elapsed shows only for a LIVE running spawn — replayed stamps are the attach moment, not the spawn (bughunt 2026-08-14)", () => {
+  const t0 = 1_000_000;
+  assert.equal(deckElapsedSeconds({ startedAt: t0 }, true, t0 + 42_500), 42);
+  assert.equal(deckElapsedSeconds({ startedAt: t0, replayed: true }, true, t0 + 42_500), undefined);
+  assert.equal(deckElapsedSeconds({ startedAt: t0 }, false, t0 + 42_500), undefined);
+  // A clock that reads slightly behind the stamp still never shows -1s.
+  assert.equal(deckElapsedSeconds({ startedAt: t0 }, true, t0 - 10), 0);
 });

--- a/web/src/subagent-deck.ts
+++ b/web/src/subagent-deck.ts
@@ -34,6 +34,20 @@ export type SubagentSummary = {
 const ACTION_DETAIL_MAX = 48;
 const RESULT_LINE_MAX = 120;
 
+/** The deck's elapsed readout, or undefined when no honest number exists:
+ *  only a RUNNING spawn whose record this client saw arrive LIVE has a
+ *  truthful start stamp. A REPLAYED record's stamp is the attach/reload
+ *  moment, not the spawn — showing it would tick a false duration
+ *  (bughunt 2026-08-14) — and a settled deck's duration was never measured. */
+export function deckElapsedSeconds(
+  task: { startedAt: number; replayed?: boolean },
+  running: boolean,
+  now: number,
+): number | undefined {
+  if (!running || task.replayed) return undefined;
+  return Math.max(0, Math.floor((now - task.startedAt) / 1_000));
+}
+
 export function subagentSummary(
   task: SubagentTaskLike,
   calls: SubagentChildLike[],

--- a/web/src/subagent-deck.ts
+++ b/web/src/subagent-deck.ts
@@ -1,4 +1,4 @@
-// The calm-summary derivation for a subagent card (PLAN Phase SA.1) — pure,
+// The calm-summary derivation for a subagent deck (PLAN Phase SA.1) — pure,
 // so Tier-1 can pin it without a DOM. A "card" is any tool_use that other
 // wire records reference as their parentId; the anchor is name-agnostic
 // (Claude Code's spawn tool is `Agent` in SDK 0.3.201, was `Task`; OpenCode's


### PR DESCRIPTION
## What this is

Phase SA complete (PLAN.md): when a session's agent fans out subagents, Mirafold renders them as live **subagent decks** — calm one-glance summaries (agent type, the spawn's own description, state, tool count, elapsed, current action), expandable to the full activity: nested calls interleaved with the subagent's own narration and reasoning as inert plain text. Automatic; no new user action.

- **SA.0** — zero-spend live probes: a real `opencode serve` 1.18.18 subagent run captured raw (fixture: `server/testing/opencode-subagent-fixture.ts`) and the real Claude Code CLI via SDK 0.3.201 against a scripted Anthropic endpoint. Pinned truths: subagent prose arrives message-grain and LIVE; a subagent's gated tool call fires the parent `canUseTool`; OpenCode's join key is the task part's `state.metadata.sessionId`; the deprecated per-session reply endpoint never validated ownership.
- **SA.1** — the deck, from data already on the wire (zero protocol change); mock three-spawn fan-out with out-of-order finishes; fold-boundary rules; e2e in headless Chrome.
- **SA.2** — the narration lane: additive opaque `parentId` on `text_delta`/`thinking_delta`; both coalescers key merges on it; Claude Code forwards subagent text/thinking through a shared per-subagent byte budget (explicit elision, never silent); expansion renders prose inert.
- **SA.3** — the OpenCode mapping proves the lane agent-neutral: child sessions route by spawn-part id (transitive for configured nesting), prose capped, child render calls get honest tool records. **Fixes a real defect: an OpenCode subagent's permission ask was dropped whole and the child hung** — now surfaced with a dim "subagent" chip (`permission_request.parentId`), deny timer armed, replied via the modern session-agnostic endpoint. Tier-4 drives a REAL engine fan-out end to end.
- **SA.4** — glossary-true rename (deck, not card) + README/ADAPTERS/GLOSSARY docs; Codex posture recorded (collab exists engine-side; mapping deferred to F.5's app-server migration).

## Verification

Tier-1 817/817 · Tier-2 152/152 · app e2e 57/57 (three decks ticking independently, out-of-order settle, expand shows narration, axe-clean, phone stack) · Tier-4 live 1/1 (real engine subagent, attributed ask answered through the production bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)