### PR TITLE
docs: record the DCO sign-off requirement in the git workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,6 +29,9 @@ conversation — the "(was)" column exists to recognize old terms, not reuse the
 
 - Normal work branches (`feature/*`, `fix/*`, `refactor/*`) start from
   `next` and open pull requests back into `next`.
+- **Every commit carries `Signed-off-by`** (the DCO check blocks merges
+  without it). A local `prepare-commit-msg` hook appends it automatically —
+  if a commit somehow lacks it, `git rebase --signoff` repairs the branch.
 - A feature pull request stays open even after its checks pass. Complete the
   requested review and refactor work there, then ask Kyle explicitly whether
   to merge when it appears ready. Opening the pull request or getting green


### PR DESCRIPTION
One line in CLAUDE.md's Git workflow section: every commit carries `Signed-off-by` (the DCO check blocks merges without it), a local `prepare-commit-msg` hook appends it automatically, and `git rebase --signoff` repairs a branch that missed it. The hook itself is local git state (installed in this repo and mirafold-relay), so this line is the requirement's only in-repo record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)