### PR TITLE
Phase CS: self-serve subscription cancel from inside the product

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2404,6 +2404,15 @@ both acceptance requirements, not a later responsive cleanup.
   full-ordered Tier-3 failure — observed 1-in-6 runs on 2026-08-12, failing
   test unnamed (the first run's log was summary-filtered); every later run
   keeps the complete TAP log, so the next occurrence names itself.
+  **2026-08-14 — it named itself, in CI:** PR #48's first Tier-2+3 run
+  failed exactly one test, **E2.4 "the Projects-root proof"**, a 30 s
+  `page.waitForSelector('.files-panel[role=dialog]')` TimeoutError at the
+  phone drill-in step (app.e2e.ts:2839). Same day the full suite passed
+  3× locally (the CS runs) with E2.4 green each time, so the 1-in-6-ish
+  intermittent read stands — now with a name and a stuck selector to
+  instrument. Not diagnosed or fixed this sitting (Phase CS's scope);
+  next occurrence: read whether the Files panel button was clicked but
+  the dialog never mounted, or the click itself was swallowed.
 
 - [x] **Step CR.13 — Security audit of the post-CR.6 delta** — done
   2026-08-12; every new input path traced with concrete values, ZERO
@@ -2602,6 +2611,134 @@ it never spawns or directs subagents itself (the homegrown-orchestrator trap).
   default-on since ~2026-02) but child inner activity needs app-server
   per-thread subscriptions — mapping deferred to **Phase F Step F.5**; the
   researched posture is recorded in docs/ADAPTERS.md's capability matrix.
+
+## Phase CS — Self-serve subscription cancel (opened 2026-08-14; Kyle-directed; plan signed off by Kyle)
+
+**Why.** A Mirafold Pro customer who wants to stop paying currently has two
+paths: the billing link in their Paddle receipt email, or emailing support —
+i.e. Kyle, manually. This phase adds the third, first-class path: cancel (or
+undo a cancel) from inside the product. Last feature before the next release
+off `next` (Kyle, 2026-08-14).
+
+**Decisions (all Kyle-signed 2026-08-14):**
+- **Direct in-product cancel**, not a Paddle customer-portal link: the daemon
+  calls new billing-backend endpoints with the license key as the bearer
+  credential — the exact trust model `/api/entitlement` already uses. A
+  portal deep-link was rejected: it would turn a leaked key into an
+  authenticated door to a Paddle billing page (email, card, invoices),
+  where the direct path exposes nothing but schedule-cancel/undo/status.
+- **The license key stays the identity** (no accounts). Anyone holding a key
+  can cancel its subscription — accepted: damage is capped at "doesn't
+  renew" (end-of-period only, never lost paid time), it's undoable, and a
+  leaked key already gives the strictly bigger prize (relay access billed
+  to the victim).
+- **End-of-period only, always** (`effective_from: next_billing_period`).
+  One code path serves trial and paid alike: a `trialing` sub's next
+  billing date IS the trial end, so cancel-in-trial = never charged, and
+  cancel-while-paid = access through the paid period. Matches /terms and
+  /refunds verbatim. No "cancel immediately" ever offered (no pro-rating
+  exists, so it would only destroy paid access).
+- **Undo ships too**: a scheduled cancellation is a pending
+  `scheduled_change` on the Paddle subscription until the period boundary;
+  `PATCH /subscriptions/{id} {scheduled_change: null}` removes it. The UI
+  shows "cancellation scheduled for <date> — undo" for the whole window.
+- **Placement: nothing cancel-shaped is ever passively visible.** A neutral
+  "manage subscription" link inside the Connect-a-device card (the one
+  place Pro already manifests) opens a subscription view — status line
+  ("trial — first charge <date>" / "renews <date>"), and cancel as an
+  action there, behind its own confirm step. Local viewports only (the
+  card already is); shown only when the daemon runs on a license key —
+  self-host, token-override, and unentitled daemons see nothing.
+
+**Revocation needs no new work:** on cancel, status stays `trialing`/`active`
+until the period ends; Paddle's `subscription.canceled` webhook then flips KV,
+`/api/entitlement` starts refusing, and the ≤48 h token window does the rest —
+exactly the promised behavior.
+
+- [x] **Step CS.1 — Billing-backend endpoints** — ✅ built + tested
+  2026-08-14 on the site repo's `feature/cancel-endpoints` branch (six new
+  offline tests drive the full arc; suite 27/27). Not yet deployed — the
+  deploy is CS.4's first move. *(original contract below)*
+  - Build: three Pages Functions under `functions/api/subscription/`
+    (`/api/subscription` status, `/api/subscription/cancel`,
+    `/api/subscription/uncancel`), all POST `{licenseKey}`. Each resolves
+    key → sub via KV with entitlement.js's exact no-oracle rule (unknown
+    and superseded keys refuse identically), then reads/acts on Paddle:
+    status = live `GET /subscriptions/{id}`; cancel = `POST …/cancel`
+    `{effective_from: "next_billing_period"}` (idempotent: already
+    scheduled or already `canceled` returns current state, no error);
+    uncancel = `PATCH …/{id}` `{scheduled_change: null}` (idempotent when
+    nothing is scheduled). All three answer one view shape:
+    `{status, periodEnd, cancelAt}` (`cancelAt` = scheduled cancel's
+    `effective_at`, else null). Cross-site guard + no-store as on the
+    existing functions; zero deps, zero build.
+  - Done when: the site's `node --test` suite covers the full arc offline
+    (status → cancel → scheduled view → uncancel → clean view, plus
+    unknown/superseded key refusals and idempotent re-cancel) and passes.
+- [x] **Step CS.2 — Daemon: subscription actions + wire messages** — ✅ done
+  2026-08-14 (`feature/cancel-subscription`): `server/relay/subscription.ts`,
+  the three additive client messages + the `subscription` reply + the
+  `billing` hello flag, connection handlers (remote refused, throttle env
+  knob `SUBSCRIPTION_MIN_GAP_MS`), 12 new Tier-1 pins. All tiers green.
+  *(original contract below)*
+  - Build: `server/relay/subscription.ts` — active only in `license-key`
+    mode; endpoint base derived from `MIRAFOLD_ENTITLEMENT_URL` (strip the
+    trailing `/entitlement`; underivable → feature off), no new env vars;
+    never throws, 10 s timeout, failures become the support-email fallback
+    line. Protocol (ADD only): client `subscription_status` /
+    `subscription_cancel` / `subscription_uncancel` (id-correlated), reply
+    `subscription` `{id, status?, periodEnd?, cancelAt?, error?}` —
+    per-viewport request/reply, never buffered or sequenced. `agents`
+    hello gains optional `billing: "license-key"`, local viewports only.
+    connection.ts handlers: remote viewports refused ("manage from the
+    desktop"), per-connection min-gap throttle, license key itself never
+    on the wire in either direction.
+  - Done when: Tier-1 covers the client (stubbed fetch: view, refusal,
+    outage → fallback line, base derivation) and connection handling
+    (billing flag local-only, remote refusal, throttle), and existing
+    suites stay green.
+- [x] **Step CS.3 — Web: the manage-subscription view** — ✅ done 2026-08-14:
+  `web/src/subscription-card.ts` (pure brain, 5 Tier-1 pins), the manage view
+  inside ConnectDevice with both hosts wired, and the Tier-3 e2e driving the
+  full arc against a stub billing backend — including the proof the license
+  key never reaches the page. Tier 1 **837** / Tier 2 **152** / Tier 3
+  **100**, all green. *(One e2e-authoring bug found + fixed en route: the
+  fleet's pair button sits under the onboarding overlay on an empty registry,
+  so the test enters a session first. The 2026-08-12 unattributed Tier-3
+  watch item did NOT reproduce in three full runs.)* *(original contract
+  below)*
+  - Build: the Connect-a-device card gains the neutral "manage
+    subscription" link (only when the hello carries `billing`); it opens
+    the subscription view: status line from the view shape, `cancel
+    subscription` → an explicit confirm quoting the real consequence
+    ("access runs to <date>; you won't be charged again"), then the
+    scheduled state with `undo cancellation`. Errors show the
+    support-email fallback. Card state is a pure reducer
+    (`web/src/subscription-card.ts`), Tier-1-pinned; both hosts (status
+    bar + fleet) wire send/reply.
+  - Done when: Tier-1 pins the reducer + labels, and a Tier-3 e2e drives
+    the real flow in headless Chrome against a stubbed billing endpoint
+    (open card → manage → renews-line → cancel → confirm → scheduled +
+    undo → clean state), all tiers green.
+- [ ] **Step CS.4 — Ship sequencing + live verification (Kyle-gated)**
+  - **Progress 2026-08-14: the site half is LIVE.** Kyle merged the site
+    branch into site main (Pages deployed); all three endpoints probed live
+    same turn — contract shapes confirmed (400 malformed / identical
+    no-oracle refusal), /refunds + /terms carry the in-product-cancel copy.
+    The deploy-before-npm rule is satisfied. Remaining: PR #48 merge, then
+    the live arc on Kyle's real subscription (status → cancel → Paddle
+    shows the scheduled change → undo).
+  - The site half deploys first (Pages deploys on push to the site repo's
+    main): until it's live, the product-side card degrades to the
+    support-email line by design — but never release the product half to
+    npm ahead of the site half. Then verify live with Kyle's real
+    subscription: status view correct → cancel → Paddle dashboard shows
+    the scheduled cancellation → undo → clean again. Site /refunds +
+    /terms gain "or from inside the product" as an additional cancel path
+    (never replacing the existing promises).
+  - Done when: the live arc above is observed on Kyle's subscription and
+    the policy-page copy is updated. Merges: Kyle's explicit yes, per the
+    standing PR rule.
 
 ## Phase PN — Panes (file views beside the transcript)
 

