### PR TITLE
feat(phone): one workspace toggle + unified drawer exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -672,8 +672,9 @@ web/               the browser app (React 19 + Vite)
                      registry/, so the trust split reads in the tree
     Shell.tsx          TRUSTED SHELL: prompt box + notices + status bar + the
                        activity bar (desktop's left strip for the mutually
-                       exclusive Files and Changes workspaces; on phone both
-                       toggles fold into the status bar); consumes the session
+                       exclusive Files and Changes workspaces; on phone they
+                       fold into ONE status-bar toggle + an in-drawer
+                       switch); consumes the session
                        bus (H.9)
     Onboarding.tsx     first-run card: pick the agent + working directory, then
                        how it's backed when there's a choice — detected
@@ -712,10 +713,17 @@ web/               the browser app (React 19 + Vite)
                        activity line (2026-07-25 — the ⚙ character
                        rendered from the color-emoji font and clashed with
                        every glyph beside it)
-    FilesGlyph.tsx     the Explorer/files glyph drawing — the activity-bar
-                       toggle and the status bar's phone-width .sb-files
-    ChangesGlyph.tsx   the workspace-changes glyph drawing — the activity-bar
-                       toggle and the status bar's phone-width .sb-changes
+    FilesGlyph.tsx     the Explorer/files glyph drawing — the desktop
+                       activity-bar toggle
+    ChangesGlyph.tsx   the workspace-changes glyph drawing — the desktop
+                       activity-bar toggle
+    WorkspaceGlyph.tsx the phone status bar's ONE workspace toggle
+                       (.sb-workspace) — Files and Changes share a
+                       full-screen drawer on ≤640px, reopened on the
+                       last-used view
+    WorkspaceTabs.tsx  the phone drawer's Files | Changes switch, at the
+                       head of both panels in the title's place; both exits
+                       are the same leading ‹ back chevron
     ArmedButton.tsx    the two-click destructive button (#11's arm → 3s
                        auto-disarm), shared by StatusBar + FleetView's end/stop
     PinDock.tsx        right-side dock for pinned components (live via entries)

--- a/README.md
+++ b/README.md
@@ -1395,8 +1395,9 @@ knowing because it constrains future UI work:
   bar — sits strictly to its right (only banners run full-width). The status
   bar's top border meets that line in a clean T, with its controls vertically
   centered in the bottom band. On phone (≤640px) the rail is hidden — a
-  permanent strip is too much of a 390px screen — and its files toggle sits
-  boxed at the status bar's far left, its separator echoing the rail's border
+  permanent strip is too much of a 390px screen — and its one workspace
+  toggle (Files + Changes behind a single drawer, 2026-08-18) sits boxed at
+  the status bar's far left, its separator echoing the rail's border
   (2026-07-25). Mission control renders a notch larger than the in-session
   workbench (`zoom: 1.15`, reset on phone; the agent picker hosted inside it
   compensates via the fluid `--onb-squeeze` chrome).

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -2834,7 +2834,7 @@ test("E2.4: the Projects-root proof — lazy expands into two repos with per-rep
       const phone = await phoneCtx.newPage();
       await phone.goto(`${base}/?token=${TOKEN}`);
       await phone.goto(`${base}/s/${created.sessionId}`);
-      await phone.locator(".sb-files").focus();
+      await phone.locator(".sb-workspace").focus();
       await phone.keyboard.press("Enter");
       await phone.waitForSelector(".files-panel[role=dialog]");
       await phone.locator('.files-dir:has(.files-name:text-is("repoA"))').tap();

--- a/server/testing/changes.e2e.ts
+++ b/server/testing/changes.e2e.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { type Browser, type BrowserContext, type Page } from "playwright-core";
 import type { ClientMsg } from "../protocol";
-import { assertAxeClean, launchChrome, noSideScroll } from "./e2e-harness";
+import { assertApartOnScreen, assertAxeClean, launchChrome, noSideScroll } from "./e2e-harness";
 import { fixtureGit as git, startDaemon, TestClient, type Daemon } from "./itest-harness";
 
 // CR.2–CR.4 in a real browser against a real daemon and real Git: responsive
@@ -672,6 +672,20 @@ test("CR.2 phone: full-screen one-file review has persistent navigation and pres
   await openPhoneWorkspace(phone, "changes");
   await phone.waitForSelector(".changes-current-path");
   assert.equal(await phone.locator(".changes-count").innerText(), "5 visible");
+  // 320px (iPhone-SE floor) with a real review in progress: the head's row
+  // two — progress beside the count pill — and row one stay apart and
+  // on-screen (2026-08-18 bughunt: the pill sat on the switch at this width).
+  await phone.setViewportSize({ width: 320, height: 568 });
+  await phone.locator(".changes-panel").evaluate((el) => Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)));
+  await assertApartOnScreen(phone, 320, [
+    ".changes-head .changes-close",
+    ".changes-head .workspace-tabs",
+    ".changes-progress",
+    ".changes-count",
+    ".changes-refresh",
+  ]);
+  await noSideScroll(phone);
+  await phone.setViewportSize({ width: 390, height: 844 });
   assert.equal(await phone.locator(".changes-rail").count(), 0, "the desktop changed-file rail rendered on phone");
   assert.ok((await phone.locator(".changes-current-path").innerText()).endsWith("a-added.ts"));
 