--- a/README.md
+++ b/README.md
@@ -1567,7 +1567,13 @@ short-lived signed tokens and sends them on the dial-out),
 `MIRAFOLD_ENTITLEMENT_URL` (the exchange endpoint, default
 `https://mirafold.com/api/entitlement`), and `MIRAFOLD_ENTITLEMENT_TOKEN`
 (a hand-issued token used verbatim — ops/testing; wins over the license
-key). For dev, `node --import tsx server/relay/relay-stub.ts`
+key). A daemon running on a license key also offers **manage
+subscription** inside the connect-a-device card (local viewports only):
+subscription status, an end-of-period cancel behind its own confirm, and
+undo while the cancellation is still scheduled — the daemon presents the
+key to the billing backend's `/api/subscription` endpoints itself, so the
+key never reaches the browser (Phase CS). For dev,
+`node --import tsx server/relay/relay-stub.ts`
 runs the in-repo stub relay on `:9100`.
 
 **Fully local, no API key:** a session is local when the *agent* behind it

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,6 +13,7 @@ import { probeLocalServers } from "./local-models";
 import { sweepLiveness } from "./sessions/ws-liveness";
 import { startRelayClient } from "./relay/relay-client";
 import { createEntitlementTokenSource } from "./relay/entitlement";
+import { createSubscriptionActions } from "./relay/subscription";
 import { MIN_PAIRING_CODE_LENGTH, resolvePairingCode } from "./relay/relay-protocol";
 import { carriesCredentialInClear, resolveRelayPlan } from "./relay/relay-url";
 import {
@@ -279,6 +280,12 @@ function resolveRelayConfig(): {
 }
 const { code: RELAY_CODE, info: relayInfo } = resolveRelayConfig();
 
+// Phase CS: the manage-subscription backend — present only when this daemon
+// runs on a license key (subscription.ts decides; token-override and
+// self-host get nothing). Handed to LOCAL viewports only: billing actions
+// stay on the machine that holds the key, so the relay path never sees it.
+const subscriptionActions = createSubscriptionActions(process.env);
+
 // Per-socket liveness, read by the heartbeat below to reap half-open
 // leftovers whose `close` never arrived (see ws-liveness.ts) (#10).
 const liveViewports = new WeakMap<WebSocket, boolean>();
@@ -298,7 +305,7 @@ wss.on("connection", (ws) => {
   const viewport = (msg: WireMsg) => {
     if (ws.readyState === ws.OPEN) ws.send(JSON.stringify(msg));
   };
-  const conn = openConnection(registry, viewport, "ws", relayInfo);
+  const conn = openConnection(registry, viewport, "ws", relayInfo, false, subscriptionActions);
   ws.on("message", (data) => conn.handleMessage(String(data)));
   ws.on("close", conn.close);
 });

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -145,6 +145,13 @@ const WIRE: WireByType = {
     version: "0.0.1",
   },
   folder_picked: { type: "folder_picked", id: "fp1", path: "/home/u/other-project" },
+  subscription: {
+    type: "subscription",
+    id: "sub1",
+    status: "active",
+    periodEnd: "2026-09-01T00:00:00Z",
+    cancelAt: "2026-09-01T00:00:00Z",
+  },
   // Phase FD: staged-upload replies (correlated, per-viewport).
   file_upload_done: {
     type: "file_upload_done",
@@ -267,6 +274,9 @@ const CLIENT: ClientByType = {
   prompt_session: { type: "prompt_session", sessionId: "s1", text: "run the tests" },
   refresh_agents: { type: "refresh_agents" },
   pick_folder: { type: "pick_folder", id: "fp1", cwd: "/home/u/proj" },
+  subscription_status: { type: "subscription_status", id: "sub1" },
+  subscription_cancel: { type: "subscription_cancel", id: "sub1" },
+  subscription_uncancel: { type: "subscription_uncancel", id: "sub1" },
   fs_list: { type: "fs_list", id: "f1" },
   fs_changes: { type: "fs_changes", id: "f5" },
   fs_listdir: { type: "fs_listdir", id: "f4", path: "src" },

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -211,10 +211,30 @@ type WireMsgBody =
       folderPicker?: boolean;
       relay?: { url: string; code: string; ws?: string };
       version?: string;
+      // Phase CS (optional/additive): this daemon runs on a license key and
+      // can manage the subscription behind it — the "manage subscription"
+      // affordance's gate. LOCAL viewports only (the R.4i posture: billing
+      // actions stay on the machine that holds the key); token-override,
+      // self-host, and unentitled daemons send nothing. Old clients strip it.
+      billing?: "license-key";
     }
   // N2: one local, per-viewport reply to `pick_folder`; never broadcast or
   // replayed. Cancel is explicit so an empty reply cannot strand the button.
   | { type: "folder_picked"; id: string; path?: string; canceled?: true; error?: string }
+  // Phase CS: the one reply to all three subscription_* requests — the
+  // manage-subscription card's data, per-viewport request/reply (echoed
+  // client-minted id), never broadcast or replay-buffered. Success carries
+  // the view (`cancelAt` set = a cancellation is scheduled for that
+  // instant); failure carries `error` and nothing else. The license key
+  // itself never rides this wire in either direction — the daemon holds it.
+  | {
+      type: "subscription";
+      id: string;
+      status?: string;
+      periodEnd?: string;
+      cancelAt?: string;
+      error?: string;
+    }
   // The daemon refused to attach this REMOTE (relay) viewport to the
   // session because the session's credential can't be used over the paid relay
   // — a subscription-backed agent (closed-model reselling posture). Sent instead
@@ -622,6 +642,15 @@ export type ClientMsg =
   // folder dialog. `cwd` is only the suggested starting directory; the daemon
   // validates it and returns the actual selected path in `folder_picked`.
   | { type: "pick_folder"; id: string; cwd?: string }
+  // Phase CS: the manage-subscription card's three requests, each answered
+  // by exactly one `subscription` reply with the echoed id. `status` reads;
+  // `cancel` schedules an end-of-period cancellation (the confirm step is
+  // the shell's, client-side); `uncancel` removes a scheduled one. Local
+  // viewports only — a remote (relay) viewport gets an error reply, and
+  // never the `billing` hello flag that draws the affordance.
+  | { type: "subscription_status"; id: string }
+  | { type: "subscription_cancel"; id: string }
+  | { type: "subscription_uncancel"; id: string }
   // Phase E (Explorer): the read-only file browser's per-viewport queries.
   // `id` is client-minted (the bang-id grammar) so the issuing component can
   // correlate the one reply each request gets. The path is a REQUEST — the

--- a/server/relay/subscription.test.ts
+++ b/server/relay/subscription.test.ts
@@ -1,0 +1,106 @@
+import { test, mock } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createSubscriptionActions,
+  createSubscriptionThrottle,
+  subscriptionBase,
+  SUPPORT_FALLBACK,
+} from "./subscription";
+
+// Phase CS: the daemon's billing-backend client. Everything here runs against
+// a mocked fetch — no test may ever reach the real billing backend, let alone
+// Paddle behind it.
+
+const KEY = "mf_abcdefghijklmnopqrstuvwxyz";
+
+test("CS: active only in license-key mode — override, keyless, and underivable URLs get nothing", () => {
+  assert.equal(createSubscriptionActions({}), undefined);
+  assert.equal(
+    createSubscriptionActions({ MIRAFOLD_ENTITLEMENT_TOKEN: "tok.x", MIRAFOLD_LICENSE_KEY: KEY }),
+    undefined,
+    "the ops override has no key in play",
+  );
+  assert.equal(
+    createSubscriptionActions({
+      MIRAFOLD_LICENSE_KEY: KEY,
+      MIRAFOLD_ENTITLEMENT_URL: "https://self.host/exchange",
+    }),
+    undefined,
+    "a custom exchange URL we can't derive siblings from turns the feature off, never guesses",
+  );
+  assert.notEqual(createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY }), undefined);
+});
+
+test("CS: endpoint derivation strips /entitlement, nothing else", () => {
+  assert.equal(
+    subscriptionBase("https://mirafold.com/api/entitlement"),
+    "https://mirafold.com/api/subscription",
+  );
+  assert.equal(
+    subscriptionBase("http://127.0.0.1:9999/api/entitlement/"),
+    "http://127.0.0.1:9999/api/subscription",
+  );
+  assert.equal(subscriptionBase("https://self.host/exchange"), undefined);
+});
+
+test("CS: the three actions hit the derived endpoints with the key, and a view round-trips", async () => {
+  const calls: { url: string; body: unknown }[] = [];
+  const m = mock.method(globalThis, "fetch", async (input: unknown, init?: RequestInit) => {
+    calls.push({ url: String(input), body: JSON.parse(String(init?.body)) });
+    return Response.json({
+      status: "active",
+      periodEnd: "2026-09-01T00:00:00Z",
+      cancelAt: null,
+    });
+  });
+  try {
+    const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY })!;
+    const s = await actions.status();
+    await actions.cancel();
+    await actions.uncancel();
+    assert.deepEqual(
+      calls.map((c) => c.url),
+      [
+        "https://mirafold.com/api/subscription",
+        "https://mirafold.com/api/subscription/cancel",
+        "https://mirafold.com/api/subscription/uncancel",
+      ],
+    );
+    assert.ok(calls.every((c) => (c.body as { licenseKey: string }).licenseKey === KEY));
+    // The null cancelAt is dropped, not forwarded as a null on the wire.
+    assert.deepEqual(s, { view: { status: "active", periodEnd: "2026-09-01T00:00:00Z" } });
+  } finally {
+    m.mock.restore();
+  }
+});
+
+test("CS: a backend refusal's reason surfaces, bounded; malformed and down degrade to the support line", async () => {
+  let mode: "refusal" | "malformed" | "down" = "refusal";
+  const m = mock.method(globalThis, "fetch", async () => {
+    if (mode === "refusal") {
+      return Response.json({ reason: `nope ${"x".repeat(500)}` }, { status: 403 });
+    }
+    if (mode === "malformed") return Response.json({ unexpected: true });
+    throw new Error("network down");
+  });
+  try {
+    const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY })!;
+    const refusal = (await actions.status()) as { error: string };
+    assert.ok(refusal.error.startsWith("nope "));
+    assert.ok(refusal.error.length <= 200, "a self-hoster's arbitrary reason text is bounded");
+    mode = "malformed";
+    assert.deepEqual(await actions.status(), { error: SUPPORT_FALLBACK });
+    mode = "down";
+    assert.deepEqual(await actions.status(), { error: SUPPORT_FALLBACK });
+  } finally {
+    m.mock.restore();
+  }
+});
+
+test("CS: the throttle admits one in-flight action and floors restarts", () => {
+  const t = createSubscriptionThrottle(60_000);
+  assert.equal(t.tryStart(), true);
+  assert.equal(t.tryStart(), false, "second start while in flight is refused");
+  t.done();
+  assert.equal(t.tryStart(), false, "the min gap holds even after completion");
+});

--- a/server/relay/subscription.ts
+++ b/server/relay/subscription.ts
@@ -1,0 +1,128 @@
+// Phase CS — the daemon's side of self-serve subscription management. Active
+// only in `license-key` mode: the license key is the bearer credential to the
+// billing backend's manage endpoints, so token-override (ops) and self-host
+// (no key) daemons have nothing to manage and get no affordance. The key
+// itself never crosses the viewport wire in either direction — the browser
+// asks THIS daemon, and this daemon presents the key, exactly like the
+// entitlement exchange.
+//
+// Endpoint discovery: derived from MIRAFOLD_ENTITLEMENT_URL (no new env
+// vars) — the default https://mirafold.com/api/entitlement yields
+// …/api/subscription[/cancel|/uncancel]. A custom exchange URL that doesn't
+// end in /entitlement is a shape we can't derive siblings for, so the
+// feature simply stays off — never a guess at someone else's routes.
+//
+// Failure posture mirrors entitlement.ts: never throw, never block; any
+// outage degrades to the standing support-email path the site promises.
+
+import { createLogger } from "../log";
+
+const log = createLogger("relay");
+
+const FETCH_TIMEOUT_MS = 10_000;
+// A cancel is a hand-clicked action; anything faster than this per action
+// burst is a stuck client or a hostile one — serve the refusal, not Paddle.
+const MIN_GAP_MS = 2_000;
+const MAX_REASON_CHARS = 200;
+
+/** What the manage-subscription card renders — nothing more rides back. */
+export type SubscriptionView = { status: string; periodEnd?: string; cancelAt?: string };
+export type SubscriptionResult = { view: SubscriptionView } | { error: string };
+
+export type SubscriptionActions = {
+  status: () => Promise<SubscriptionResult>;
+  cancel: () => Promise<SubscriptionResult>;
+  uncancel: () => Promise<SubscriptionResult>;
+};
+
+/** The one fallback line — the path /refunds already promises, so an outage
+ *  never strands a customer with no way to cancel. */
+export const SUPPORT_FALLBACK =
+  "billing backend unreachable — email support@mirafold.com and we'll handle it directly";
+
+/** Exported for the boot log + tests: where the manage endpoints live for a
+ *  given exchange URL, or undefined when underivable. */
+export function subscriptionBase(entitlementUrl: string): string | undefined {
+  const base = entitlementUrl.replace(/\/entitlement\/?$/, "/subscription");
+  return base === entitlementUrl ? undefined : base;
+}
+
+const optionalIso = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+
+export function createSubscriptionActions(env: {
+  MIRAFOLD_ENTITLEMENT_TOKEN?: string;
+  MIRAFOLD_LICENSE_KEY?: string;
+  MIRAFOLD_ENTITLEMENT_URL?: string;
+}): SubscriptionActions | undefined {
+  if (env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim()) return undefined; // ops override — no key in play
+  const licenseKey = env.MIRAFOLD_LICENSE_KEY?.trim();
+  if (!licenseKey) return undefined;
+  const url = env.MIRAFOLD_ENTITLEMENT_URL?.trim() || "https://mirafold.com/api/entitlement";
+  const base = subscriptionBase(url);
+  if (!base) {
+    log.warn(
+      `manage-subscription off: MIRAFOLD_ENTITLEMENT_URL doesn't end in /entitlement, ` +
+        `so the manage endpoints can't be derived from it`,
+    );
+    return undefined;
+  }
+
+  const call = async (endpoint: string): Promise<SubscriptionResult> => {
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ licenseKey }),
+        signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+      });
+      if (res.status === 403 || res.status === 400) {
+        // Our backend's own composed refusal (unknown/superseded key). Shown
+        // as-is but bounded: a self-hoster can point the exchange anywhere,
+        // and this string lands in a shell-owned surface.
+        const reason = ((await res.json().catch(() => ({}))) as { reason?: string; error?: string });
+        const text = typeof reason.reason === "string" ? reason.reason : reason.error;
+        return { error: (text || SUPPORT_FALLBACK).slice(0, MAX_REASON_CHARS) };
+      }
+      if (!res.ok) throw new Error(`http ${res.status}`);
+      const body = (await res.json()) as Record<string, unknown>;
+      if (typeof body.status !== "string") throw new Error("malformed response");
+      const view: SubscriptionView = { status: body.status.slice(0, 40) };
+      const periodEnd = optionalIso(body.periodEnd);
+      const cancelAt = optionalIso(body.cancelAt);
+      if (periodEnd) view.periodEnd = periodEnd;
+      if (cancelAt) view.cancelAt = cancelAt;
+      return { view };
+    } catch {
+      return { error: SUPPORT_FALLBACK };
+    }
+  };
+
+  return {
+    status: () => call(base),
+    cancel: () => call(`${base}/cancel`),
+    uncancel: () => call(`${base}/uncancel`),
+  };
+}
+
+/**
+ * Per-connection guard shared by the three message handlers: one in-flight
+ * action at a time with a floor between starts, so a stuck button or a
+ * hostile viewport can't turn clicks into a Paddle hammer. Throttled
+ * requests still get a reply — silence strands the card in "working".
+ */
+export function createSubscriptionThrottle(minGapMs = MIN_GAP_MS) {
+  let lastStart = 0;
+  let inflight = false;
+  return {
+    tryStart(): boolean {
+      const now = Date.now();
+      if (inflight || now - lastStart < minGapMs) return false;
+      lastStart = now;
+      inflight = true;
+      return true;
+    },
+    done(): void {
+      inflight = false;
+    },
+  };
+}

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -16,6 +16,10 @@ import {
   type Backend,
 } from "../adapters";
 import { relayGateRefusal } from "../provider-policy";