@@ -1014,7 +1028,12 @@ test("CR.4: review progress resumes and only the changed revision reopens on des
     await mobile.waitForSelector(".changes-panel", { state: "detached" });
     // The single toggle reopens the LAST view — Changes — with no tab tap.
     await mobile.locator(".sb-workspace").tap();
-    await mobile.waitForSelector(".changes-panel[role=dialog]");
+    await mobile.waitForSelector(".files-panel[role=dialog], .changes-panel[role=dialog]");
+    assert.equal(
+      await mobile.locator(".changes-panel[role=dialog]").count(),
+      1,
+      "the workspace toggle must reopen the last-used view (Changes), not Files",
+    );
     await mobile.waitForSelector(".changes-current-path");
     assert.equal(await progressText(mobile), "5 / 5 reviewed");
     assert.ok((await mobile.locator(".changes-current-path").innerText()).endsWith("a-added.ts"));

--- a/server/testing/changes.e2e.ts
+++ b/server/testing/changes.e2e.ts
@@ -77,6 +77,16 @@ const createSession = async (cwd: string): Promise<string> => {
 const sessionUrl = (sessionId: string): string =>
   `http://127.0.0.1:${daemon.port}/s/${sessionId}?token=${TOKEN}`;
 
+// Phone (2026-08-18): the status bar has ONE workspace toggle that reopens
+// the last-used view (Files on a fresh page); the drawer's own head switches.
+// Tapping the already-active tab is a no-op, so this is safe either way.
+const openPhoneWorkspace = async (page: Page, view: "files" | "changes"): Promise<void> => {
+  await page.locator(".sb-workspace").tap();
+  await page.waitForSelector(".files-panel[role=dialog], .changes-panel[role=dialog]");
+  await page.locator(`.workspace-tab:has-text("${view === "files" ? "Files" : "Changes"}")`).tap();
+  await page.waitForSelector(view === "files" ? ".files-panel[role=dialog]" : ".changes-panel[role=dialog]");
+};
+
 const selectDesktopFile = async (name: string): Promise<void> => {
   await desktop.locator(".changes-file", { hasText: name }).click();
   await desktop.waitForFunction(
@@ -659,8 +669,7 @@ test("CR.2 phone: full-screen one-file review has persistent navigation and pres
   const transcriptScroll = await phone.locator(".render-zone").evaluate((element) => element.scrollTop);
   assert.ok(transcriptScroll > 0, "phone transcript fixture did not become scrollable");
 
-  await phone.locator(".sb-changes").tap();
-  await phone.waitForSelector(".changes-panel[role=dialog]");
+  await openPhoneWorkspace(phone, "changes");
   await phone.waitForSelector(".changes-current-path");
   assert.equal(await phone.locator(".changes-count").innerText(), "5 visible");
   assert.equal(await phone.locator(".changes-rail").count(), 0, "the desktop changed-file rail rendered on phone");
@@ -710,16 +719,14 @@ test("CR.2 phone: full-screen one-file review has persistent navigation and pres
   const lightGroup = phone.locator('.theme-group[aria-label="Light themes"]');
   await lightGroup.locator(".theme-row", { hasText: "Standard" }).tap();
   await phone.locator(".settings-close").tap();
-  await phone.locator(".sb-changes").tap();
-  await phone.waitForSelector(".changes-panel[role=dialog]");
+  await openPhoneWorkspace(phone, "changes");
   assert.ok((await phone.locator(".changes-current-path").innerText()).endsWith("z-binary.bin"));
   await phone.screenshot({ path: path.join(os.tmpdir(), "mirafold-changes-phone-light.png") });
   await assertAxeClean(phone, "phone workspace changes (light)");
   await noSideScroll(phone);
 
   await phone.locator(".changes-close").tap();
-  await phone.locator(".sb-files").tap();
-  await phone.waitForSelector(".files-panel[role=dialog]");
+  await openPhoneWorkspace(phone, "files");
   await phone.locator(".files-file-row", { hasText: "a-added.ts" }).tap();
   await phone.waitForSelector(".files-view .fv-content");
   await noSideScroll(phone);
@@ -737,8 +744,7 @@ test("CR.3 phone: tap and whole-hunk selection keep context beside the editable 
   const page = await context.newPage();
   try {
     await page.goto(sessionUrl(changedSession));
-    await page.waitForSelector(".sb-changes");
-    await page.locator(".sb-changes").tap();
+    await openPhoneWorkspace(page, "changes");
     await page.waitForSelector(".changes-current-path");
     for (const name of ["d-deleted.ts", "m-modified.ts"]) {
       await page.locator('[aria-label="Next changed file"]').tap();
@@ -966,8 +972,7 @@ test("CR.4: review progress resumes and only the changed revision reopens on des
     // on phone, change one behind it, then wrap directly to that sole reopened
     // revision and resume after closing/reopening the full-screen layer.
     await mobile.goto(sessionUrl(changedSession));
-    await mobile.waitForSelector(".sb-changes");
-    await mobile.locator(".sb-changes").tap();
+    await openPhoneWorkspace(mobile, "changes");
     await mobile.waitForSelector(".changes-current-path");
     assert.equal(await progressText(mobile), "0 / 5 reviewed", "review progress leaked between viewports");
     for (let index = 0; index < 5; index += 1) {
@@ -1007,7 +1012,9 @@ test("CR.4: review progress resumes and only the changed revision reopens on des
     await assertAxeClean(mobile, "phone resumable change review");
     await mobile.locator(".changes-close").tap();
     await mobile.waitForSelector(".changes-panel", { state: "detached" });
-    await mobile.locator(".sb-changes").tap();
+    // The single toggle reopens the LAST view — Changes — with no tab tap.
+    await mobile.locator(".sb-workspace").tap();
+    await mobile.waitForSelector(".changes-panel[role=dialog]");
     await mobile.waitForSelector(".changes-current-path");
     assert.equal(await progressText(mobile), "5 / 5 reviewed");
     assert.ok((await mobile.locator(".changes-current-path").innerText()).endsWith("a-added.ts"));

--- a/server/testing/e2e-harness.ts
+++ b/server/testing/e2e-harness.ts
@@ -79,6 +79,31 @@ export async function enterMockSession(page: Page): Promise<void> {
   await page.locator(".prompt-box textarea").waitFor();
 }
 
+/** Phone-head oracle (2026-08-18): every selector renders, none overlaps
+ *  another (rectangle intersection — a control on the row below is fine, one
+ *  on top of its neighbour is not), and each sits fully inside the viewport:
+ *  the drawers are overflow:hidden, so a control pushed off the edge is
+ *  clipped, not side-scrolled, and `noSideScroll` alone would miss it. */
+export const assertApartOnScreen = async (page: Page, viewportWidth: number, selectors: string[]) => {
+  const boxes: { sel: string; x: number; y: number; width: number; height: number }[] = [];
+  for (const sel of selectors) {
+    const box = await page.locator(sel).boundingBox();
+    assert.ok(box, `${sel} did not render at ${viewportWidth}px`);
+    assert.ok(
+      box.x >= 0 && box.x + box.width <= viewportWidth,
+      `${sel} is off-screen at ${viewportWidth}px (${JSON.stringify(box)})`,
+    );
+    boxes.push({ sel, ...box });
+  }
+  for (const a of boxes) {
+    for (const b of boxes) {
+      if (a === b) continue;
+      const apart = a.x + a.width <= b.x || b.x + b.width <= a.x || a.y + a.height <= b.y || b.y + b.height <= a.y;
+      assert.ok(apart, `${a.sel} overlaps ${b.sel} at ${viewportWidth}px (${JSON.stringify([a, b])})`);
+    }
+  }
+};
+
 /** Phone-width oracle: the page must never pan sideways. */
 export const noSideScroll = async (p: Page) => {
   const over = await p.evaluate(

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -199,7 +199,9 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   // tap: focus-return-on-close is an A.3 KEYBOARD contract, and a touch tap
   // doesn't move DOM focus to the button, so only the keyboard path has a
   // meaningful opener to return to.
-  await phone.locator(".sb-files").focus();
+  // ONE workspace toggle on phone (2026-08-18): a fresh page opens Files.
+  assert.equal(await phone.locator(".sb-files, .sb-changes").count(), 0, "the two-icon pair must be gone on phone");
+  await phone.locator(".sb-workspace").focus();
   await phone.keyboard.press("Enter");
   await phone.waitForSelector(".files-panel[role=dialog]");
   await noSideScroll(phone);
@@ -208,6 +210,23 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
     return el ? Math.round(el.getBoundingClientRect().width) : 0;
   });
   assert.ok(width >= 380, `panel is ${width}px wide — not full-screen`);
+
+  // Both drawer views exit the same way — a leading ‹ at the top-left (the
+  // Files × at the top-right was the odd one out) — and the drawer's own
+  // head switches between them; switching keeps the exit where it was.
+  assert.equal(await phone.locator(".files-panel-head .files-panel-back").getAttribute("aria-label"), "Back to conversation");
+  const filesBack = (await phone.locator(".files-panel-back").boundingBox())!;
+  assert.ok(filesBack.x < 60 && filesBack.y < 120, `files back is at ${filesBack.x},${filesBack.y} — not top-left`);
+  assert.ok(filesBack.width >= 40 && filesBack.height >= 40, "files back is under the 40px thumb rule");
+  await phone.locator('.files-panel-head .workspace-tab:has-text("Changes")').tap();
+  await phone.waitForSelector(".changes-panel[role=dialog]");
+  assert.equal(await phone.locator(".files-panel").count(), 0, "one drawer view at a time");
+  const changesBack = (await phone.locator(".changes-head .changes-close").boundingBox())!;
+  assert.equal(await phone.locator(".changes-head .changes-close").getAttribute("aria-label"), "Back to conversation");
+  assert.ok(Math.abs(changesBack.x - filesBack.x) <= 8, `exits drift: files ${filesBack.x} vs changes ${changesBack.x}`);
+  await phone.locator('.changes-head .workspace-tab:has-text("Files")').tap();
+  await phone.waitForSelector(".files-panel[role=dialog]");
+  await noSideScroll(phone);
 
   // The tree is live git data (the daemon runs in the repo) — drill into a file.
   const pkg = phone.locator(".files-file-row", { hasText: "package.json" }).first();
@@ -240,9 +259,9 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   assert.equal(await phone.locator(".files-panel").count(), 0, "Esc from the tree closes the panel");
   await noSideScroll(phone);
   const focusedFiles = await phone.evaluate(
-    () => document.activeElement?.classList.contains("sb-files") ?? false,
+    () => document.activeElement?.classList.contains("sb-workspace") ?? false,
   );
-  assert.ok(focusedFiles, "focus returned to the files toggle on close");
+  assert.ok(focusedFiles, "focus returned to the workspace toggle on close");
 });
 
 test("phone: a permission request is answerable by thumb", async () => {
@@ -359,7 +378,7 @@ test("phone: a discarded tab comes back paired — the session survives, transcr
   // Explorer toggle is disabled without one.
   await phone.waitForSelector(".sb-end", { timeout: 20_000 });
   assert.equal(
-    await phone.locator(".sb-files").isDisabled(),
+    await phone.locator(".sb-workspace").isDisabled(),
     false,
     "Explorer still disabled — the viewport never attached",
   );

--- a/server/testing/phone.e2e.ts
+++ b/server/testing/phone.e2e.ts
@@ -2,7 +2,7 @@ import { test, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { type Browser, type BrowserContext, type Page } from "playwright-core";
 import { startDaemon, type Daemon } from "./itest-harness";
-import { launchChrome, noSideScroll } from "./e2e-harness";
+import { assertApartOnScreen, launchChrome, noSideScroll } from "./e2e-harness";
 import { startRelayStub, type RelayStub } from "../relay/relay-stub";
 
 // R.4, the locally-verifiable slice: a phone-sized browser pairs through the
@@ -29,6 +29,22 @@ const sendPrompt = async (p: Page, text: string) => {
   await p.keyboard.type(text);
   await p.locator(".prompt-send").tap();
 };
+
+// Geometry is asserted at REST: the drawers slide in (02-explorer.css
+// files-in, 03-changes.css changes-in) and a mid-transform boundingBox reads
+// a sub-pixel short (39.9999 for a 40px button) — the 2026-08-18 flake.
+const settled = (page: Page, selector: string) =>
+  page.locator(selector).evaluate((el) => Promise.all(el.getAnimations({ subtree: true }).map((a) => a.finished)));
+
+// Esc walks the drawer out one layer at a time (file → tree → closed).
+const closeDrawer = async (page: Page) => {
+  for (let i = 0; i < 3 && (await page.locator(".files-panel, .changes-panel").count()) > 0; i += 1) {
+    await page.keyboard.press("Escape");
+    await page.waitForTimeout(50);
+  }
+  await page.waitForSelector(".files-panel, .changes-panel", { state: "detached" });
+};
+
 
 before(async () => {
   stub = await startRelayStub();
@@ -204,6 +220,10 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   await phone.locator(".sb-workspace").focus();
   await phone.keyboard.press("Enter");
   await phone.waitForSelector(".files-panel[role=dialog]");
+  // The toggle reports the drawer's state (it stays in the DOM under the
+  // full-screen drawer; while open it is covered and focus-trapped away, so
+  // "toggle closes" is not a reachable phone path — Esc/‹ are).
+  assert.equal(await phone.locator(".sb-workspace").getAttribute("aria-expanded"), "true");
   await noSideScroll(phone);
   const width = await phone.evaluate(() => {
     const el = document.querySelector(".files-panel");
@@ -215,15 +235,40 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   // Files × at the top-right was the odd one out) — and the drawer's own
   // head switches between them; switching keeps the exit where it was.
   assert.equal(await phone.locator(".files-panel-head .files-panel-back").getAttribute("aria-label"), "Back to conversation");
+  await settled(phone, ".files-panel");
   const filesBack = (await phone.locator(".files-panel-back").boundingBox())!;
   assert.ok(filesBack.x < 60 && filesBack.y < 120, `files back is at ${filesBack.x},${filesBack.y} — not top-left`);
-  assert.ok(filesBack.width >= 40 && filesBack.height >= 40, "files back is under the 40px thumb rule");
+  assert.ok(
+    filesBack.width >= 40 && filesBack.height >= 40,
+    `files back is under the 40px thumb rule (${JSON.stringify(filesBack)})`,
+  );
+  // The switch is the phone's ONLY way between the views, so it obeys the
+  // ≥40px thumb rule itself (the pill's buttons, not the pill).
+  const filesTabs = (await phone.locator(".files-panel-head .workspace-tabs").boundingBox())!;
+  for (const tab of await phone.locator(".files-panel-head .workspace-tab").all()) {
+    const box = (await tab.boundingBox())!;
+    assert.ok(box.height >= 40 && box.width >= 40, `workspace tab is ${box.width}×${box.height} — under the 40px thumb rule`);
+  }
   await phone.locator('.files-panel-head .workspace-tab:has-text("Changes")').tap();
   await phone.waitForSelector(".changes-panel[role=dialog]");
   assert.equal(await phone.locator(".files-panel").count(), 0, "one drawer view at a time");
+  await settled(phone, ".changes-panel");
   const changesBack = (await phone.locator(".changes-head .changes-close").boundingBox())!;
   assert.equal(await phone.locator(".changes-head .changes-close").getAttribute("aria-label"), "Back to conversation");
-  assert.ok(Math.abs(changesBack.x - filesBack.x) <= 8, `exits drift: files ${filesBack.x} vs changes ${changesBack.x}`);
+  // "One control in two places": the exit and the switch sit at the SAME
+  // spot in both heads (both axes; 1px = sub-pixel rounding, nothing more),
+  // so switching views never moves either under the thumb.
+  const samePlace = (a: { x: number; y: number }, b: { x: number; y: number }) =>
+    Math.abs(a.x - b.x) <= 1 && Math.abs(a.y - b.y) <= 1;
+  assert.ok(
+    samePlace(changesBack, filesBack),
+    `exits drift between heads: files ${filesBack.x},${filesBack.y} vs changes ${changesBack.x},${changesBack.y}`,
+  );
+  const changesTabs = (await phone.locator(".changes-head .workspace-tabs").boundingBox())!;
+  assert.ok(
+    samePlace(changesTabs, filesTabs),
+    `switch jumps between heads: files ${filesTabs.x},${filesTabs.y} vs changes ${changesTabs.x},${changesTabs.y}`,
+  );
   await phone.locator('.changes-head .workspace-tab:has-text("Files")').tap();
   await phone.waitForSelector(".files-panel[role=dialog]");
   await noSideScroll(phone);
@@ -257,11 +302,56 @@ test("phone (E.4): the files panel is a full-screen drill-in — tree → file �
   // Esc from the tree closes the panel, and focus returns to the opener.
   await phone.keyboard.press("Escape");
   assert.equal(await phone.locator(".files-panel").count(), 0, "Esc from the tree closes the panel");
+  assert.equal(await phone.locator(".sb-workspace").getAttribute("aria-expanded"), "false");
   await noSideScroll(phone);
   const focusedFiles = await phone.evaluate(
     () => document.activeElement?.classList.contains("sb-workspace") ?? false,
   );
   assert.ok(focusedFiles, "focus returned to the workspace toggle on close");
+});
+
+// The drawer heads hold fixed-width controls (‹, the Files | Changes switch,
+// refresh, the count pill) — none may shrink, so on the narrowest phones
+// they must not land on each other. 320px is the iPhone-SE-class floor; the
+// 2026-08-18 bughunt caught the count pill sitting on the switch there.
+test("phone (320px): both drawer heads keep their controls apart", async () => {
+  // Self-contained: an earlier failure may have left the drawer open (a file
+  // view needs two Escapes: back to the tree, then out), and a covered toggle
+  // would turn that one failure into a second, unrelated one.
+  await closeDrawer(phone);
+  await phone.setViewportSize({ width: 320, height: 568 });
+  try {
+    await phone.locator(".sb-workspace").tap();
+    // Whichever view was used last: land on Files explicitly.
+    await phone.waitForSelector(".files-panel[role=dialog], .changes-panel[role=dialog]");
+    await phone.locator('.workspace-tab:has-text("Files")').tap();
+    await phone.waitForSelector(".files-panel[role=dialog]");
+    await settled(phone, ".files-panel");
+    await assertApartOnScreen(phone, 320, [".files-panel-back", ".files-panel-head .workspace-tabs", ".files-refresh"]);
+    await noSideScroll(phone);
+    await phone.locator('.files-panel-head .workspace-tab:has-text("Changes")').tap();
+    await phone.waitForSelector(".changes-panel[role=dialog]");
+    await phone.waitForSelector(".changes-count");
+    await settled(phone, ".changes-panel");
+    // Row two: the review progress renders only with ≥1 change (this daemon
+    // runs in the checkout, clean in CI); changes.e2e pins the pair on its
+    // 5-file fixture unconditionally.
+    const progress = (await phone.locator(".changes-progress").count()) > 0 ? [".changes-progress"] : [];
+    await assertApartOnScreen(phone, 320, [
+      ".changes-head .changes-close",
+      ".changes-head .workspace-tabs",
+      ".changes-count",
+      ...progress,
+      ".changes-refresh",
+    ]);
+    await noSideScroll(phone);
+    await phone.locator(".changes-head .changes-close").tap();
+    await phone.waitForSelector(".changes-panel", { state: "detached" });
+  } finally {
+    // A failed assertion must not leave the drawer over the later tests.
+    await closeDrawer(phone);
+    await phone.setViewportSize({ width: 390, height: 844 });
+  }
 });
 
 test("phone: a permission request is answerable by thumb", async () => {

--- a/web/src/components/FilesGlyph.tsx
+++ b/web/src/components/FilesGlyph.tsx
@@ -1,5 +1,5 @@
-/* The Explorer files glyph — one drawing, two homes: the desktop activity
-   bar (Shell) and the status bar's phone-only toggle. A single document sheet,
+/* The Explorer files glyph — the desktop activity bar's Files toggle (the
+   phone status bar carries WorkspaceGlyph instead). A single document sheet,
    drawn symmetric about the viewBox center — a two-page glyph reads as
    hanging right (its front page's mass sits right of center) even when its
    bounds are centered. Tight viewBox: the drawing fills the box. */

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -9,6 +9,7 @@ import { PromptBox, type PromptDraft } from "./PromptBox";
 import { RenderZone } from "./RenderZone";
 import { FilesPanel } from "./files/FilesPanel";
 import { ChangesPanel } from "./changes/ChangesPanel";
+import type { WorkspaceSurface } from "./WorkspaceTabs";
 import { StatusBar, type Usage } from "./StatusBar";
 import { createSessionBus } from "../session-bus";
 import type { SubscriptionReply } from "../subscription-card";
@@ -146,7 +147,7 @@ export function Shell() {
   // exists; Changes answers what differs from Git HEAD. This single slot is
   // the invariant that keeps the transcript visible on desktop and prevents
   // stacked full-screen layers on phone.
-  const [auxiliary, setAuxiliary] = useState<"files" | "changes" | null>(null);
+  const [auxiliary, setAuxiliary] = useState<WorkspaceSurface | null>(null);
   const filesOpen = auxiliary === "files";
   const changesOpen = auxiliary === "changes";
   const [reviewPromptVisible, setReviewPromptVisible] = useState(false);
@@ -157,7 +158,7 @@ export function Shell() {
     setPromptDraft({ id: promptDraftId.current, text });
     setReviewPromptVisible(true);
   }, []);
-  const toggleAuxiliary = (surface: "files" | "changes") => {
+  const toggleAuxiliary = (surface: WorkspaceSurface) => {
     if (surface !== "changes" || auxiliary !== "changes") setReviewPromptVisible(false);
     setAuxiliary((current) => (current === surface ? null : surface));
   };
@@ -169,12 +170,11 @@ export function Shell() {
   // not two side-by-side icons; it reopens whichever surface was used last
   // (Files until Changes has been chosen once), and the drawer's own head
   // switches between them. Desktop keeps the two-icon rail unchanged.
-  const lastSurface = useRef<"files" | "changes">("files");
+  const lastSurface = useRef<WorkspaceSurface>("files");
   if (auxiliary) lastSurface.current = auxiliary;
   const toggleWorkspace = () => toggleAuxiliary(lastSurface.current);
-  const switchAuxiliary = (surface: "files" | "changes") => {
-    if (surface !== "changes") setReviewPromptVisible(false);
-    setAuxiliary(surface);
+  const switchAuxiliary = (surface: WorkspaceSurface) => {
+    if (auxiliary !== surface) toggleAuxiliary(surface);
   };
 
   // ── The theme (4.3; two-slot model S.3) ─────────────────────────────────

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -165,6 +165,17 @@ export function Shell() {
     setAuxiliary(null);
     setReviewPromptVisible(false);
   };
+  // Phone (2026-08-18, Kyle): the status bar carries ONE workspace toggle,
+  // not two side-by-side icons; it reopens whichever surface was used last
+  // (Files until Changes has been chosen once), and the drawer's own head
+  // switches between them. Desktop keeps the two-icon rail unchanged.
+  const lastSurface = useRef<"files" | "changes">("files");
+  if (auxiliary) lastSurface.current = auxiliary;
+  const toggleWorkspace = () => toggleAuxiliary(lastSurface.current);
+  const switchAuxiliary = (surface: "files" | "changes") => {
+    if (surface !== "changes") setReviewPromptVisible(false);
+    setAuxiliary(surface);
+  };
 
   // ── The theme (4.3; two-slot model S.3) ─────────────────────────────────
   // Theme is shell-owned UI state. Dark is the default and the identity;
@@ -659,6 +670,7 @@ export function Shell() {
                 requestRead={bus.requestFsRead}
                 requestDiff={bus.requestFsDiff}
                 onClose={closeAuxiliary}
+                onSwitch={switchAuxiliary}
                 rootLabel={tildify(meta.cwd, daemonInfo.home)}
                 sessionKey={meta.sessionId}
               />
@@ -669,6 +681,7 @@ export function Shell() {
                 requestRead={bus.requestFsRead}
                 requestDiff={bus.requestFsDiff}
                 onClose={closeAuxiliary}
+                onSwitch={switchAuxiliary}
                 onCreateDraft={createReviewDraft}
                 promptContainerRef={promptContainerRef}
                 promptVisible={reviewPromptVisible}
@@ -743,12 +756,9 @@ export function Shell() {
               billing={daemonInfo.billing === "license-key"}
               subRequest={bus.requestSubscription}
               subReply={subReply}
-              filesOpen={filesOpen}
-              filesDisabled={!meta.sessionId}
-              onToggleFiles={() => toggleAuxiliary("files")}
-              changesOpen={changesOpen}
-              changesDisabled={!meta.sessionId}
-              onToggleChanges={() => toggleAuxiliary("changes")}
+              workspaceOpen={auxiliary !== null}
+              workspaceDisabled={!meta.sessionId}
+              onToggleWorkspace={toggleWorkspace}
             />
           </div>
         </div>

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -1,9 +1,8 @@
 import { useState } from "react";
 import { ArmedButton } from "./ArmedButton";
-import { ChangesGlyph } from "./ChangesGlyph";
 import { ConnectDevice, type RelayInfo, type SubscriptionRequest } from "./ConnectDevice";
 import type { SubscriptionReply } from "../subscription-card";
-import { FilesGlyph } from "./FilesGlyph";
+import { WorkspaceGlyph } from "./WorkspaceGlyph";
 import { GearGlyph } from "./GearGlyph";
 import { useArmedConfirm } from "../use-armed-confirm";
 import { useIsPhone } from "../use-is-phone";
@@ -51,12 +50,9 @@ export function StatusBar({
   billing,
   subRequest,
   subReply,
-  filesOpen,
-  filesDisabled,
-  onToggleFiles,
-  changesOpen,
-  changesDisabled,
-  onToggleChanges,
+  workspaceOpen,
+  workspaceDisabled,
+  onToggleWorkspace,
 }: {
   connected: boolean;
   // Why the socket is down, when the relay refused it (no daemon / at capacity /
@@ -85,18 +81,17 @@ export function StatusBar({
   // The daemon's version, off the agents hello — the first thing a
   // bug report needs (R.4g).
   version?: string;
-  // The Explorer toggle's PHONE home (2026-07-25, Kyle): the activity bar is
-  // a desktop affordance, so on ≤640px the bar hides and this button carries
-  // the same open/collapse — boxed off at the far left by its own separator
+  // The workspace toggle's PHONE home (2026-07-25, Kyle): the activity bar
+  // is a desktop affordance, so on ≤640px the bar hides and this ONE button
+  // opens the full-screen workspace drawer (Files / Changes — the drawer's
+  // own head switches between them; two side-by-side icons here were too
+  // crowded, 2026-08-18) — boxed off at the far left by its own separator
   // line (the rail's border, folded into the row). Not rendered on desktop
   // at all (useIsPhone), where home must stay the bar's first control
   // (2026-07-16 order).
-  filesOpen?: boolean;
-  filesDisabled?: boolean;
-  onToggleFiles?: () => void;
-  changesOpen?: boolean;
-  changesDisabled?: boolean;
-  onToggleChanges?: () => void;
+  workspaceOpen?: boolean;
+  workspaceDisabled?: boolean;
+  onToggleWorkspace?: () => void;
   // Phase CS: the manage-subscription plumbing, passed through to the pair
   // card (present only when the daemon runs on a license key).
   billing?: boolean;
@@ -138,30 +133,20 @@ export function StatusBar({
 
   return (
     <div className="status-bar">
-      {/* Phone-only (desktop's activity bar owns these there): the workspace
-          toggles sit one notch OUTSIDE home, boxed off as navigation distinct
+      {/* Phone-only (desktop's activity bar owns this there): the workspace
+          toggle sits one notch OUTSIDE home, boxed off as navigation distinct
           from the session controls. */}
-      {phone && onToggleFiles && onToggleChanges && (
+      {phone && onToggleWorkspace && (
         <div className="sb-side-nav" aria-label="Workspace views">
           <button
-            className={"sb-files" + (filesOpen ? " is-active" : "")}
-            onClick={onToggleFiles}
-            disabled={filesDisabled}
-            title={filesOpen ? "Hide files" : "Show files"}
-            aria-label="Files"
-            aria-expanded={filesOpen}
+            className={"sb-workspace" + (workspaceOpen ? " is-active" : "")}
+            onClick={onToggleWorkspace}
+            disabled={workspaceDisabled}
+            title={workspaceOpen ? "Hide workspace" : "Show workspace (files and changes)"}
+            aria-label="Workspace"
+            aria-expanded={workspaceOpen}
           >
-            <FilesGlyph size={20} />
-          </button>
-          <button
-            className={"sb-changes" + (changesOpen ? " is-active" : "")}
-            onClick={onToggleChanges}
-            disabled={changesDisabled}
-            title={changesOpen ? "Hide workspace changes" : "Show workspace changes"}
-            aria-label="Workspace changes"
-            aria-expanded={changesOpen}
-          >
-            <ChangesGlyph size={20} />
+            <WorkspaceGlyph size={20} />
           </button>
         </div>
       )}

--- a/web/src/components/WorkspaceGlyph.tsx
+++ b/web/src/components/WorkspaceGlyph.tsx
@@ -1,0 +1,23 @@
+/** The phone workspace toggle's glyph: a panel with its side column — the
+ * one drawer that holds both Files and Changes on ≤640px, where the two
+ * separate desktop rail icons were too crowded for the status bar
+ * (2026-08-18, Kyle). Drawn on FilesGlyph's 14×20 artwork box at the same
+ * 1.5 stroke so it sits in the bar at the same footprint. */
+export function WorkspaceGlyph({ size = 28 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 14 20"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="0.75" y="3.25" width="12.5" height="13.5" rx="1.5" />
+      <path d="M5.25 3.25v13.5" />
+      <path d="M2.75 6.5h0.75M2.75 9h0.75M2.75 11.5h0.75" strokeLinecap="round" />
+    </svg>
+  );
+}

--- a/web/src/components/WorkspaceTabs.tsx
+++ b/web/src/components/WorkspaceTabs.tsx
@@ -1,5 +1,10 @@
 export type WorkspaceSurface = "files" | "changes";
 
+const SURFACES: readonly (readonly [WorkspaceSurface, string])[] = [
+  ["files", "Files"],
+  ["changes", "Changes"],
+];
+
 /** The phone drawer's view switch (2026-08-18, Kyle): on ≤640px Files and
  * Changes share one full-screen drawer, opened by the status bar's single
  * workspace toggle, and this segmented control at the drawer's head is how
@@ -16,22 +21,17 @@ export function WorkspaceTabs({
 }) {
   return (
     <div className="workspace-tabs" role="group" aria-label="Workspace view">
-      <button
-        type="button"
-        className={"workspace-tab" + (active === "files" ? " is-active" : "")}
-        aria-pressed={active === "files"}
-        onClick={() => active !== "files" && onSwitch("files")}
-      >
-        Files
-      </button>
-      <button
-        type="button"
-        className={"workspace-tab" + (active === "changes" ? " is-active" : "")}
-        aria-pressed={active === "changes"}
-        onClick={() => active !== "changes" && onSwitch("changes")}
-      >
-        Changes
-      </button>
+      {SURFACES.map(([surface, label]) => (
+        <button
+          key={surface}
+          type="button"
+          className={"workspace-tab" + (active === surface ? " is-active" : "")}
+          aria-pressed={active === surface}
+          onClick={() => active !== surface && onSwitch(surface)}
+        >
+          {label}
+        </button>
+      ))}
     </div>
   );
 }

--- a/web/src/components/WorkspaceTabs.tsx
+++ b/web/src/components/WorkspaceTabs.tsx
@@ -1,0 +1,37 @@
+export type WorkspaceSurface = "files" | "changes";
+
+/** The phone drawer's view switch (2026-08-18, Kyle): on ≤640px Files and
+ * Changes share one full-screen drawer, opened by the status bar's single
+ * workspace toggle, and this segmented control at the drawer's head is how
+ * the user moves between them — in place of the two side-by-side status-bar
+ * icons. Phone-only; the desktop rail keeps one icon per surface. A group of
+ * pressed/unpressed buttons rather than a tablist: the two views are separate
+ * panels, not tab panels of one composite widget. */
+export function WorkspaceTabs({
+  active,
+  onSwitch,
+}: {
+  active: WorkspaceSurface;
+  onSwitch: (surface: WorkspaceSurface) => void;
+}) {
+  return (
+    <div className="workspace-tabs" role="group" aria-label="Workspace view">
+      <button
+        type="button"
+        className={"workspace-tab" + (active === "files" ? " is-active" : "")}
+        aria-pressed={active === "files"}
+        onClick={() => active !== "files" && onSwitch("files")}
+      >
+        Files
+      </button>
+      <button
+        type="button"
+        className={"workspace-tab" + (active === "changes" ? " is-active" : "")}
+        aria-pressed={active === "changes"}
+        onClick={() => active !== "changes" && onSwitch("changes")}
+      >
+        Changes
+      </button>
+    </div>
+  );
+}

--- a/web/src/components/changes/ChangesChrome.tsx
+++ b/web/src/components/changes/ChangesChrome.tsx
@@ -2,6 +2,7 @@ import type { FsChangeRepo } from "@protocol";
 import { changeStatus, repoLabel, type ChangeItem } from "../../changes";
 import { RefreshIcon } from "../RefreshIcon";
 import type { ReviewProgress } from "../../review-progress";
+import { WorkspaceTabs, type WorkspaceSurface } from "../WorkspaceTabs";
 
 export function ChangesHeader({
   phone,
@@ -12,6 +13,7 @@ export function ChangesHeader({
   pending,
   onRefresh,
   onClose,
+  onSwitch,
 }: {
   phone: boolean;
   loaded: boolean;
@@ -21,6 +23,8 @@ export function ChangesHeader({
   pending: boolean;
   onRefresh: () => void;
   onClose: () => void;
+  /** Phone drawer view switch (Files ⇄ Changes), shown in the title's place. */
+  onSwitch?: (surface: WorkspaceSurface) => void;
 }) {
   return (
     <header className="changes-head">
@@ -29,10 +33,14 @@ export function ChangesHeader({
           ‹
         </button>
       )}
-      <div className="changes-title-block">
-        <h2>Workspace changes</h2>
-        <span className="changes-subtitle">Working tree versus Git HEAD</span>
-      </div>
+      {phone && onSwitch ? (
+        <WorkspaceTabs active="changes" onSwitch={onSwitch} />
+      ) : (
+        <div className="changes-title-block">
+          <h2>Workspace changes</h2>
+          <span className="changes-subtitle">Working tree versus Git HEAD</span>
+        </div>
+      )}
       {loaded && itemCount > 0 && (
         <span
           className="changes-progress"

--- a/web/src/components/changes/ChangesPanel.tsx
+++ b/web/src/components/changes/ChangesPanel.tsx
@@ -2,6 +2,7 @@ import { useRef, type RefObject } from "react";
 import type { ZoneMsg } from "../../session-bus";
 import { useEscapeKey } from "../../use-escape";
 import { useFocusTrap } from "../../use-focus-trap";
+import type { WorkspaceSurface } from "../WorkspaceTabs";
 import { useIsPhone } from "../../use-is-phone";
 import { FileView } from "../files/FileView";
 import {
@@ -21,6 +22,7 @@ export function ChangesPanel({
   requestRead,
   requestDiff,
   onClose,
+  onSwitch,
   onCreateDraft,
   promptContainerRef,
   promptVisible,
@@ -33,6 +35,7 @@ export function ChangesPanel({
   requestRead: (path: string) => string;
   requestDiff: (path: string) => string;
   onClose: () => void;
+  onSwitch?: (surface: WorkspaceSurface) => void;
   onCreateDraft: (text: string) => void;
   promptContainerRef?: RefObject<HTMLElement | null>;
   promptVisible?: boolean;
@@ -101,6 +104,7 @@ export function ChangesPanel({
         pending={changeSet.pending}
         onRefresh={requestSet}
         onClose={onClose}
+        onSwitch={onSwitch}
       />
 
       {changeSet.error && items.length > 0 && (

--- a/web/src/components/files/FilesPanel.tsx
+++ b/web/src/components/files/FilesPanel.tsx
@@ -18,6 +18,7 @@ import { FileView } from "./FileView";
 import { ExplorerChevron, ExplorerNodeGlyph } from "./ExplorerNodeGlyph";
 import { DirChildren } from "./FilesTreeRows";
 import { RefreshIcon } from "../RefreshIcon";
+import { WorkspaceTabs, type WorkspaceSurface } from "../WorkspaceTabs";
 import { useFileView } from "./use-file-view";
 
 // The Explorer's shell-owned panel (E.3 desktop, E.4 phone; lazy since
@@ -59,6 +60,7 @@ export function FilesPanel({
   requestRead,
   requestDiff,
   onClose,
+  onSwitch,
   rootLabel,
   sessionKey,
 }: {
@@ -68,6 +70,9 @@ export function FilesPanel({
   requestRead: (path: string) => string;
   requestDiff: (path: string) => string;
   onClose: () => void;
+  /** Phone drawer view switch (Files ⇄ Changes); rendered in the head on
+   *  ≤640px only — desktop's rail owns the choice there. */
+  onSwitch?: (surface: WorkspaceSurface) => void;
   /** ~-abbreviated session root — its basename names the tree's root row,
    *  the full path lives in that row's tooltip. */
   rootLabel?: string;
@@ -300,8 +305,26 @@ export function FilesPanel({
           over it, so back reveals the tree at its prior scroll (E.4). */}
       <div className="files-main">
         <div className="files-tree">
+          {/* Phone head: back chevron LEADING (top-left, thumb-reachable —
+              the same exit Changes has; a top-right × was the odd one out,
+              2026-08-18 Kyle), then the drawer's Files/Changes switch in the
+              title's place. Desktop keeps the plain title, no close. */}
           <header className="files-panel-head">
-            <h2 className="files-panel-title">Files</h2>
+            {phone && (
+              <button
+                className="files-panel-action files-panel-back"
+                onClick={onClose}
+                title="Back to conversation"
+                aria-label="Back to conversation"
+              >
+                ‹
+              </button>
+            )}
+            {phone && onSwitch ? (
+              <WorkspaceTabs active="files" onSwitch={onSwitch} />
+            ) : (
+              <h2 className="files-panel-title">Files</h2>
+            )}
             <div className="files-panel-actions">
               <button
                 className="files-panel-action files-refresh"
@@ -311,16 +334,6 @@ export function FilesPanel({
               >
                 <RefreshIcon className="files-action-icon" />
               </button>
-              {phone && (
-                <button
-                  className="files-panel-action"
-                  onClick={onClose}
-                  title="Close files"
-                  aria-label="Close files"
-                >
-                  <ExplorerCloseIcon />
-                </button>
-              )}
             </div>
           </header>
           {/* The session's checked-out root leads the tree as its top node
@@ -452,13 +465,5 @@ export function FilesPanel({
   );
 }
 
-
-function ExplorerCloseIcon() {
-  return (
-    <svg className="files-action-icon" viewBox="0 0 16 16" aria-hidden="true" focusable="false">
-      <path d="m4 4 8 8M12 4l-8 8" />
-    </svg>
-  );
-}
 
 

--- a/web/src/styles/11-status-bar.css
+++ b/web/src/styles/11-status-bar.css
@@ -165,9 +165,10 @@
 /* #9: mission-control home — an <a> styled as an icon button, the status
    bar's outermost far-LEFT control (moved from the far right 2026-07-16);
    the connection dot sits between it and the agent text. */
-/* .sb-files — the Explorer toggle's phone home (2026-07-25, Kyle) — only
-   RENDERS on ≤640px (StatusBar gates on useIsPhone, keeping home the bar's
-   first control on desktop); its styles live in the phone block. */
+/* .sb-workspace — the workspace drawer's phone toggle (2026-07-25, Kyle;
+   one button for Files + Changes since 2026-08-18) — only RENDERS on ≤640px
+   (StatusBar gates on useIsPhone, keeping home the bar's first control on
+   desktop); its styles live in the phone block. */
 
 .sb-home {
   display: inline-flex;

--- a/web/src/styles/15-phone.css
+++ b/web/src/styles/15-phone.css
@@ -281,29 +281,40 @@
     display: none;
   }
 
+  /* Row one holds only the fixed-width Files | Changes switch between the
+     two 42px buttons — nothing else competes with it, so it fits at any
+     phone width (at 320px the count pill used to land on it, 2026-08-18).
+     The count rides row two, right-aligned beside the review progress. */
   .changes-head {
     min-height: 68px;
     display: grid;
     grid-template-columns: 42px minmax(0, 1fr) auto 42px;
     grid-template-areas:
-      "close title count refresh"
-      "close progress progress refresh";
+      "close title title refresh"
+      "close progress count refresh";
     gap: 2px 6px;
     padding: 7px 8px;
   }
 
+  /* Both icon buttons sit on row one (not centred across the two rows) so
+     the ‹ is at the same y as the Files head's — one exit, two places. */
   .changes-head .changes-close {
     grid-area: close;
+    align-self: start;
   }
 
   .changes-title-block,
   .changes-head .workspace-tabs {
     grid-area: title;
     justify-self: start;
+    /* Row two is empty until the first snapshot; without this the grid
+       stretches the pill to fill min-height for that instant. */
+    align-self: start;
   }
 
   .changes-head .changes-refresh {
     grid-area: refresh;
+    align-self: start;
   }
 
   .changes-subtitle {
@@ -316,6 +327,8 @@
 
   .changes-count {
     grid-area: count;
+    justify-self: end;
+    align-self: center;
     padding: 3px 6px;
     font-size: 0.66em;
   }
@@ -547,16 +560,17 @@
     display: inline-flex;
     align-items: stretch;
     min-width: 0;
-    height: 34px;
-    padding: 2px;
+    padding: 0;
     background: var(--surface-2);
     border: 1px solid var(--border-2);
     border-radius: 8px;
   }
 
+  /* 40px tall = the tap target itself, not the pill around it. */
   .workspace-tab {
     display: inline-flex;
     align-items: center;
+    height: 40px;
     padding: 0 12px;
     background: transparent;
     border: none;
@@ -571,11 +585,14 @@
   .workspace-tab.is-active {
     color: var(--fg-strong);
     background: var(--surface-hover);
+    border-radius: 7px;
   }
 
-  /* Same glyph, size and weight as .changes-close so the two exits are one
-     control in two places. */
+  /* Same glyph, size, weight AND width as .changes-close (42px) so the two
+     exits are one control in two places — and the switch beside them lands
+     at the same x/y in both heads (8 + 42 + 6, row centred at y = 7). */
   .files-panel-back {
+    width: 42px;
     font: inherit;
     font-size: 20px;
     line-height: 1;

--- a/web/src/styles/15-phone.css
+++ b/web/src/styles/15-phone.css
@@ -109,7 +109,7 @@
   .status-bar {
     flex-wrap: nowrap;
     column-gap: 5px;
-    /* No activity bar on phone (it folds into .sb-files) — the negative
+    /* No activity bar on phone (it folds into .sb-workspace) — the negative
        margin just runs the top border edge-to-edge; the controls stay at
        the column's content edge. */
     margin: 4px 0 0 calc(-1 * var(--content-air));
@@ -296,8 +296,10 @@
     grid-area: close;
   }
 
-  .changes-title-block {
+  .changes-title-block,
+  .changes-head .workspace-tabs {
     grid-area: title;
+    justify-self: start;
   }
 
   .changes-head .changes-refresh {
@@ -467,8 +469,13 @@
     min-height: 42px;
   }
 
+  /* Files head on phone: back chevron leading (top-left, same exit as
+     Changes, 2026-08-18 Kyle), the .workspace-tabs switch beside it, refresh
+     trailing — a centered flex row, not the desktop's baseline title bar. */
   .files-panel-head {
-    padding: 8px 8px 7px 14px;
+    align-items: center;
+    gap: 6px;
+    padding: 8px 8px 7px 8px;
   }
 
   .files-panel-action {
@@ -481,16 +488,18 @@
   }
 
   /* The rail is a desktop affordance — a permanent 46px strip is too much
-     of a 390px screen (2026-07-25, Kyle). Its files toggle folds down into
-     the status bar (.sb-files below); the shell and prompt box above run
+     of a 390px screen (2026-07-25, Kyle). Its toggles fold down into the
+     status bar (.sb-workspace below); the shell and prompt box above run
      full-width. */
   .activity-bar {
     display: none;
   }
 
-  /* Files + Changes fold the desktop activity rail into one compact phone
-     navigation group. The separator after the pair keeps workspace views
-     distinct from home/new/session controls. */
+  /* Files + Changes fold the desktop activity rail into ONE phone toggle
+     (two side-by-side icons crowded the bar, 2026-08-18 Kyle) that opens the
+     full-screen workspace drawer; the drawer's head carries the
+     .workspace-tabs switch between the two views. The separator after it
+     keeps the workspace distinct from home/new/session controls. */
   .sb-side-nav {
     display: flex;
     align-items: center;
@@ -503,8 +512,7 @@
     border-right: 1px solid var(--border);
   }
 
-  .sb-files,
-  .sb-changes {
+  .sb-workspace {
     display: flex;
     align-items: center;
     justify-content: center;
@@ -520,16 +528,57 @@
     cursor: pointer;
   }
 
-  .sb-files.is-active,
-  .sb-changes.is-active {
+  .sb-workspace.is-active {
     color: var(--fg-body);
     background: var(--surface-hover);
   }
 
-  .sb-files:disabled,
-  .sb-changes:disabled {
+  .sb-workspace:disabled {
     opacity: 0.35;
     cursor: default;
+  }
+
+  /* The drawer's view switch — a segmented pair at the head of both panels,
+     in the title's place. It is the phone's ONLY way between Files and
+     Changes (the status bar has one toggle), so it reads as a control, not a
+     label: bordered pill, the pressed side filled. ≥40px tall (thumb rule);
+     both panels' heads position it identically so switching never moves it. */
+  .workspace-tabs {
+    display: inline-flex;
+    align-items: stretch;
+    min-width: 0;
+    height: 34px;
+    padding: 2px;
+    background: var(--surface-2);
+    border: 1px solid var(--border-2);
+    border-radius: 8px;
+  }
+
+  .workspace-tab {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 12px;
+    background: transparent;
+    border: none;
+    border-radius: 6px;
+    color: var(--fg-dim);
+    font-size: 0.78em;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    cursor: pointer;
+  }
+
+  .workspace-tab.is-active {
+    color: var(--fg-strong);
+    background: var(--surface-hover);
+  }
+
+  /* Same glyph, size and weight as .changes-close so the two exits are one
+     control in two places. */
+  .files-panel-back {
+    font: inherit;
+    font-size: 20px;
+    line-height: 1;
   }
 
   /* Cockpit sub-lines: they lose the desktop indent (a 390px canvas has no


### PR DESCRIPTION
## What

Two small phone-only (≤640px) changes to the Files / Changes drawer, both Kyle's asks (2026-08-18). Desktop is untouched.

1. **One workspace button instead of two.** The status bar's side-by-side Files and Changes icons crowded the bar. They fold into a single `.sb-workspace` toggle (new `WorkspaceGlyph`) that opens the full-screen drawer on the **last-used** view (Files until Changes has been chosen once). A **Files | Changes** segmented switch (`WorkspaceTabs`) sits at the head of both panels, in the title's place, and is how the user moves between them — the pattern VS Code web / GitHub mobile use (one place with sections, not N header buttons).
2. **Same exit for both views.** Changes already had a leading `‹` back chevron at the top-left (thumb-reachable); Files had a top-right ×. Files now gets the same leading chevron (`Back to conversation`), the × is gone. Both heads read `‹  [Files | Changes]  ↻`.

## Verification

- `yarn test` 840/840 · `yarn typecheck` clean
- `phone.e2e` 8/8 (asserts the two-icon pair is gone, both exits are top-left within 8px of each other and ≥40px, the switch flips views without stacking panels, focus returns to the single toggle) · `changes.e2e` 12/12 · `app.e2e` 58/58 · `test:ui:built` 7/7 (visual baselines unchanged)
- Screenshots of the mock session at 390×844 checked by eye for both heads and the bar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)