+import {
+  createSubscriptionThrottle,
+  type SubscriptionActions,
+} from "../relay/subscription";
 import { probeLocalServers } from "../local-models";
 import { createLogger } from "../log";
 import { VERSION } from "../version";
@@ -86,6 +90,11 @@ export function openConnection(
   // it). The relay gate refuses to attach such a viewport to a subscription-
   // backed session; local viewports are never gated (R.4i).
   remote = false,
+  // Phase CS: present when this daemon runs on a license key — the manage-
+  // subscription card's backend. The local WS path passes it; billing
+  // actions never ride the relay (the key stays with the machine that
+  // holds it), so remote viewports get error replies and no hello flag.
+  subscription?: SubscriptionActions,
 ): Connection {
   const log = createLogger(label);
   // A connection is a viewport onto one registry session (Step 4.2) — or,
@@ -256,6 +265,7 @@ export function openConnection(
       folderPicker: !remote && folderPickerAvailable(),
       version: VERSION,
       ...(relay ? { relay } : {}),
+      ...(subscription && !remote ? { billing: "license-key" as const } : {}),
     });
   sendAgents();
 
@@ -277,6 +287,39 @@ export function openConnection(
     if (typeof v === "string" && v && v !== VERSION) {
       log.warn(`version skew: client v${v}, daemon v${VERSION}`);
     }
+  };
+
+  // Phase CS: the manage-subscription card's three requests. One in-flight
+  // action with a floor between starts (a stuck/hostile client must not
+  // hammer the billing backend), and EVERY request gets its reply — silence
+  // would strand the card in "working". Remote viewports are refused here
+  // too, not just denied the hello flag: the flag gates the UI, this gates
+  // the action (a crafted frame is cheap; the key's actions stay local).
+  const subThrottle = createSubscriptionThrottle(envInt("SUBSCRIPTION_MIN_GAP_MS", 2_000));
+  const handleSubscription = (id: unknown, act: keyof SubscriptionActions) => {
+    if (typeof id !== "string" || !id) return;
+    const refused = !subscription
+      ? "no subscription is configured on this daemon"
+      : remote
+        ? "manage the subscription from the desktop that holds the license key"
+        : undefined;
+    if (refused) {
+      viewport({ type: "subscription", id, error: refused });
+      return;
+    }
+    if (!subThrottle.tryStart()) {
+      viewport({ type: "subscription", id, error: "one moment — a billing request is already in flight" });
+      return;
+    }
+    void subscription![act]().then((r) => {
+      subThrottle.done();
+      if (closed) return;
+      viewport(
+        "view" in r
+          ? { type: "subscription", id, ...r.view }
+          : { type: "subscription", id, error: r.error },
+      );
+    });
   };
 
   // Resolve a cockpit act's target session (M.2): unknown id → error reply;
@@ -551,6 +594,15 @@ export function openConnection(
         void probeLocalServers().then(() => {
           if (!closed) sendAgents();
         });
+        break;
+      case "subscription_status":
+        handleSubscription(msg.id, "status");
+        break;
+      case "subscription_cancel":
+        handleSubscription(msg.id, "cancel");
+        break;
+      case "subscription_uncancel":
+        handleSubscription(msg.id, "uncancel");
         break;
       case "pick_folder":
         folderPicker.pick(msg);

--- a/server/sessions/subscription-conn.test.ts
+++ b/server/sessions/subscription-conn.test.ts
@@ -1,0 +1,112 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import type { WireMsg } from "../protocol";
+import { SessionRegistry } from "./registry";
+import { openConnection, type Connection } from "./connection";
+import type { SubscriptionActions, SubscriptionResult } from "../relay/subscription";
+import type { Backend } from "../adapters";
+
+// Phase CS at the connection layer: the hello's `billing` flag and the three
+// subscription_* handlers, openConnection driven directly (the fleet-acts
+// harness) with a fake SubscriptionActions in hand.
+
+const NONE: Backend = { agent: "claude-code", kind: "none", live: false };
+
+function fakeActions(result: SubscriptionResult = { view: { status: "active" } }) {
+  const calls: string[] = [];
+  const act = (name: string) => () => {
+    calls.push(name);
+    return Promise.resolve(result);
+  };
+  const actions: SubscriptionActions = {
+    status: act("status"),
+    cancel: act("cancel"),
+    uncancel: act("uncancel"),
+  };
+  return { actions, calls };
+}
+
+function conn(remote: boolean, actions?: SubscriptionActions) {
+  const reg = new SessionRegistry(NONE);
+  const seen: WireMsg[] = [];
+  const c = openConnection(reg, (m) => seen.push(m), "test", undefined, remote, actions);
+  return { c, seen };
+}
+const send = (c: Connection, msg: unknown) => c.handleMessage(JSON.stringify(msg));
+const replies = (seen: WireMsg[]) =>
+  seen.filter((m) => m.type === "subscription") as Extract<WireMsg, { type: "subscription" }>[];
+const settle = () => new Promise((r) => setImmediate(r));
+
+test("CS: the billing hello flag is local-only and actions-only", () => {
+  const { actions } = fakeActions();
+  const hello = (remote: boolean, a?: SubscriptionActions) =>
+    conn(remote, a).seen.find((m) => m.type === "agents") as { billing?: string };
+  assert.equal(hello(false, actions).billing, "license-key");
+  assert.equal(hello(true, actions).billing, undefined, "remote viewports never see the flag");
+  assert.equal(hello(false, undefined).billing, undefined, "no license key, no affordance");
+});
+
+test("CS: a status request round-trips the view with the echoed id", async () => {
+  const { actions } = fakeActions({
+    view: { status: "trialing", periodEnd: "2026-08-17T00:00:00Z" },
+  });
+  const { c, seen } = conn(false, actions);
+  send(c, { type: "subscription_status", id: "s1" });
+  await settle();
+  assert.deepEqual(replies(seen), [
+    { type: "subscription", id: "s1", status: "trialing", periodEnd: "2026-08-17T00:00:00Z" },
+  ]);
+});
+
+test("CS: an error result answers as error, same echoed id", async () => {
+  const { actions } = fakeActions({ error: "billing backend unreachable" });
+  const { c, seen } = conn(false, actions);
+  send(c, { type: "subscription_cancel", id: "c1" });
+  await settle();
+  assert.deepEqual(replies(seen), [
+    { type: "subscription", id: "c1", error: "billing backend unreachable" },
+  ]);
+});
+
+test("CS: a remote viewport's crafted cancel is refused and never reaches the backend", async () => {
+  // The hello flag gates the UI; this gates the action — a crafted frame is
+  // cheap, and the key's actions stay on the machine that holds it.
+  const { actions, calls } = fakeActions();
+  const { c, seen } = conn(true, actions);
+  send(c, { type: "subscription_cancel", id: "r1" });
+  await settle();
+  assert.equal(replies(seen).length, 1);
+  assert.match(replies(seen)[0].error!, /desktop/);
+  assert.deepEqual(calls, []);
+});
+
+test("CS: a daemon with no subscription answers every request with an error, not silence", async () => {
+  const { c, seen } = conn(false, undefined);
+  for (const type of ["subscription_status", "subscription_cancel", "subscription_uncancel"]) {
+    send(c, { type, id: `x-${type}` });
+  }
+  await settle();
+  assert.equal(replies(seen).length, 3);
+  assert.ok(replies(seen).every((r) => r.error?.includes("no subscription")));
+});
+
+test("CS: rapid repeats are throttled with a reply, and only one call goes out", async () => {
+  const { actions, calls } = fakeActions();
+  const { c, seen } = conn(false, actions);
+  send(c, { type: "subscription_cancel", id: "t1" });
+  send(c, { type: "subscription_cancel", id: "t2" });
+  await settle();
+  assert.deepEqual(calls, ["cancel"], "the second burst never reached the backend");
+  const second = replies(seen).find((r) => r.id === "t2");
+  assert.match(second!.error!, /in flight/);
+});
+
+test("CS: a malformed id is dropped without a crash or a reply", async () => {
+  const { actions, calls } = fakeActions();
+  const { c, seen } = conn(false, actions);
+  send(c, { type: "subscription_status", id: 42 });
+  send(c, { type: "subscription_status" });
+  await settle();
+  assert.equal(replies(seen).length, 0);
+  assert.deepEqual(calls, []);
+});

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1,6 +1,7 @@
 import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
 import { type Browser, type Page } from "playwright-core";
@@ -3075,6 +3076,102 @@ test("C.2: axe-core finds no serious/critical WCAG violations across the app", a
     await p.close();
     await dax.stop();
     await relay.stop();
+  }
+});
+
+test("CS: manage subscription — status, cancel behind its confirm, scheduled state, undo", async () => {
+  // A licensed daemon against a stateful billing-backend stub: /api/subscription
+  // reads, /cancel schedules at period end, /uncancel clears. The daemon only
+  // ever POSTs the license key; end-of-period timing is the SITE's business
+  // (pinned in the site repo's own suite). Midday-UTC instants keep the
+  // rendered dates timezone-stable.
+  const relay = await startRelayStub({});
+  const KEY = "mf_e2ecancelabcdefghijklmnop";
+  let cancelAt: string | null = null;
+  const seenKeys: string[] = [];
+  const billing = createServer((req, res) => {
+    let raw = "";
+    req.on("data", (c) => (raw += String(c)));
+    req.on("end", () => {
+      let body: { licenseKey?: unknown } = {};
+      try {
+        body = JSON.parse(raw) as { licenseKey?: unknown };
+      } catch {
+        /* the entitlement warm-up may probe with anything — fall through */
+      }
+      if (typeof body.licenseKey === "string") seenKeys.push(body.licenseKey);
+      const url = req.url ?? "";
+      if (!url.startsWith("/api/subscription")) {
+        res.writeHead(404).end(); // the boot-time entitlement exchange — not under test
+        return;
+      }
+      if (body.licenseKey !== KEY) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ reason: "unknown license key" }));
+        return;
+      }
+      if (url === "/api/subscription/cancel") cancelAt = "2026-09-01T12:00:00Z";
+      if (url === "/api/subscription/uncancel") cancelAt = null;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ status: "active", periodEnd: "2026-09-01T12:00:00Z", cancelAt }));
+    });
+  });
+  await new Promise<void>((resolve) => billing.listen(0, "127.0.0.1", resolve));
+  const billingPort = (billing.address() as { port: number }).port;
+
+  const token = "e2e-cs-9c2f";
+  const d2 = await startDaemon({
+    MIRAFOLD_TOKEN: token,
+    MIRAFOLD_RELAY_URL: relay.url,
+    MIRAFOLD_RELAY_CODE: "e2e-cs-pairing-code-1a2b",
+    MIRAFOLD_LICENSE_KEY: KEY,
+    MIRAFOLD_ENTITLEMENT_URL: `http://127.0.0.1:${billingPort}/api/entitlement`,
+    SUBSCRIPTION_MIN_GAP_MS: "0", // test clicks outrun the human-pace floor
+  });
+  const p = await browser.newPage();
+  try {
+    await p.goto(`http://127.0.0.1:${d2.port}/?token=${token}`);
+    // An empty registry opens the onboarding overlay, which sits over the
+    // fleet's pair button — enter a session and use the status bar's instead
+    // (both hosts render the same card).
+    await p.locator(".onb-agent", { hasText: "Claude Code" }).click();
+    await p.waitForURL(/\/s\/[\w-]+/);
+
+    // The resting UI shows only the pair button; nothing cancel-shaped.
+    await p.locator(".sb-pair").click();
+    await p.waitForSelector(".pair-card");
+    const manage = p.locator(".pair-manage", { hasText: "manage subscription" });
+    assert.equal(await manage.count(), 1, "licensed daemon must offer the neutral manage link");
+
+    // Manage → the live status line, no cancel action fired yet.
+    await manage.click();
+    await p.waitForSelector(".sub-line:has-text('active — renews Sep 1, 2026')");
+    await assertAxeClean(p, "manage subscription");
+
+    // The confirm step quotes the real consequence — and backing out works.
+    await p.locator(".sub-btn", { hasText: "cancel subscription…" }).click();
+    await p.waitForSelector(".sub-line:has-text(\"You won't be charged again\")");
+    assert.match(await p.locator(".sub-line").innerText(), /Sep 1, 2026/);
+    await p.locator(".sub-btn", { hasText: "keep subscription" }).click();
+    await p.waitForSelector(".sub-line:has-text('active — renews Sep 1, 2026')");
+
+    // Cancel for real: the scheduled state, with undo as the one action.
+    await p.locator(".sub-btn", { hasText: "cancel subscription…" }).click();
+    await p.locator(".sub-btn-danger", { hasText: "cancel subscription" }).click();
+    await p.waitForSelector(".sub-line:has-text('cancellation scheduled — access ends Sep 1, 2026')");
+    await p.locator(".sub-btn", { hasText: "undo cancellation" }).click();
+    await p.waitForSelector(".sub-line:has-text('active — renews Sep 1, 2026')");
+
+    // The daemon presented the key on every request…
+    assert.ok(seenKeys.length >= 3);
+    assert.ok(seenKeys.every((k) => k === KEY));
+    // …and the key itself never reached the page (secrets stay server-side).
+    assert.ok(!(await p.content()).includes(KEY), "license key leaked into the DOM");
+  } finally {
+    await p.close();
+    await d2.stop();
+    await relay.stop();
+    await new Promise((resolve) => billing.close(resolve));
   }
 });
 

--- a/web/src/components/ConnectDevice.tsx
+++ b/web/src/components/ConnectDevice.tsx
@@ -1,6 +1,16 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import qrcode from "qrcode-generator";
 import { ModalCard } from "./ModalCard";
+import type { SubscriptionAct } from "../session-bus";
+import {
+  acting,
+  confirmLede,
+  describeSubscription,
+  loading,
+  onReply,
+  type CardState,
+  type SubscriptionReply,
+} from "../subscription-card";
 
 // The shell-owned "connect a device" affordance. The daemon hands local
 // viewports the relay's HTTP origin + the pairing code (agents hello); this
@@ -49,13 +59,108 @@ function QrSvg({ text }: { text: string }) {
   );
 }
 
+/** Phase CS: mints + sends one subscription request; returns its id. */
+export type SubscriptionRequest = (act: SubscriptionAct) => string;
+
+// Phase CS — the manage-subscription view behind the neutral link below.
+// Everything shown is shell-owned copy composed by subscription-card.ts;
+// cancel sits behind its own confirm step quoting the real consequence, and
+// a scheduled cancel offers undo for the whole remainder of the period.
+function ManageSubscription({
+  request,
+  reply,
+  titleId,
+}: {
+  request: SubscriptionRequest;
+  reply: SubscriptionReply | null;
+  titleId: string;
+}) {
+  const [state, setState] = useState<CardState>({ phase: "loading", waitId: "" });
+  useEffect(() => {
+    setState(loading(request("status")));
+  }, [request]);
+  useEffect(() => {
+    if (reply) setState((s) => onReply(s, reply));
+  }, [reply]);
+
+  if (state.phase === "loading" || state.phase === "acting") {
+    return <div className="sub-line sub-dim">{state.phase === "loading" ? "checking…" : "working…"}</div>;
+  }
+  if (state.phase === "failed") {
+    return (
+      <div role="alert">
+        <div className="sub-line">{state.message}</div>
+        <button className="sub-btn" onClick={() => setState(loading(request("status")))}>
+          try again
+        </button>
+      </div>
+    );
+  }
+  const { line, action } = describeSubscription(state.reply);
+  if (state.confirming) {
+    return (
+      <div aria-labelledby={titleId}>
+        <div className="sub-line">{confirmLede(state.reply)}</div>
+        <div className="sub-actions">
+          <button
+            className="sub-btn"
+            onClick={() => setState({ ...state, confirming: false })}
+            autoFocus
+          >
+            keep subscription
+          </button>
+          <button
+            className="sub-btn sub-btn-danger"
+            onClick={() => setState(acting(request("cancel")))}
+          >
+            cancel subscription
+          </button>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <div className="sub-line">{line}</div>
+      {action === "cancel" && (
+        <button className="sub-btn" onClick={() => setState({ ...state, confirming: true })}>
+          cancel subscription…
+        </button>
+      )}
+      {action === "uncancel" && (
+        <button className="sub-btn" onClick={() => setState(acting(request("uncancel")))}>
+          undo cancellation
+        </button>
+      )}
+    </div>
+  );
+}
+
 // `sessionId`: pairing from inside a session encodes that session into the
 // fragment (`&s=<id>`) so the scanned phone lands IN it, not on the fleet
 // list. Mission control's pair button passes nothing and keeps landing on the
 // fleet — no special case.
-export function ConnectDevice({ relay, sessionId }: { relay?: RelayInfo; sessionId?: string }) {
+// `billing` + `subRequest` + `subReply` (Phase CS): present when this daemon
+// runs on a license key — the card then carries the neutral "manage
+// subscription" link. Nothing cancel-shaped is ever passively visible: the
+// resting UI shows only the pair button; cancel lives two deliberate steps
+// deep, behind the link and its own confirm.
+export function ConnectDevice({
+  relay,
+  sessionId,
+  billing,
+  subRequest,
+  subReply,
+}: {
+  relay?: RelayInfo;
+  sessionId?: string;
+  billing?: boolean;
+  subRequest?: SubscriptionRequest;
+  subReply?: SubscriptionReply | null;
+}) {
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [manage, setManage] = useState(false);
 
   if (!relay) return null;
   const href = `${relay.url}/#code=${relay.code}${
@@ -76,47 +181,72 @@ export function ConnectDevice({ relay, sessionId }: { relay?: RelayInfo; session
           overlayClass="pair-backdrop"
           cardClass="pair-card"
           titleId={TITLE_ID}
-          onDismiss={() => setOpen(false)}
+          onDismiss={() => {
+            setOpen(false);
+            setManage(false);
+          }}
         >
           <div className="pair-head">
             <span className="glyph" aria-hidden="true">
               ❯
             </span>
             <span className="pair-title" id={TITLE_ID}>
-              connect a device
+              {manage ? "subscription" : "connect a device"}
             </span>
             <button
               className="pair-close"
-              onClick={() => setOpen(false)}
+              onClick={() => {
+                setOpen(false);
+                setManage(false);
+              }}
               title="Close (Esc)"
-              aria-label="Close connect a device"
+              aria-label={manage ? "Close subscription" : "Close connect a device"}
             >
               ✕
             </button>
           </div>
-          <QrSvg text={href} />
-          <div className="pair-hint">
-            Scan from your phone. The pairing code rides the URL fragment — it never
-            reaches the relay, and every frame is end-to-end encrypted.
-          </div>
-          {/* Can't scan? Copy the link and send it to your own phone. Copy is
-              the one action, full width; the URL below it wraps to a couple of
-              readable lines — the old one-line box scrolled sideways, which was
-              the thing worth killing (2026-07-25, Kyle). */}
-          <button
-            className="pair-copy"
-            onClick={() => {
-              void navigator.clipboard?.writeText(href).then(() => {
-                setCopied(true);
-                setTimeout(() => setCopied(false), 1500);
-              });
-            }}
-          >
-            {copied ? "copied" : "copy link"}
-          </button>
-          <code className="pair-url" tabIndex={0}>
-            {href}
-          </code>
+          {manage && subRequest ? (
+            <>
+              <ManageSubscription request={subRequest} reply={subReply ?? null} titleId={TITLE_ID} />
+              <button className="pair-manage" onClick={() => setManage(false)}>
+                ← back to pairing
+              </button>
+            </>
+          ) : (
+            <>
+              <QrSvg text={href} />
+              <div className="pair-hint">
+                Scan from your phone. The pairing code rides the URL fragment — it never
+                reaches the relay, and every frame is end-to-end encrypted.
+              </div>
+              {/* Can't scan? Copy the link and send it to your own phone. Copy is
+                  the one action, full width; the URL below it wraps to a couple of
+                  readable lines — the old one-line box scrolled sideways, which was
+                  the thing worth killing (2026-07-25, Kyle). */}
+              <button
+                className="pair-copy"
+                onClick={() => {
+                  void navigator.clipboard?.writeText(href).then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                  });
+                }}
+              >
+                {copied ? "copied" : "copy link"}
+              </button>
+              <code className="pair-url" tabIndex={0}>
+                {href}
+              </code>
+              {/* Phase CS: deliberately neutral wording — the resting card
+                  invites managing, never leaving; cancel appears only inside,
+                  behind its own confirm. */}
+              {billing && subRequest && (
+                <button className="pair-manage" onClick={() => setManage(true)}>
+                  manage subscription
+                </button>
+              )}
+            </>
+          )}
         </ModalCard>
       )}
     </>

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -3,6 +3,8 @@ import type { AgentInfo, SessionMeta } from "@protocol";
 import { Onboarding } from "./Onboarding";
 import { ArmedButton } from "./ArmedButton";
 import { ConnectDevice, type RelayInfo } from "./ConnectDevice";
+import { sendSubscriptionRequest, type SubscriptionAct } from "../session-bus";
+import type { SubscriptionReply } from "../subscription-card";
 import { GearGlyph } from "./GearGlyph";
 import { SocketClient } from "../ws";
 import { tildify } from "../tildify";
@@ -95,7 +97,11 @@ export function FleetView() {
     // The agents hello's relay info (protocol.ts) — RelayInfo mirrors its
     // shape, `ws` included (static-origin serving).
     relay?: RelayInfo;
+    billing?: "license-key";
   }>({});
+  // Phase CS: the latest `subscription` reply for the pair card's manage view
+  // (id-correlated there, so only the newest matters).
+  const [subReply, setSubReply] = useState<SubscriptionReply | null>(null);
   const [connected, setConnected] = useState(false);
   // ?new=1 lands straight on the picker — that's the URL the in-session "new"
   // button opens in a fresh tab (2026-07-20, Kyle).
@@ -153,7 +159,15 @@ export function FleetView() {
         });
       } else if (m.type === "agents") {
         setAgents(m.agents);
-        setDaemon({ cwd: m.cwd, home: m.home, folderPicker: m.folderPicker, relay: m.relay });
+        setDaemon({
+          cwd: m.cwd,
+          home: m.home,
+          folderPicker: m.folderPicker,
+          relay: m.relay,
+          billing: m.billing,
+        });
+      } else if (m.type === "subscription") {
+        setSubReply(m);
       } else if (m.type === "session_created") {
         // The create issued from the onboarding card below: enter the session.
         location.assign(`/s/${m.sessionId}`);
@@ -235,6 +249,11 @@ export function FleetView() {
   // fresh arrow each render would restart the 3s timer instead of letting
   // it fire.
   const refreshAgents = useCallback(() => socket.send({ type: "refresh_agents" }), [socket]);
+  // Phase CS: the pair card's manage view mints + sends over this socket.
+  const subRequest = useCallback(
+    (act: SubscriptionAct) => sendSubscriptionRequest((m) => socket.send(m), act),
+    [socket],
+  );
   const browseFolder = useCallback(
     (cwd?: string) => folderPicker.request(cwd),
     [folderPicker],
@@ -298,7 +317,12 @@ export function FleetView() {
             {sessions === null ? "connecting…" : `${sessions.length} session${sessions.length === 1 ? "" : "s"}`}
           </span>
           <span className="fleet-spacer" />
-          <ConnectDevice relay={daemon.relay} />
+          <ConnectDevice
+            relay={daemon.relay}
+            billing={daemon.billing === "license-key"}
+            subRequest={subRequest}
+            subReply={subReply}
+          />
           <button className="fleet-new" onClick={() => setShowNew(true)}>
             + new session
           </button>

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -11,6 +11,7 @@ import { FilesPanel } from "./files/FilesPanel";
 import { ChangesPanel } from "./changes/ChangesPanel";
 import { StatusBar, type Usage } from "./StatusBar";
 import { createSessionBus } from "../session-bus";
+import type { SubscriptionReply } from "../subscription-card";
 import { nextOpenTurns } from "../turn-busy";
 import { traceTurn } from "../turn-trace";
 import {
@@ -104,7 +105,11 @@ export function Shell() {
     folderPicker?: boolean;
     relay?: { url: string; code: string; ws?: string };
     version?: string;
+    billing?: "license-key";
   }>({ agents: null });
+  // Phase CS: the latest `subscription` reply — the pair card's manage view
+  // correlates it by id, so holding just the newest one is enough.
+  const [subReply, setSubReply] = useState<SubscriptionReply | null>(null);
 
   // ── The dismissable notices (all SHELL-OWNED — the agent paints none) ───
   const [notices, setNotices] = useState<{
@@ -381,7 +386,10 @@ export function Shell() {
             folderPicker: m.folderPicker,
             relay: m.relay,
             version: m.version,
+            billing: m.billing,
           });
+        } else if (m.type === "subscription") {
+          setSubReply(m);
         } else if (m.type === "prompt_options") {
           setPromptOptions(m.options);
         } else if (m.type === "session_created") {
@@ -732,6 +740,9 @@ export function Shell() {
               onEndSession={meta.sessionId ? bus.endSession : undefined}
               relay={daemonInfo.relay}
               version={daemonInfo.version}
+              billing={daemonInfo.billing === "license-key"}
+              subRequest={bus.requestSubscription}
+              subReply={subReply}
               filesOpen={filesOpen}
               filesDisabled={!meta.sessionId}
               onToggleFiles={() => toggleAuxiliary("files")}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { ArmedButton } from "./ArmedButton";
 import { ChangesGlyph } from "./ChangesGlyph";
-import { ConnectDevice, type RelayInfo } from "./ConnectDevice";
+import { ConnectDevice, type RelayInfo, type SubscriptionRequest } from "./ConnectDevice";
+import type { SubscriptionReply } from "../subscription-card";
 import { FilesGlyph } from "./FilesGlyph";
 import { GearGlyph } from "./GearGlyph";
 import { useArmedConfirm } from "../use-armed-confirm";
@@ -47,6 +48,9 @@ export function StatusBar({
   onEndSession,
   relay,
   version,
+  billing,
+  subRequest,
+  subReply,
   filesOpen,
   filesDisabled,
   onToggleFiles,
@@ -93,6 +97,11 @@ export function StatusBar({
   changesOpen?: boolean;
   changesDisabled?: boolean;
   onToggleChanges?: () => void;
+  // Phase CS: the manage-subscription plumbing, passed through to the pair
+  // card (present only when the daemon runs on a license key).
+  billing?: boolean;
+  subRequest?: SubscriptionRequest;
+  subReply?: SubscriptionReply | null;
 }) {
   const [open, setOpen] = useState(true);
   const phone = useIsPhone();
@@ -245,7 +254,13 @@ export function StatusBar({
           v{version}
         </span>
       )}
-      <ConnectDevice relay={relay} sessionId={sessionId} />
+      <ConnectDevice
+        relay={relay}
+        sessionId={sessionId}
+        billing={billing}
+        subRequest={subRequest}
+        subReply={subReply}
+      />
       {/* Settings gear (S.4) — beside the pill, which is now the far-right
           control (home moved to the far left). The pill below is LOCKED
           unchanged (Phase S). */}

--- a/web/src/session-bus.ts
+++ b/web/src/session-bus.ts
@@ -1,4 +1,4 @@
-import type { Action, AgentName, BackendChoice, WireMsg } from "@protocol";
+import type { Action, AgentName, BackendChoice, ClientMsg, WireMsg } from "@protocol";
 import { SocketClient } from "./ws";
 import { createFolderPickerRequests } from "./folder-picker-requests";
 
@@ -6,6 +6,25 @@ import { createFolderPickerRequests } from "./folder-picker-requests";
  *  side so each surface can match the one reply/stream it asked for. */
 const mintId = (prefix: string): string =>
   `${prefix}-${Math.random().toString(36).slice(2, 10)}`;
+
+/** Phase CS: mint + send one manage-subscription request over any sender —
+ *  shared by the session bus and the fleet's own socket. The single
+ *  `subscription` reply echoes the returned id. */
+export type SubscriptionAct = "status" | "cancel" | "uncancel";
+export function sendSubscriptionRequest(
+  send: (m: ClientMsg) => void,
+  act: SubscriptionAct,
+): string {
+  const id = mintId("sub");
+  send(
+    act === "status"
+      ? { type: "subscription_status", id }
+      : act === "cancel"
+        ? { type: "subscription_cancel", id }
+        : { type: "subscription_uncancel", id },
+  );
+  return id;
+}
 
 /**
  * What the output zone consumes: the wire protocol plus one local control
@@ -51,6 +70,9 @@ export interface SessionBus {
   requestFsChanges(): string;
   requestFsRead(path: string): string;
   requestFsDiff(path: string): string;
+  /** Phase CS: one manage-subscription request (status/cancel/uncancel);
+   *  the single `subscription` reply echoes the returned minted id. */
+  requestSubscription(act: SubscriptionAct): string;
   /** Phase FD: stream a dropped file's bytes to the daemon's staging dir.
    *  Mints and returns the correlation id; the done/error reply echoes it. */
   uploadBegin(name: string, size: number): string;
@@ -184,6 +206,9 @@ export function createSessionBus(): SessionBus {
       const id = mintId("fsd");
       socket.send({ type: "fs_diff", id, path });
       return id;
+    },
+    requestSubscription(act: SubscriptionAct): string {
+      return sendSubscriptionRequest((m) => socket.send(m), act);
     },
     // Phase FD — the sendBang mint shape; per-viewport correlation only.
     uploadBegin(name: string, size: number): string {

--- a/web/src/styles/12-dialogs.css
+++ b/web/src/styles/12-dialogs.css
@@ -535,6 +535,76 @@
   overflow-wrap: anywhere;
 }
 
+/* ---- Manage subscription (Phase CS) — inside the pairing card --------------
+   The resting card shows only the deliberately neutral link below the URL;
+   cancel lives in the manage view, behind its own confirm. Same modal, same
+   type ramp as the pair content around it. */
+.pair-manage {
+  display: block;
+  width: 100%;
+  margin-top: 14px;
+  padding: 6px 0;
+  background: transparent;
+  border: 0;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 1.05em;
+  color: var(--fg-dimmer);
+  cursor: pointer;
+  text-align: center;
+}
+
+.pair-manage:hover {
+  color: var(--fg);
+  text-decoration: underline;
+}
+
+.sub-line {
+  margin: 6px 2px 14px;
+  font-size: 1.23em;
+  line-height: 1.5;
+  color: var(--fg-dim);
+}
+
+.sub-dim {
+  color: var(--fg-dimmer);
+}
+
+.sub-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sub-btn {
+  display: block;
+  width: 100%;
+  padding: 10px 12px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 1.05em;
+  color: var(--fg-mid);
+  background: transparent;
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.sub-btn:hover {
+  color: var(--fg);
+  background: var(--bg-inset);
+}
+
+/* The point of no return gets the warning tint — everything before it is
+   an ordinary quiet control. */
+.sub-btn-danger {
+  color: var(--error);
+  border-color: var(--err-border);
+}
+
+.sub-btn-danger:hover {
+  background: var(--err-bg);
+  color: var(--error);
+}
+
 /* ---- Settings card (S.4) ----------------------------------------------------
    Shell-owned, same modal idiom as the pairing card. One section today
    (Theme); built to grow more sections. The gear (.sb-settings) sits beside

--- a/web/src/subscription-card.test.ts
+++ b/web/src/subscription-card.test.ts
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  acting,
+  confirmLede,
+  day,
+  describeSubscription,
+  loading,
+  onReply,
+  type SubscriptionReply,
+} from "./subscription-card";
+
+// Phase CS: the card's pure brain. The component only renders these
+// decisions, so this is where the flow's correctness is pinned.
+
+const reply = (over: Partial<SubscriptionReply>): SubscriptionReply => ({
+  type: "subscription",
+  id: "sub-1",
+  ...over,
+});
+
+test("CS: replies correlate by id — the awaited one lands, strangers are dropped", () => {
+  const s0 = loading("sub-1");
+  assert.equal(onReply(s0, reply({ id: "sub-OTHER", status: "active" })), s0);
+  const s1 = onReply(s0, reply({ status: "active", periodEnd: "2026-09-01T12:00:00Z" }));
+  assert.equal(s1.phase, "ready");
+  // A late duplicate can't knock a settled card back around.
+  assert.equal(onReply(s1, reply({ status: "canceled" })), s1);
+});
+
+test("CS: an error reply fails the card with the daemon's own line", () => {
+  const s = onReply(acting("sub-2"), reply({ id: "sub-2", error: "billing backend unreachable" }));
+  assert.deepEqual(s, { phase: "failed", message: "billing backend unreachable" });
+});
+
+test("CS: the status lines and their one offered action", () => {
+  assert.deepEqual(
+    describeSubscription(reply({ status: "trialing", periodEnd: "2026-08-17T12:00:00Z" })),
+    { line: "free trial — first charge Aug 17, 2026", action: "cancel" },
+  );
+  assert.deepEqual(
+    describeSubscription(reply({ status: "active", periodEnd: "2026-09-01T12:00:00Z" })),
+    { line: "active — renews Sep 1, 2026", action: "cancel" },
+  );
+  // A scheduled cancel wins the line regardless of status, and flips the
+  // action to undo — the whole point of shipping uncancel.
+  assert.deepEqual(
+    describeSubscription(
+      reply({ status: "active", periodEnd: "2026-09-01T12:00:00Z", cancelAt: "2026-09-01T12:00:00Z" }),
+    ),
+    { line: "cancellation scheduled — access ends Sep 1, 2026", action: "uncancel" },
+  );
+  assert.deepEqual(describeSubscription(reply({ status: "canceled" })), {
+    line: "subscription ended",
+    action: null,
+  });
+  assert.equal(describeSubscription(reply({ status: "past_due" })).action, "cancel");
+  assert.deepEqual(describeSubscription(reply({ status: "paused" })), {
+    line: "subscription is paused",
+    action: null,
+  });
+});
+
+test("CS: the confirm copy stays true to the refund policy — trial = never charged, paid = end of period", () => {
+  assert.equal(
+    confirmLede(reply({ status: "trialing", periodEnd: "2026-08-17T12:00:00Z" })),
+    "Cancel now and you'll never be charged. Your trial access still runs to Aug 17, 2026.",
+  );
+  assert.equal(
+    confirmLede(reply({ status: "active", periodEnd: "2026-09-01T12:00:00Z" })),
+    "You won't be charged again. Access runs to Sep 1, 2026, then the subscription ends.",
+  );
+});
+
+test("CS: garbled dates degrade to dateless lines, never 'Invalid Date'", () => {
+  assert.equal(day("not-a-date"), null);
+  assert.equal(day(undefined), null);
+  assert.deepEqual(describeSubscription(reply({ status: "trialing", periodEnd: "garbage" })), {
+    line: "free trial",
+    action: "cancel",
+  });
+  assert.ok(!confirmLede(reply({ status: "active", periodEnd: "garbage" })).includes("Invalid"));
+});

--- a/web/src/subscription-card.ts
+++ b/web/src/subscription-card.ts
@@ -1,0 +1,88 @@
+// Phase CS — the manage-subscription card's brain, kept pure so Tier 1 pins
+// it: the request/reply state machine (id-correlated, stale replies dropped)
+// and the shell-owned copy composed from the daemon's subscription view.
+// The component (ConnectDevice.tsx) only renders what this module decides.
+
+import type { WireMsg } from "@protocol";
+
+export type SubscriptionReply = Extract<WireMsg, { type: "subscription" }>;
+
+export type CardState =
+  /** A request is out; `waitId` names the one reply we'll accept. */
+  | { phase: "loading"; waitId: string }
+  /** A view arrived. `confirming` = the cancel confirm step is showing. */
+  | { phase: "ready"; reply: SubscriptionReply; confirming: boolean }
+  /** A cancel/uncancel is in flight — buttons disabled, no double-fire. */
+  | { phase: "acting"; waitId: string }
+  /** The daemon's error line (it already carries the support fallback). */
+  | { phase: "failed"; message: string };
+
+export const loading = (waitId: string): CardState => ({ phase: "loading", waitId });
+export const acting = (waitId: string): CardState => ({ phase: "acting", waitId });
+
+/** Fold one `subscription` reply in. A reply whose id isn't the one this
+ *  card is waiting on is another surface's (or a stale retry's) — ignored. */
+export function onReply(state: CardState, m: SubscriptionReply): CardState {
+  if (state.phase !== "loading" && state.phase !== "acting") return state;
+  if (m.id !== state.waitId) return state;
+  if (m.error) return { phase: "failed", message: m.error };
+  return { phase: "ready", reply: m, confirming: false };
+}
+
+/** "Aug 17, 2026" — or null for absent/garbled input (the line then simply
+ *  omits the date rather than showing "Invalid Date"). */
+export function day(iso: string | undefined): string | null {
+  if (!iso) return null;
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return null;
+  return new Date(t).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+/** The status line plus which single action (if any) the card offers. */
+export function describeSubscription(reply: SubscriptionReply): {
+  line: string;
+  action: "cancel" | "uncancel" | null;
+} {
+  const d = day(reply.cancelAt) ?? day(reply.periodEnd);
+  if (reply.cancelAt) {
+    return {
+      line: d ? `cancellation scheduled — access ends ${d}` : "cancellation scheduled",
+      action: "uncancel",
+    };
+  }
+  switch (reply.status) {
+    case "trialing":
+      return { line: d ? `free trial — first charge ${d}` : "free trial", action: "cancel" };
+    case "active":
+      return { line: d ? `active — renews ${d}` : "active", action: "cancel" };
+    case "past_due":
+      // Cancel stays offered: stopping future attempts is exactly what a
+      // past-due customer may want. Fixing the card is Paddle's surface.
+      return {
+        line: "payment past due — update your card from your Paddle receipt email",
+        action: "cancel",
+      };
+    case "canceled":
+      return { line: "subscription ended", action: null };
+    default:
+      return { line: `subscription is ${reply.status ?? "unknown"}`, action: null };
+  }
+}
+
+/** The confirm step's consequence sentence — must stay true to /terms and
+ *  /refunds: end-of-period only, trial cancels are never charged. */
+export function confirmLede(reply: SubscriptionReply): string {
+  const d = day(reply.periodEnd);
+  if (reply.status === "trialing") {
+    return d
+      ? `Cancel now and you'll never be charged. Your trial access still runs to ${d}.`
+      : "Cancel now and you'll never be charged. Your trial access still runs to its end.";
+  }
+  return d
+    ? `You won't be charged again. Access runs to ${d}, then the subscription ends.`
+    : "You won't be charged again. Access runs to the end of the paid period, then the subscription ends.";
+}


### PR DESCRIPTION
The product half of Phase CS (plan signed off by Kyle, 2026-08-14): a Mirafold Pro daemon running on a license key gains an in-product way to cancel (or un-cancel) the subscription behind it — the last feature into `next` before the next release.

**What ships**
- `server/relay/subscription.ts`: status/cancel/uncancel against the billing backend's new `/api/subscription` endpoints, derived from `MIRAFOLD_ENTITLEMENT_URL` (no new env vars). License-key mode only; the key never crosses the viewport wire.
- Protocol (additive only): `subscription_status` / `subscription_cancel` / `subscription_uncancel` client messages, one per-viewport `subscription` reply, and a `billing` flag on the agents hello (local viewports only).
- Web: a neutral **manage subscription** link inside the connect-a-device card (status bar + fleet hosts); the view shows the live status line, an end-of-period cancel behind its own confirm quoting the real consequence date, and **undo** while the cancellation is scheduled. Copy matches /terms and /refunds exactly: trial cancel = never charged; paid cancel = access to period end; immediate cancel is never offered.
- Remote (relay) viewports are refused at the handler as well as denied the hello flag — billing actions stay on the machine that holds the key.

**Tests**: Tier 1 837 / Tier 2 152 / Tier 3 100, all green. New pins: the actions client (endpoint derivation, refusal bounding, outage fallback), connection handling (local-only flag, remote refusal, throttle), the pure card brain, and a full-arc e2e against a stub billing backend that also proves the license key never reaches the DOM.

**Ship coupling**: the site half (mirafold-site `feature/cancel-endpoints` — three Pages Functions + 6 tests) must be deployed before this reaches npm; until then the card degrades to the standing support-email line. Live verification on a real subscription is Phase CS.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)