### PR TITLE
Extract transcript projection from RenderZone

### DIFF
--- a/web/src/components/RenderZone.tsx
+++ b/web/src/components/RenderZone.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useMemo,
   useReducer,
-  useRef,
   useState,
 } from "react";
 import ReactMarkdown from "react-markdown";
@@ -17,101 +16,19 @@ import { mdOverrides, mdUrlTransform } from "../registry/Md";
 import { PinDock } from "./PinDock";
 import { ToolBlock } from "./ToolBlock";
 import { Artifact } from "./Artifact";
-import { PickerBlock, type PickerRow } from "./PickerBlock";
+import { PickerBlock } from "./PickerBlock";
 import { GearGlyph } from "./GearGlyph";
 import { useFollowTail } from "../use-follow-tail";
-import { queueDelta, type QueuedDelta } from "../delta-queue";
-import { groupSettledTools, type ActivityItem, type FoldedActivity } from "../tool-visibility";
-import { deckElapsedSeconds, subagentSummary } from "../subagent-deck";
+import { createTranscriptIngress } from "../delta-queue";
+import { deckElapsedSeconds } from "../subagent-deck";
 import { shouldFocusPromptFromTranscriptPointer } from "../transcript-focus";
-
-// The scrollback is a flat list of entries: text blocks and rendered
-// components, in the exact order they arrived on the wire.
-type Entry =
-  | { kind: "text"; id: number; role: "user" | "assistant"; text: string; done: boolean }
-  | {
-      kind: "render";
-      id: number;
-      renderId: string; // wire id — re-sends with this id update props in place
-      component: string;
-      props: Record<string, unknown>;
-    }
-  | {
-      kind: "tool";
-      id: number;
-      toolId: string; // wire id — the matching tool_result completes this record
-      name: string;
-      detail?: string;
-      input?: Record<string, unknown>; // full args (T2.2), rendered in the expansion
-      output?: string; // undefined until the result arrives
-      truncatedBytes?: number; // T2.3: bytes elided past the cap, if any
-      parentId?: string; // T2.4: Task wire id if this is a subagent's call
-      isError?: boolean;
-      batchId: number; // user-turn batch; successful calls fold together at its end
-      settled: boolean;
-      // SA.1: when this client appended the record — the subagent deck's
-      // elapsed ticker. Only honest for a record seen arriving LIVE, so the
-      // deck shows elapsed only while running AND not replayed (a replayed
-      // record's stamp is the attach moment, not the spawn — bughunt
-      // 2026-08-14).
-      startedAt: number;
-      replayed?: boolean;
-    }
-  | {
-      // SA.2: a subagent's narration or reasoning — prose the wire tags with
-      // a parentId. Lives inside its deck's expansion, never at top level,
-      // and renders as INERT PLAIN TEXT (trusted-shell rule: subagent words
-      // never get markdown inside shell chrome).
-      kind: "subtext";
-      id: number;
-      parentId: string; // the spawn wire id whose deck holds this
-      variant: "text" | "thinking";
-      text: string;
-    }
-  | {
-      kind: "artifact";
-      id: number;
-      artifactId: string; // wire id — re-sends with this id replace the html
-      html: string;
-      title?: string;
-    }
-  | {
-      kind: "thinking";
-      id: number;
-      text: string;
-      done: boolean; // done ⇒ folded to one line unless the user expands it
-      expanded: boolean;
-    }
-  | {
-      // A service-status line (retry, compaction, rate limit, refusal) —
-      // the UI must not lie in degraded service. Persistent, dim, non-agent (F.2).
-      kind: "notice";
-      id: number;
-      text: string;
-      noticeKind?: string;
-      // The engine whose own words these are; absent = Mirafold's own voice.
-      source?: string;
-    }
-  | {
-      kind: "bang"; // a `!` shell command (4.9): its strip + live PTY output
-      id: number;
-      bangId: string; // wire id — output/end messages complete this record
-      command: string;
-      output: string;
-      exitCode?: number | null; // undefined while running; null = killed
-      done: boolean;
-    }
-  | {
-      // Shell-owned selector re-skinning terminal chrome (/model, /effort).
-      kind: "picker";
-      id: number;
-      pickerId: string; // wire id — the action's sourceId when a row is picked
-      title: string;
-      rows: PickerRow[];
-      hint?: string;
-    };
-type ToolCall = Extract<Entry, { kind: "tool" }>;
-type SubtextEntry = Extract<Entry, { kind: "subtext" }>;
+import {
+  createTranscriptProjection,
+  type OutputZoneRow,
+  type SubagentDeckRow,
+  type ThinkingRow,
+  type ToolFoldRow,
+} from "../transcript-projection";
 
 /** The transcript fields ToolBlock renders, picked off any tool-shaped
  *  record — the one spread all three ToolBlock sites share. */
@@ -130,9 +47,6 @@ const toolBlockProps = (call: {
   truncatedBytes: call.truncatedBytes,
   isError: call.isError,
 });
-type ThinkingEntry = Extract<Entry, { kind: "thinking" }>;
-
-let nextId = 0;
 
 // Memoized on the entry's text: a settled block's markdown tree is reused
 // as-is while later entries stream.
@@ -155,12 +69,14 @@ const AssistantTurn = memo(function AssistantTurn({ text }: { text: string }) {
 // memo comparison is the entry reference itself.
 const ThinkingBlock = memo(function ThinkingBlock({
   entry,
+  expanded,
   onToggle,
 }: {
-  entry: Extract<Entry, { kind: "thinking" }>;
+  entry: ThinkingRow;
+  expanded: boolean;
   onToggle: (id: number) => void;
 }) {
-  const folded = entry.done && !entry.expanded;
+  const folded = entry.done && !expanded;
   return (
     <div
       className={
@@ -180,7 +96,7 @@ const ThinkingBlock = memo(function ThinkingBlock({
 /** The deck's full activity, in true stream order (SA.2): tool rows plus the
  *  subagent's own narration and reasoning. Prose is INERT PLAIN TEXT —
  *  subagent words never render as markdown inside shell chrome. */
-function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) {
+function SubagentActivity({ items }: { items: SubagentDeckRow["items"] }) {
   return (
     <div className="subagent-calls">
       {items.map((item) =>
@@ -208,15 +124,12 @@ function SubagentActivity({ items }: { items: Array<ToolCall | SubtextEntry> }) 
  * inert plain text; the deck itself is shell chrome. Elapsed ticks only
  * while running — a settled or replayed card never shows a stale duration. */
 const SubagentDeck = memo(function SubagentDeck({
-  task,
-  items,
+  row,
 }: {
-  task: ToolCall;
-  items: Array<ToolCall | SubtextEntry>;
+  row: SubagentDeckRow;
 }) {
+  const { task, items, summary: s } = row;
   const [open, setOpen] = useState(false);
-  const calls = items.filter((item) => item.kind === "tool");
-  const s = subagentSummary(task, calls);
   const running = s.state === "running";
   const [, tick] = useReducer((n: number) => n + 1, 0);
   useEffect(() => {
@@ -270,20 +183,16 @@ const SubagentDeck = memo(function SubagentDeck({
  * command); expansion replays calls and thinking in true transcript order.
  * The count and summary speak of ACTIONS only — narration isn't one. */
 function ToolActivityGroup({
-  items,
+  row,
+  expandedThinking,
   onToggleThinking,
 }: {
-  items: Array<FoldedActivity<ToolCall, ThinkingEntry>>;
+  row: ToolFoldRow;
+  expandedThinking: ReadonlySet<number>;
   onToggleThinking: (id: number) => void;
 }) {
+  const { items } = row;
   const [open, setOpen] = useState(false);
-  const calls = items.flatMap((item) => (item.kind === "tool" ? [item.tool] : []));
-  const counts = new Map<string, number>();
-  for (const call of calls) counts.set(call.name, (counts.get(call.name) ?? 0) + 1);
-  const summary = [...counts]
-    .slice(0, 3)
-    .map(([name, count]) => `${name}${count > 1 ? ` ×${count}` : ""}`)
-    .join(" · ");
   return (
     <div className="tool-activity-group">
       <button
@@ -293,9 +202,9 @@ function ToolActivityGroup({
       >
         <span className="subagent-caret">{open ? "▾" : "▸"}</span>
         <span className="tool-activity-label">
-          <GearGlyph size="1em" /> worked · {calls.length} action{calls.length === 1 ? "" : "s"}
+          <GearGlyph size="1em" /> worked · {row.actionCount} action{row.actionCount === 1 ? "" : "s"}
         </span>
-        <span className="tool-activity-summary">{summary}</span>
+        <span className="tool-activity-summary">{row.summary}</span>
       </button>
       {open && (
         <div className="tool-activity-calls">
@@ -303,7 +212,12 @@ function ToolActivityGroup({
             item.kind === "tool" ? (
               <ToolBlock key={item.tool.id} {...toolBlockProps(item.tool)} />
             ) : (
-              <ThinkingBlock key={item.thinking.id} entry={item.thinking} onToggle={onToggleThinking} />
+              <ThinkingBlock
+                key={item.thinking.id}
+                entry={item.thinking}
+                expanded={expandedThinking.has(item.thinking.id)}
+                onToggle={onToggleThinking}
+              />
             ),
           )}
         </div>
@@ -313,9 +227,9 @@ function ToolActivityGroup({
 }
 
 /**
- * The output zone — an interpreter for the wire protocol. Level 1: streamed
- * text renders as sanitized markdown (react-markdown never emits raw HTML).
- * Level 2: `render` messages mount registry components inline.
+ * The output zone renders projected transcript rows. Level 1: streamed text
+ * renders as sanitized markdown (react-markdown never emits raw HTML).
+ * Level 2: projected render rows mount registry components inline.
  */
 export function RenderZone({
   subscribe,
@@ -334,7 +248,6 @@ export function RenderZone({
   busy: boolean;
   focusPrompt: () => void;
 }) {
-  const [entries, setEntries] = useState<Entry[]>([]);
   // Pinning is pure output-zone state: wire ids (render or artifact) in pin
   // order. The dock only exists while something is pinned (PLAN Step 1.6).
   const [pinned, setPinned] = useState<string[]>([]);
@@ -342,350 +255,37 @@ export function RenderZone({
   // Streamed output scrolls you down only while you're already at the bottom
   // (2026-07-20, Kyle) — terminal-scrollback behavior, in use-follow-tail.ts.
   const tail = useFollowTail();
-  // The text block currently receiving deltas. Kept in a ref so a user prompt
-  // sent mid-stream can't detach the tail of the reply.
-  const streamingId = useRef<number | null>(null);
-  // SA.2: the open subtext entry per (parentId|variant) — a subagent's
-  // consecutive prose extends in place; its own next tool call closes it so
-  // the deck's expansion keeps true stream order.
-  const subtextIds = useRef(new Map<string, number>());
-  // The thinking block currently receiving deltas (T2.1).
-  const thinkingId = useRef<number | null>(null);
-  // User prompts may queue while a turn is running. Tool events still belong
-  // to the OLDEST open turn, so a FIFO — not "latest prompt" — assigns the
-  // compaction batch correctly.
-  const openToolBatches = useRef<number[]>([]);
-  const orphanToolBatch = useRef(-1);
-
-  useEffect(
-    () => {
-      const apply = (msg: ZoneMsg) => {
-        // SA.2: a subagent's prose routes to its deck BEFORE the fold/close
-        // logic below — a child streaming must not fold the parent's open
-        // thinking or close the parent's streaming text block. Consecutive
-        // same-parent same-variant deltas extend one subtext entry, so the
-        // card reads as prose, not confetti.
-        if ((msg.type === "text_delta" || msg.type === "thinking_delta") && msg.parentId) {
-          const parentId = msg.parentId;
-          const text = msg.text;
-          const variant = msg.type === "text_delta" ? ("text" as const) : ("thinking" as const);
-          const key = `${parentId}|${variant}`;
-          const openId = subtextIds.current.get(key);
-          if (openId !== undefined) {
-            setEntries((es) =>
-              es.map((e) =>
-                e.kind === "subtext" && e.id === openId ? { ...e, text: e.text + text } : e,
-              ),
-            );
-          } else {
-            const newId = nextId++;
-            subtextIds.current.set(key, newId);
-            setEntries((es) => [...es, { kind: "subtext", id: newId, parentId, variant, text }]);
-          }
-          return;
-        }
-        // Collapse-on-finalize (T2.1): the open thinking block folds the
-        // moment the turn's real output starts.
-        const foldThinking = () => {
-          const id = thinkingId.current;
-          if (id === null) return;
-          thinkingId.current = null;
-          setEntries((es) =>
-            es.map((e) => (e.kind === "thinking" && e.id === id ? { ...e, done: true } : e)),
-          );
-        };
-        if (
-          msg.type === "text_delta" ||
-          msg.type === "render" ||
-          msg.type === "picker" ||
-          msg.type === "tool_use" ||
-          msg.type === "artifact" ||
-          msg.type === "turn_end"
-        ) {
-          foldThinking();
-        }
-        switch (msg.type) {
-          case "user_prompt": {
-            // Sending re-arms follow: typing a message says you're back in
-            // the conversation, so jump to the tail even if you'd scrolled up.
-            tail.armFollow();
-            const id = nextId++;
-            openToolBatches.current.push(id);
-            setEntries((es) => [
-              ...es,
-              { kind: "text", id, role: "user", text: msg.text, done: true },
-            ]);
-            break;
-          }
-          case "thinking_delta": {
-            const id = thinkingId.current;
-            if (id !== null) {
-              setEntries((es) =>
-                es.map((e) =>
-                  e.kind === "thinking" && e.id === id ? { ...e, text: e.text + msg.text } : e,
-                ),
-              );
-            } else {
-              const newId = nextId++;
-              thinkingId.current = newId;
-              setEntries((es) => [
-                ...es,
-                { kind: "thinking", id: newId, text: msg.text, done: false, expanded: false },
-              ]);
-            }
-            break;
-          }
-          case "text_delta": {
-            const id = streamingId.current;
-            if (id !== null) {
-              setEntries((es) =>
-                es.map((e) =>
-                  e.kind === "text" && e.id === id ? { ...e, text: e.text + msg.text } : e,
-                ),
-              );
-            } else {
-              const newId = nextId++;
-              streamingId.current = newId;
-              setEntries((es) => [
-                ...es,
-                { kind: "text", id: newId, role: "assistant", text: msg.text, done: false },
-              ]);
-            }
-            break;
-          }
-          case "render": {
-            // Close the streaming text block so any further deltas open a new
-            // one *after* this component — the transcript keeps wire order.
-            streamingId.current = null;
-            const id = nextId++;
-            setEntries((es) => {
-              const i = es.findIndex((e) => e.kind === "render" && e.renderId === msg.id);
-              if (i >= 0) {
-                // Update-in-place: same wire id replaces that component's props.
-                const updated = [...es];
-                updated[i] = { ...(updated[i] as Entry & { kind: "render" }), component: msg.component, props: msg.props };
-                return updated;
-              }
-              return [
-                ...es,
-                { kind: "render", id, renderId: msg.id, component: msg.component, props: msg.props },
-              ];
-            });
-            break;
-          }
-          case "picker": {
-            // Same wire-order rule as `render`: close the streaming block.
-            streamingId.current = null;
-            const id = nextId++;
-            setEntries((es) => [
-              ...es,
-              { kind: "picker", id, pickerId: msg.id, title: msg.title, rows: msg.rows, hint: msg.hint },
-            ]);
-            break;
-          }
-          case "artifact": {
-            // Same wire-order rule as `render`: close the streaming block.
-            streamingId.current = null;
-            const id = nextId++;
-            setEntries((es) => {
-              const i = es.findIndex(
-                (e) => e.kind === "artifact" && e.artifactId === msg.id,
-              );
-              if (i >= 0) {
-                const updated = [...es];
-                updated[i] = {
-                  ...(updated[i] as Entry & { kind: "artifact" }),
-                  html: msg.html,
-                  title: msg.title,
-                };
-                return updated;
-              }
-              return [
-                ...es,
-                { kind: "artifact", id, artifactId: msg.id, html: msg.html, title: msg.title },
-              ];
-            });
-            break;
-          }
-          case "tool_use": {
-            // Close the streaming text block (same reason as `render`):
-            // later deltas must open a new block after this record.
-            streamingId.current = null;
-            // A subagent's own tool call closes ITS open prose runs, so
-            // narration after the call opens a new entry below it (SA.2).
-            if (msg.parentId) {
-              subtextIds.current.delete(`${msg.parentId}|text`);
-              subtextIds.current.delete(`${msg.parentId}|thinking`);
-            }
-            const id = nextId++;
-            const batchId = openToolBatches.current[0] ?? orphanToolBatch.current;
-            setEntries((es) => [
-              ...es,
-              {
-                kind: "tool",
-                id,
-                toolId: msg.id,
-                name: msg.name,
-                detail: msg.detail,
-                input: msg.input,
-                parentId: msg.parentId,
-                batchId,
-                settled: false,
-                startedAt: Date.now(),
-                ...(msg.replay ? { replayed: true } : {}),
-              },
-            ]);
-            break;
-          }
-          case "tool_result": {
-            setEntries((es) =>
-              es.map((e) =>
-                e.kind === "tool" && e.toolId === msg.id
-                  ? { ...e, output: msg.output, truncatedBytes: msg.truncatedBytes, isError: msg.isError }
-                  : e,
-              ),
-            );
-            break;
-          }
-          // `status` frames are Shell's to interpret (the ActivityLine label);
-          // the transcript renders nothing for them.
-          case "turn_end": {
-            const id = streamingId.current;
-            streamingId.current = null;
-            subtextIds.current.clear();
-            const batchId = openToolBatches.current.shift() ?? orphanToolBatch.current--;
-            setEntries((es) =>
-              es.map((e) => {
-                if (e.kind === "text" && e.id === id) return { ...e, done: true };
-                // A tool still pending at turn end was interrupted — settle
-                // its record so the row doesn't pulse forever.
-                if (e.kind === "tool" && e.batchId === batchId) {
-                  return {
-                    ...e,
-                    settled: true,
-                    ...(e.output === undefined
-                      ? { output: "(interrupted — no result)", isError: true }
-                      : {}),
-                  };
-                }
-                return e;
-              }),
-            );
-            break;
-          }
-          case "error": {
-            // Close the streaming text block like every other appended entry —
-            // a delta after the error must open a NEW block below it, keeping
-            // wire order (2026-07-28 fix: it glued onto the block ABOVE the
-            // error). notice/user_prompt omit this deliberately and say so.
-            streamingId.current = null;
-            const id = nextId++;
-            setEntries((es) => [
-              ...es,
-              {
-                kind: "text",
-                id,
-                role: "assistant",
-                text: `**Error:** ${msg.message}`,
-                done: true,
-              },
-            ]);
-            break;
-          }
-          case "notice": {
-            // A dim system line in transcript order. It does NOT fold thinking
-            // or close the streaming text block — a retry/compaction is a status
-            // aside, not the turn's real output starting.
-            const id = nextId++;
-            setEntries((es) => [
-              ...es,
-              { kind: "notice", id, text: msg.text, noticeKind: msg.kind, source: msg.source },
-            ]);
-            break;
-          }
-          case "bang_start": {
-            // Same wire-order rule as `render`: close the streaming block.
-            streamingId.current = null;
-            const id = nextId++;
-            setEntries((es) => [
-              ...es,
-              { kind: "bang", id, bangId: msg.id, command: msg.command, output: "", done: false },
-            ]);
-            break;
-          }
-          case "bang_output": {
-            setEntries((es) =>
-              es.map((e) =>
-                e.kind === "bang" && e.bangId === msg.id
-                  ? { ...e, output: e.output + msg.data }
-                  : e,
-              ),
-            );
-            break;
-          }
-          case "bang_end": {
-            setEntries((es) =>
-              es.map((e) =>
-                e.kind === "bang" && e.bangId === msg.id
-                  ? { ...e, exitCode: msg.exitCode, done: true }
-                  : e,
-              ),
-            );
-            break;
-          }
-          case "zone_reset": {
-            // A (re)attach replays the session's history from scratch.
-            streamingId.current = null;
-            thinkingId.current = null;
-            // Stale open-subtext keys would swallow replayed subagent prose
-            // into entry ids that no longer exist (bughunt 2026-08-14 r2).
-            subtextIds.current.clear();
-            openToolBatches.current = [];
-            orphanToolBatch.current = -1;
-            tail.resetTail(); // a replayed transcript lands at its end
-            setEntries([]);
-            // pinned renderIds survive — the replayed render entries carry
-            // the same wire ids, so pins re-bind to the repainted blocks.
-            break;
-          }
-        }
-      };
-      // Streamed deltas batch into one state pass per animation frame (the
-      // timer stands in where frames pause — a hidden tab). Anything else
-      // applies the pending batch first, so entries keep exact wire order —
-      // and every non-transcript bus listener still hears the raw stream.
-      const queue: QueuedDelta[] = [];
-      let frame: number | null = null;
-      let timer: ReturnType<typeof setTimeout> | null = null;
-      const flush = () => {
-        if (frame !== null) cancelAnimationFrame(frame);
-        if (timer !== null) clearTimeout(timer);
-        frame = null;
-        timer = null;
-        for (const m of queue.splice(0)) apply(m);
-      };
-      const unsubscribe = subscribe((msg) => {
-        if (msg.type === "text_delta" || msg.type === "thinking_delta") {
-          queueDelta(queue, msg);
-          if (frame === null) {
-            frame = requestAnimationFrame(flush);
-            timer = setTimeout(flush, 50);
-          }
-          return;
-        }
-        flush();
-        apply(msg);
-      });
-      return () => {
-        unsubscribe();
-        if (frame !== null) cancelAnimationFrame(frame);
-        if (timer !== null) clearTimeout(timer);
-      };
-    },
-    [subscribe],
+  const [projection] = useState(() => createTranscriptProjection());
+  const [transcript, setTranscript] = useState(
+    () => projection.apply([], Date.now).snapshot,
+  );
+  // Disclosure belongs to the renderer, but the ids survive a thinking row
+  // moving into a completed tool fold just as the old entry field did.
+  const [expandedThinking, setExpandedThinking] = useState<ReadonlySet<number>>(
+    () => new Set(),
   );
 
-  useEffect(tail.followTail, [entries]);
+  useEffect(() => {
+    const ingress = createTranscriptIngress((messages) => {
+      const result = projection.apply(messages, Date.now);
+      for (const intent of result.tailIntents) {
+        if (intent === "arm-follow") {
+          tail.armFollow();
+        } else {
+          tail.resetTail();
+          setExpandedThinking(new Set());
+        }
+      }
+      setTranscript(result.snapshot);
+    });
+    const unsubscribe = subscribe(ingress.accept);
+    return () => {
+      unsubscribe();
+      ingress.dispose();
+    };
+  }, [projection, subscribe]);
+
+  useEffect(tail.followTail, [transcript, expandedThinking]);
 
   const togglePin = useCallback(
     (renderId: string) =>
@@ -714,83 +314,20 @@ export function RenderZone({
 
   const toggleThinking = useCallback(
     (id: number) =>
-      setEntries((es) =>
-        es.map((e) =>
-          e.kind === "thinking" && e.id === id ? { ...e, expanded: !e.expanded } : e,
-        ),
-      ),
+      setExpandedThinking((current) => {
+        const next = new Set(current);
+        if (next.has(id)) next.delete(id);
+        else next.add(id);
+        return next;
+      }),
     [],
   );
 
-  // Dock items reference the same entry objects the transcript holds, so an
+  // Dock items reference the same painting objects the transcript holds, so an
   // update-in-place render/artifact (same wire id) keeps pinned blocks live.
   const pinnedItems = useMemo(
-    () =>
-      pinned.flatMap((id) => {
-        const entry = entries.find(
-          (e) =>
-            (e.kind === "render" && e.renderId === id) ||
-            (e.kind === "artifact" && e.artifactId === id),
-        );
-        return entry && (entry.kind === "render" || entry.kind === "artifact") ? [entry] : [];
-      }),
-    [entries, pinned],
-  );
-
-  // The ACTIVE picker — the one whose arrow-key capture is live: the newest
-  // copy, and only until the user moves on (a later user turn retires it).
-  const activePickerId = useMemo(() => {
-    let active: number | null = null;
-    for (const e of entries) {
-      if (e.kind === "picker") active = e.id;
-      else if (e.kind === "text" && e.role === "user") active = null;
-    }
-    return active;
-  }, [entries]);
-
-  // Everything a subagent deck shows, grouped under its spawn's wire id and
-  // in true stream order: child calls (T2.4/SA.1) interleaved with the
-  // subagent's prose (SA.2). Also the deck's anchor test — narration can
-  // arrive before the first child tool call, and a spawn with only prose is
-  // still a deck. A FAILED child is excluded: it moves to its own expanded
-  // top-level row, and keeping it here too would show the same failure twice
-  // between result and turn_end.
-  const cardItemsByParent = useMemo(() => {
-    const byParent = new Map<string, Array<ToolCall | SubtextEntry>>();
-    for (const e of entries) {
-      if ((e.kind !== "tool" && e.kind !== "subtext") || !e.parentId) continue;
-      if (e.kind === "tool" && e.isError) continue;
-      const arr = byParent.get(e.parentId) ?? [];
-      arr.push(e);
-      byParent.set(e.parentId, arr);
-    }
-    return byParent;
-  }, [entries]);
-
-  const compactedTools = useMemo(
-    () =>
-      groupSettledTools(
-        entries.flatMap((entry): Array<ActivityItem<ToolCall, ThinkingEntry>> =>
-          entry.kind === "tool"
-            ? entry.parentId && !entry.isError
-              ? // A subagent's call lives inside its deck — invisible to the
-                // fold, and OMITTED (not a boundary) so a parent-level run is
-                // not split by child traffic it never displaces (SA.1).
-                []
-              : cardItemsByParent.has(entry.toolId)
-                ? // A subagent deck is a visible block: folding across it
-                  // would move later work ahead of it. Hard boundary.
-                  [null]
-                : [{ kind: "tool" as const, tool: entry }]
-            : entry.kind === "thinking"
-              ? [{ kind: "thinking" as const, thinking: entry }]
-              : entry.kind === "subtext"
-                ? // Inside its deck — invisible to folding, like child calls.
-                  []
-                : [null],
-        ),
-      ),
-    [entries, cardItemsByParent],
+    () => pinned.flatMap((id) => transcript.paintingsById.get(id) ?? []),
+    [pinned, transcript.paintingsById],
   );
 
   const handleTranscriptPointerUp = (event: React.PointerEvent<HTMLDivElement>) => {
@@ -827,7 +364,7 @@ export function RenderZone({
         onTouchMove={tail.onTouchMove}
         onPointerUp={handleTranscriptPointerUp}
       >
-        {entries.length === 0 && !busy && (
+        {!transcript.hasTranscriptContent && !busy && (
           // A fresh session (no transcript yet) shows an inviting welcome
           // instead of raw emptiness. Shell-owned and agent-neutral (#12).
           <div className="zone-empty">
@@ -871,14 +408,12 @@ export function RenderZone({
             </div>
           </div>
         )}
-        {entries.map((entry) => (
+        {transcript.rows.map((entry) => (
           <ZoneEntry
             key={entry.id}
             entry={entry}
             toggleThinking={toggleThinking}
-            cardItemsByParent={cardItemsByParent}
-            compactedTools={compactedTools}
-            activePickerId={activePickerId}
+            expandedThinking={expandedThinking}
             handleAction={handleAction}
             pinned={pinned}
             togglePin={togglePin}
@@ -908,33 +443,31 @@ export function RenderZone({
 
 /** One transcript entry's presentation — the per-kind branches of the
  *  scrollback. File-local on purpose: the renderers lean on RenderZone's
- *  context (pin state, subagent grouping, the mediated action path), and
- *  brand-mark.test.ts reads this file as text. */
+ *  context (pin state and the mediated action path), and brand-mark.test.ts
+ *  reads this file as text. */
 function ZoneEntry({
   entry,
   toggleThinking,
-  cardItemsByParent,
-  compactedTools,
-  activePickerId,
+  expandedThinking,
   handleAction,
   pinned,
   togglePin,
 }: {
-  entry: Entry;
+  entry: OutputZoneRow;
   toggleThinking: (id: number) => void;
-  cardItemsByParent: Map<string, Array<ToolCall | SubtextEntry>>;
-  compactedTools: ReturnType<typeof groupSettledTools<ToolCall, ThinkingEntry>>;
-  activePickerId: number | null;
+  expandedThinking: ReadonlySet<number>;
   handleAction: (action: Action, sourceId: string) => void;
   pinned: string[];
   togglePin: (renderId: string) => void;
 }) {
-  // A subagent's prose lives inside its deck's expansion, never top-level.
-  if (entry.kind === "subtext") return null;
   if (entry.kind === "thinking") {
-    // Narration absorbed into a "worked" fold renders inside that fold.
-    if (compactedTools.hidden.has(entry.id)) return null;
-    return <ThinkingBlock entry={entry} onToggle={toggleThinking} />;
+    return (
+      <ThinkingBlock
+        entry={entry}
+        expanded={expandedThinking.has(entry.id)}
+        onToggle={toggleThinking}
+      />
+    );
   }
   if (entry.kind === "notice") {
     const glyph =
@@ -983,17 +516,19 @@ function ZoneEntry({
       </div>
     );
   }
+  if (entry.kind === "tool-fold") {
+    return (
+      <ToolActivityGroup
+        row={entry}
+        expandedThinking={expandedThinking}
+        onToggleThinking={toggleThinking}
+      />
+    );
+  }
+  if (entry.kind === "subagent-deck") {
+    return <SubagentDeck row={entry} />;
+  }
   if (entry.kind === "tool") {
-    const compacted = compactedTools.anchors.get(entry.id);
-    if (compacted) return <ToolActivityGroup items={compacted} onToggleThinking={toggleThinking} />;
-    if (compactedTools.hidden.has(entry.id)) return null;
-    // Subagent calls are rendered nested inside their deck (below),
-    // not at the top level.
-    if (entry.parentId && !entry.isError) return null;
-    const items = cardItemsByParent.get(entry.toolId);
-    // A spawn with visible children IS the deck — the anchor is the
-    // referenced-as-parentId relationship, never the tool's name (SA.1).
-    if (items && items.length > 0) return <SubagentDeck task={entry} items={items} />;
     return (
       <div className="tool-group">
         <ToolBlock {...toolBlockProps(entry)} />
@@ -1008,7 +543,7 @@ function ZoneEntry({
           title={entry.title}
           rows={entry.rows}
           hint={entry.hint}
-          active={entry.id === activePickerId}
+          active={entry.active}
           onPick={(text) => handleAction({ kind: "prompt", text }, entry.pickerId)}
         />
       </div>

--- a/web/src/delta-queue.test.ts
+++ b/web/src/delta-queue.test.ts
@@ -1,6 +1,12 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { queueDelta, type QueuedDelta } from "./delta-queue";
+import type { ZoneMsg } from "./session-bus";
+import {
+  createTranscriptIngress,
+  queueDelta,
+  type QueuedDelta,
+  type TranscriptIngressRuntime,
+} from "./delta-queue";
 
 test("consecutive same-type deltas merge into one entry whose text is the concatenation", () => {
   const q: QueuedDelta[] = [];
@@ -45,4 +51,94 @@ test("SA.2: a different parentId never merges — parallel subagents keep their 
     { type: "text_delta", text: "B1", parentId: "b" },
     { type: "thinking_delta", text: "B-think", parentId: "b" },
   ]);
+});
+
+class ManualIngressRuntime implements TranscriptIngressRuntime {
+  frame: (() => void) | undefined;
+  fallback: (() => void) | undefined;
+  fallbackDelay: number | undefined;
+
+  scheduleFrame(run: () => void): () => void {
+    this.frame = run;
+    return () => {
+      if (this.frame === run) this.frame = undefined;
+    };
+  }
+
+  scheduleAfter(delayMs: number, run: () => void): () => void {
+    this.fallbackDelay = delayMs;
+    this.fallback = run;
+    return () => {
+      if (this.fallback === run) this.fallback = undefined;
+    };
+  }
+
+  runFrame(): void {
+    this.frame?.();
+  }
+
+  runFallback(): void {
+    this.fallback?.();
+  }
+}
+
+test("the first frame publishes one coalesced delta batch and cancels the fallback", () => {
+  const runtime = new ManualIngressRuntime();
+  const batches: Array<readonly ZoneMsg[]> = [];
+  const ingress = createTranscriptIngress((batch) => batches.push(batch), runtime);
+
+  ingress.accept({ type: "text_delta", text: "hel" });
+  ingress.accept({ type: "text_delta", text: "lo" });
+  assert.equal(batches.length, 0);
+  assert.equal(runtime.fallbackDelay, 50);
+
+  runtime.runFrame();
+  assert.deepEqual(batches, [[{ type: "text_delta", text: "hello" }]]);
+  assert.equal(runtime.frame, undefined);
+  assert.equal(runtime.fallback, undefined);
+});
+
+test("the 50 ms fallback publishes when no animation frame arrives", () => {
+  const runtime = new ManualIngressRuntime();
+  const batches: Array<readonly ZoneMsg[]> = [];
+  const ingress = createTranscriptIngress((batch) => batches.push(batch), runtime);
+
+  ingress.accept({ type: "thinking_delta", text: "wait" });
+  runtime.runFallback();
+  assert.deepEqual(batches, [[{ type: "thinking_delta", text: "wait" }]]);
+  assert.equal(runtime.frame, undefined);
+  assert.equal(runtime.fallback, undefined);
+});
+
+test("every non-delta follows pending deltas in one ordered batch, even when transcript-inert", () => {
+  const runtime = new ManualIngressRuntime();
+  const batches: Array<readonly ZoneMsg[]> = [];
+  const ingress = createTranscriptIngress((batch) => batches.push(batch), runtime);
+
+  ingress.accept({ type: "text_delta", text: "before" });
+  ingress.accept({ type: "status", state: "thinking" });
+  assert.deepEqual(batches, [
+    [
+      { type: "text_delta", text: "before" },
+      { type: "status", state: "thinking" },
+    ],
+  ]);
+  assert.equal(runtime.frame, undefined);
+  assert.equal(runtime.fallback, undefined);
+});
+
+test("dispose cancels scheduled work, drops queued deltas, and ignores later messages", () => {
+  const runtime = new ManualIngressRuntime();
+  const batches: Array<readonly ZoneMsg[]> = [];
+  const ingress = createTranscriptIngress((batch) => batches.push(batch), runtime);
+
+  ingress.accept({ type: "text_delta", text: "discard" });
+  ingress.dispose();
+  runtime.runFrame();
+  runtime.runFallback();
+  ingress.accept({ type: "user_prompt", text: "also discarded" });
+
+  assert.deepEqual(batches, []);
+  assert.equal(runtime.frame, undefined);
+  assert.equal(runtime.fallback, undefined);
 });

--- a/web/src/delta-queue.ts
+++ b/web/src/delta-queue.ts
@@ -1,4 +1,5 @@
 import type { WireMsg } from "@protocol";
+import type { ZoneMsg } from "./session-bus";
 
 /** A streamed delta waiting in the output zone's per-frame batch. */
 export type QueuedDelta = Extract<WireMsg, { type: "text_delta" | "thinking_delta" }>;
@@ -22,4 +23,73 @@ export function queueDelta(queue: QueuedDelta[], msg: QueuedDelta): void {
       ...(msg.parentId !== undefined ? { parentId: msg.parentId } : {}),
     });
   }
+}
+
+export type TranscriptIngressRuntime = {
+  scheduleFrame(run: () => void): () => void;
+  scheduleAfter(delayMs: number, run: () => void): () => void;
+};
+
+export const browserTranscriptIngressRuntime: TranscriptIngressRuntime = {
+  scheduleFrame(run) {
+    const id = requestAnimationFrame(run);
+    return () => cancelAnimationFrame(id);
+  },
+  scheduleAfter(delayMs, run) {
+    const id = setTimeout(run, delayMs);
+    return () => clearTimeout(id);
+  },
+};
+
+/**
+ * The browser-facing edge of the transcript projection. Deltas wait for the
+ * first animation frame or the 50 ms hidden-tab fallback; any non-delta drains
+ * that queue and follows it in the same ordered batch. The projection itself
+ * therefore knows nothing about subscriptions, timers, frames, or disposal.
+ */
+export function createTranscriptIngress(
+  deliver: (messages: readonly ZoneMsg[]) => void,
+  runtime: TranscriptIngressRuntime = browserTranscriptIngressRuntime,
+): { accept(message: ZoneMsg): void; dispose(): void } {
+  const queue: QueuedDelta[] = [];
+  let cancelFrame: (() => void) | null = null;
+  let cancelFallback: (() => void) | null = null;
+  let disposed = false;
+
+  const cancelScheduledFlush = () => {
+    cancelFrame?.();
+    cancelFallback?.();
+    cancelFrame = null;
+    cancelFallback = null;
+  };
+
+  const flush = () => {
+    cancelScheduledFlush();
+    if (queue.length) deliver(queue.splice(0));
+  };
+
+  const accept = (message: ZoneMsg) => {
+    if (disposed) return;
+    if (message.type === "text_delta" || message.type === "thinking_delta") {
+      queueDelta(queue, message);
+      if (cancelFrame === null) {
+        cancelFrame = runtime.scheduleFrame(flush);
+        cancelFallback = runtime.scheduleAfter(50, flush);
+      }
+      return;
+    }
+
+    cancelScheduledFlush();
+    deliver([...queue.splice(0), message]);
+  };
+
+  return {
+    accept,
+    dispose() {
+      if (disposed) return;
+      disposed = true;
+      cancelScheduledFlush();
+      queue.splice(0);
+    },
+  };
 }

--- a/web/src/transcript-projection.test.ts
+++ b/web/src/transcript-projection.test.ts
@@ -1,0 +1,380 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { ZoneMsg } from "./session-bus";
+import {
+  createTranscriptProjection,
+  type OutputZoneRow,
+  type TranscriptProjection,
+  type TranscriptSnapshot,
+} from "./transcript-projection";
+
+const NOW = 1_000_000;
+
+function apply(
+  projection: TranscriptProjection,
+  ...messages: ZoneMsg[]
+): TranscriptSnapshot {
+  return projection.apply(messages, () => NOW).snapshot;
+}
+
+const rowKinds = (snapshot: TranscriptSnapshot) => snapshot.rows.map((row) => row.kind);
+const rowsOf = <K extends OutputZoneRow["kind"]>(snapshot: TranscriptSnapshot, kind: K) =>
+  snapshot.rows.filter(
+    (row): row is Extract<OutputZoneRow, { kind: K }> => row.kind === kind,
+  );
+
+test("ignored shell messages are inert; prompt and reset return ordered tail intents", () => {
+  const projection = createTranscriptProjection();
+  const initial = apply(projection);
+  const ignored = projection.apply([{ type: "status", state: "thinking" }], () => NOW);
+  assert.strictEqual(ignored.snapshot, initial);
+  assert.deepEqual(ignored.tailIntents, []);
+
+  const changed = projection.apply([{ type: "user_prompt", text: "hello" }], () => NOW);
+  assert.deepEqual(changed.tailIntents, ["arm-follow"]);
+  assert.deepEqual(rowKinds(changed.snapshot), ["text"]);
+
+  const reset = projection.apply([{ type: "zone_reset" }], () => NOW);
+  assert.deepEqual(reset.tailIntents, ["reset-tail"]);
+  assert.deepEqual(reset.snapshot.rows, []);
+
+  const ordered = projection.apply(
+    [
+      { type: "user_prompt", text: "again" },
+      { type: "zone_reset" },
+    ],
+    () => NOW,
+  );
+  assert.deepEqual(ordered.tailIntents, ["arm-follow", "reset-tail"]);
+  assert.deepEqual(ordered.snapshot.rows, []);
+});
+
+test("root text, thinking, and text preserve the existing open-stream behavior", () => {
+  const projection = createTranscriptProjection();
+  const snapshot = apply(
+    projection,
+    { type: "text_delta", text: "A" },
+    { type: "thinking_delta", text: "B" },
+    { type: "text_delta", text: "C" },
+  );
+  assert.deepEqual(rowKinds(snapshot), ["text", "thinking"]);
+  assert.deepEqual(rowsOf(snapshot, "text").map(({ text, done }) => ({ text, done })), [
+    { text: "AC", done: false },
+  ]);
+  assert.deepEqual(rowsOf(snapshot, "thinking").map(({ text, done }) => ({ text, done })), [
+    { text: "B", done: true },
+  ]);
+
+  const ended = apply(projection, { type: "turn_end" });
+  assert.equal(rowsOf(ended, "text")[0]?.done, true);
+});
+
+test("a user prompt arriving mid-stream does not detach the assistant reply tail", () => {
+  const projection = createTranscriptProjection();
+  const result = projection.apply(
+    [
+      { type: "text_delta", text: "A" },
+      { type: "user_prompt", text: "queued" },
+      { type: "text_delta", text: "B" },
+    ],
+    () => NOW,
+  );
+  assert.deepEqual(result.tailIntents, ["arm-follow"]);
+  assert.deepEqual(rowsOf(result.snapshot, "text").map((row) => [row.role, row.text]), [
+    ["assistant", "AB"],
+    ["user", "queued"],
+  ]);
+});
+
+test("notice leaves streams open; error closes text without folding thinking", () => {
+  const projection = createTranscriptProjection();
+  const noticed = apply(
+    projection,
+    { type: "text_delta", text: "A" },
+    { type: "thinking_delta", text: "B" },
+    { type: "notice", text: "retrying", kind: "retry" },
+    { type: "text_delta", text: "C" },
+  );
+  assert.deepEqual(rowKinds(noticed), ["text", "thinking", "notice"]);
+  assert.equal(rowsOf(noticed, "text")[0]?.text, "AC");
+  assert.equal(rowsOf(noticed, "thinking")[0]?.done, true);
+
+  const errors = createTranscriptProjection();
+  const atError = apply(
+    errors,
+    { type: "text_delta", text: "before" },
+    { type: "thinking_delta", text: "still open" },
+    { type: "error", message: "boom" },
+  );
+  assert.equal(rowsOf(atError, "thinking")[0]?.done, false);
+
+  const errored = apply(errors, { type: "text_delta", text: "after" });
+  assert.deepEqual(rowsOf(errored, "text").map((row) => row.text), [
+    "before",
+    "**Error:** boom",
+    "after",
+  ]);
+  assert.equal(rowsOf(errored, "thinking")[0]?.done, true);
+});
+
+test("parented prose keeps independent variant runs and true ledger chronology", () => {
+  const projection = createTranscriptProjection();
+  const hidden = apply(
+    projection,
+    { type: "text_delta", text: "A", parentId: "spawn" },
+    { type: "thinking_delta", text: "B", parentId: "spawn" },
+    { type: "text_delta", text: "C", parentId: "spawn" },
+  );
+  assert.equal(hidden.hasTranscriptContent, true);
+  assert.deepEqual(hidden.rows, []);
+
+  const snapshot = apply(
+    projection,
+    { type: "tool_use", id: "spawn", name: "Task", input: { description: "trace" } },
+  );
+  const deck = rowsOf(snapshot, "subagent-deck")[0];
+  assert.ok(deck);
+  assert.deepEqual(
+    deck.items.map((item) => ({ kind: item.kind, text: item.kind === "subtext" ? item.text : undefined })),
+    [
+      { kind: "subtext", text: "AC" },
+      { kind: "subtext", text: "B" },
+    ],
+  );
+});
+
+test("render and artifact updates retain position and key while preserving unrelated identities", () => {
+  const projection = createTranscriptProjection();
+  const before = apply(
+    projection,
+    { type: "text_delta", text: "intro" },
+    { type: "render", id: "painting", component: "Meter", props: { value: 1 } },
+    { type: "artifact", id: "artifact", html: "<p>one</p>", title: "A" },
+  );
+  const textBefore = rowsOf(before, "text")[0]!;
+  const renderBefore = rowsOf(before, "render")[0]!;
+  const artifactBefore = rowsOf(before, "artifact")[0]!;
+  assert.strictEqual(before.paintingsById.get("painting"), renderBefore);
+  assert.strictEqual(before.paintingsById.get("artifact"), artifactBefore);
+
+  const after = apply(
+    projection,
+    { type: "render", id: "painting", component: "Meter", props: { value: 2 } },
+  );
+  const renderAfter = rowsOf(after, "render")[0]!;
+  assert.equal(renderAfter.id, renderBefore.id);
+  assert.notStrictEqual(renderAfter, renderBefore);
+  assert.strictEqual(rowsOf(after, "text")[0], textBefore);
+  assert.strictEqual(rowsOf(after, "artifact")[0], artifactBefore);
+  assert.strictEqual(after.paintingsById.get("painting"), renderAfter);
+  assert.deepEqual(rowKinds(after), ["text", "render", "artifact"]);
+
+  const collisions = createTranscriptProjection();
+  const collision = apply(
+    collisions,
+    { type: "render", id: "shared", component: "Meter", props: { value: 1 } },
+    { type: "artifact", id: "shared", html: "<p>later</p>" },
+  );
+  assert.equal(collision.paintingsById.get("shared")?.kind, "render");
+});
+
+test("only the newest picker is active until the next user prompt", () => {
+  const projection = createTranscriptProjection();
+  const first = apply(projection, {
+    type: "picker",
+    id: "one",
+    title: "One",
+    rows: [{ label: "a", text: "a" }],
+  });
+  assert.equal(rowsOf(first, "picker")[0]?.active, true);
+
+  const second = apply(projection, {
+    type: "picker",
+    id: "two",
+    title: "Two",
+    rows: [{ label: "b", text: "b" }],
+  });
+  assert.deepEqual(rowsOf(second, "picker").map((row) => row.active), [false, true]);
+
+  const retired = apply(projection, { type: "user_prompt", text: "continue" });
+  assert.deepEqual(rowsOf(retired, "picker").map((row) => row.active), [false, false]);
+});
+
+test("settled successful tools become a render-ready fold without reordering", () => {
+  const projection = createTranscriptProjection();
+  const snapshot = apply(
+    projection,
+    { type: "user_prompt", text: "work" },
+    { type: "tool_use", id: "read", name: "Read", detail: "a.ts" },
+    { type: "tool_result", id: "read", output: "a" },
+    { type: "thinking_delta", text: "next" },
+    { type: "tool_use", id: "grep", name: "Grep", detail: "needle" },
+    { type: "tool_result", id: "grep", output: "b" },
+    { type: "turn_end" },
+  );
+  assert.deepEqual(rowKinds(snapshot), ["text", "tool-fold"]);
+  const fold = rowsOf(snapshot, "tool-fold")[0]!;
+  assert.equal(fold.actionCount, 2);
+  assert.equal(fold.summary, "Read · Grep");
+  assert.deepEqual(
+    fold.items.map((item) =>
+      item.kind === "tool" ? `tool:${item.tool.toolId}` : `thinking:${item.thinking.text}`,
+    ),
+    ["tool:read", "thinking:next", "tool:grep"],
+  );
+});
+
+test("failed and interrupted tools stay visible and never enter a fold", () => {
+  const projection = createTranscriptProjection();
+  const failed = apply(
+    projection,
+    { type: "user_prompt", text: "work" },
+    { type: "tool_use", id: "bad", name: "Write" },
+    { type: "tool_result", id: "bad", output: "denied", isError: true },
+    { type: "tool_use", id: "lost", name: "Read" },
+    { type: "turn_end" },
+  );
+  assert.deepEqual(rowKinds(failed), ["text", "tool", "tool"]);
+  assert.equal("batchId" in rowsOf(failed, "tool")[0]!, false);
+  assert.equal("settled" in rowsOf(failed, "tool")[0]!, false);
+  assert.equal(rowsOf(failed, "tool")[0]?.isError, true);
+  assert.deepEqual(
+    rowsOf(failed, "tool").map(({ output, isError }) => ({ output, isError })),
+    [
+      { output: "denied", isError: true },
+      { output: "(interrupted — no result)", isError: true },
+    ],
+  );
+});
+
+test("tool start time is read at each tool message and private settlement fields stay behind the seam", () => {
+  const projection = createTranscriptProjection();
+  const times = [100, 200];
+  const snapshot = projection.apply(
+    [
+      { type: "tool_use", id: "one", name: "Read" },
+      { type: "tool_use", id: "two", name: "Grep" },
+    ],
+    () => times.shift()!,
+  ).snapshot;
+  const tools = rowsOf(snapshot, "tool");
+  assert.deepEqual(tools.map((tool) => tool.startedAt), [100, 200]);
+  for (const tool of tools) {
+    assert.equal("batchId" in tool, false);
+    assert.equal("settled" in tool, false);
+  }
+});
+
+test("queued prompts assign later tools to the oldest still-open turn", () => {
+  const projection = createTranscriptProjection();
+  apply(
+    projection,
+    { type: "user_prompt", text: "first" },
+    { type: "user_prompt", text: "second" },
+    { type: "tool_use", id: "first-tool", name: "Read" },
+    { type: "tool_result", id: "first-tool", output: "one" },
+    { type: "turn_end" },
+  );
+  const beforeSecondEnd = apply(
+    projection,
+    { type: "tool_use", id: "second-tool", name: "Grep" },
+    { type: "tool_result", id: "second-tool", output: "two" },
+  );
+  assert.deepEqual(rowKinds(beforeSecondEnd), ["text", "text", "tool", "tool"]);
+
+  const afterSecondEnd = apply(projection, { type: "turn_end" });
+  assert.deepEqual(rowKinds(afterSecondEnd), ["text", "text", "tool", "tool"]);
+  assert.equal(rowsOf(afterSecondEnd, "tool")[1]?.output, "two");
+});
+
+test("a subagent deck owns successful child activity; failed children remain top-level", () => {
+  const projection = createTranscriptProjection();
+  const snapshot = apply(
+    projection,
+    { type: "user_prompt", text: "delegate" },
+    {
+      type: "tool_use",
+      id: "spawn",
+      name: "Agent",
+      input: { description: "trace", subagent_type: "Explore" },
+    },
+    { type: "text_delta", text: "before", parentId: "spawn" },
+    { type: "tool_use", id: "child-ok", name: "Read", parentId: "spawn" },
+    { type: "tool_result", id: "child-ok", output: "ok", parentId: "spawn" },
+    { type: "thinking_delta", text: "after", parentId: "spawn" },
+    { type: "tool_use", id: "child-bad", name: "Write", parentId: "spawn" },
+    {
+      type: "tool_result",
+      id: "child-bad",
+      output: "failed",
+      isError: true,
+      parentId: "spawn",
+    },
+    { type: "tool_result", id: "spawn", output: "done" },
+    { type: "turn_end" },
+  );
+  assert.deepEqual(rowKinds(snapshot), ["text", "subagent-deck", "tool"]);
+  const deck = rowsOf(snapshot, "subagent-deck")[0]!;
+  assert.equal(deck.summary.agentType, "Explore");
+  assert.equal(deck.summary.description, "trace");
+  assert.equal(deck.summary.state, "done");
+  assert.deepEqual(
+    deck.items.map((item) => (item.kind === "tool" ? item.toolId : `${item.variant}:${item.text}`)),
+    ["text:before", "child-ok", "thinking:after"],
+  );
+  assert.equal(rowsOf(snapshot, "tool")[0]?.toolId, "child-bad");
+});
+
+test("zone reset clears every hidden parent-prose cursor before replay", () => {
+  const projection = createTranscriptProjection();
+  apply(projection, { type: "text_delta", text: "stale", parentId: "spawn" });
+  apply(projection, { type: "zone_reset" });
+  const replayed = apply(
+    projection,
+    { type: "text_delta", text: "replayed", parentId: "spawn" },
+    { type: "tool_use", id: "spawn", name: "Task", replay: true },
+  );
+  const deck = rowsOf(replayed, "subagent-deck")[0]!;
+  assert.equal(deck.items[0]?.kind, "subtext");
+  assert.equal((deck.items[0] as { text: string }).text, "replayed");
+  assert.equal(deck.task.replayed, true);
+});
+
+test("bang start, output, and end update one stable row", () => {
+  const projection = createTranscriptProjection();
+  const started = apply(projection, { type: "bang_start", id: "b", command: "pwd" });
+  const startRow = rowsOf(started, "bang")[0]!;
+  const ended = apply(
+    projection,
+    { type: "bang_output", id: "b", data: "/tmp" },
+    { type: "bang_end", id: "b", exitCode: 0 },
+  );
+  const endRow = rowsOf(ended, "bang")[0]!;
+  assert.equal(endRow.id, startRow.id);
+  assert.deepEqual(
+    { output: endRow.output, done: endRow.done, exitCode: endRow.exitCode },
+    { output: "/tmp", done: true, exitCode: 0 },
+  );
+});
+
+test("unchanged rows retain identity; unmatched updates still publish like the existing state map", () => {
+  const projection = createTranscriptProjection();
+  const before = apply(
+    projection,
+    { type: "text_delta", text: "first" },
+    { type: "render", id: "painting", component: "Meter", props: { value: 1 } },
+  );
+  const firstText = rowsOf(before, "text")[0]!;
+  const painting = rowsOf(before, "render")[0]!;
+
+  const after = apply(projection, { type: "text_delta", text: "second" });
+  assert.strictEqual(rowsOf(after, "text")[0], firstText);
+  assert.strictEqual(rowsOf(after, "render")[0], painting);
+
+  const unmatched = apply(projection, { type: "tool_result", id: "missing", output: "x" });
+  assert.notStrictEqual(unmatched, after);
+  assert.equal(unmatched.revision, after.revision + 1);
+  assert.strictEqual(unmatched.rows, after.rows);
+  assert.strictEqual(unmatched.paintingsById, after.paintingsById);
+});

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -1,0 +1,734 @@
+import type { ZoneMsg } from "./session-bus";
+import { subagentSummary, type SubagentSummary } from "./subagent-deck";
+import {
+  groupSettledTools,
+  type ActivityItem,
+  type FoldedActivity,
+} from "./tool-visibility";
+
+/**
+ * Stateful wire-to-view projection for the output zone. It owns transcript
+ * chronology and grouping, while React owns disclosure and the browser edge
+ * owns subscription/timing. Callers receive rows that are ready to render.
+ */
+
+export type TextRow = {
+  kind: "text";
+  id: number;
+  role: "user" | "assistant";
+  text: string;
+  done: boolean;
+};
+
+export type RenderRow = {
+  kind: "render";
+  id: number;
+  renderId: string;
+  component: string;
+  props: Record<string, unknown>;
+};
+
+export type ArtifactRow = {
+  kind: "artifact";
+  id: number;
+  artifactId: string;
+  html: string;
+  title?: string;
+};
+
+export type PaintingRow = RenderRow | ArtifactRow;
+
+export type ToolRow = {
+  kind: "tool";
+  id: number;
+  toolId: string;
+  name: string;
+  detail?: string;
+  input?: Record<string, unknown>;
+  output?: string;
+  truncatedBytes?: number;
+  parentId?: string;
+  isError?: boolean;
+  startedAt: number;
+  replayed?: boolean;
+};
+
+export type SubagentProseRow = {
+  kind: "subtext";
+  id: number;
+  parentId: string;
+  variant: "text" | "thinking";
+  text: string;
+};
+
+export type ThinkingRow = {
+  kind: "thinking";
+  id: number;
+  text: string;
+  done: boolean;
+};
+
+export type NoticeRow = {
+  kind: "notice";
+  id: number;
+  text: string;
+  noticeKind?: string;
+  source?: string;
+};
+
+export type BangRow = {
+  kind: "bang";
+  id: number;
+  bangId: string;
+  command: string;
+  output: string;
+  exitCode?: number | null;
+  done: boolean;
+};
+
+export type PickerTranscriptRow = {
+  kind: "picker";
+  id: number;
+  pickerId: string;
+  title: string;
+  rows: { label: string; detail?: string; current?: boolean; text: string }[];
+  hint?: string;
+  active: boolean;
+};
+
+export type ToolFoldItem = FoldedActivity<ToolRow, ThinkingRow>;
+
+export type ToolFoldRow = {
+  kind: "tool-fold";
+  id: number;
+  items: ToolFoldItem[];
+  actionCount: number;
+  summary: string;
+};
+
+export type SubagentDeckRow = {
+  kind: "subagent-deck";
+  id: number;
+  task: ToolRow;
+  items: Array<ToolRow | SubagentProseRow>;
+  summary: SubagentSummary;
+};
+
+export type OutputZoneRow =
+  | TextRow
+  | RenderRow
+  | ArtifactRow
+  | ToolRow
+  | ThinkingRow
+  | NoticeRow
+  | BangRow
+  | PickerTranscriptRow
+  | ToolFoldRow
+  | SubagentDeckRow;
+
+export type TranscriptSnapshot = {
+  revision: number;
+  /** Includes nested prose waiting for its deck anchor, not only visible rows. */
+  hasTranscriptContent: boolean;
+  rows: readonly OutputZoneRow[];
+  /** The values are the exact painting objects present in `rows`. */
+  paintingsById: ReadonlyMap<string, PaintingRow>;
+};
+
+export type TranscriptTailIntent = "arm-follow" | "reset-tail";
+
+export type TranscriptProjectionResult = {
+  snapshot: TranscriptSnapshot;
+  tailIntents: readonly TranscriptTailIntent[];
+};
+
+export interface TranscriptProjection {
+  apply(messages: readonly ZoneMsg[], readNow: () => number): TranscriptProjectionResult;
+}
+
+type ToolEntry = ToolRow & {
+  batchId: number;
+  settled: boolean;
+};
+
+type PickerEntry = Omit<PickerTranscriptRow, "active">;
+
+type TranscriptEntry =
+  | TextRow
+  | RenderRow
+  | ArtifactRow
+  | ToolEntry
+  | SubagentProseRow
+  | ThinkingRow
+  | NoticeRow
+  | BangRow
+  | PickerEntry;
+
+let nextTranscriptId = 0;
+const toolRowCache = new WeakMap<ToolEntry, ToolRow>();
+
+function visibleToolRow(entry: ToolEntry): ToolRow {
+  const cached = toolRowCache.get(entry);
+  if (cached) return cached;
+  const { batchId, settled, ...row } = entry;
+  void batchId;
+  void settled;
+  toolRowCache.set(entry, row);
+  return row;
+}
+
+const sameReferences = <T>(left: readonly T[], right: readonly T[]): boolean =>
+  left.length === right.length && left.every((item, index) => item === right[index]);
+
+const sameFoldItems = (
+  left: readonly ToolFoldItem[],
+  right: readonly ToolFoldItem[],
+): boolean =>
+  left.length === right.length &&
+  left.every((item, index) => {
+    const other = right[index];
+    if (!other || item.kind !== other.kind) return false;
+    return item.kind === "tool"
+      ? item.tool === (other as Extract<ToolFoldItem, { kind: "tool" }>).tool
+      : item.thinking ===
+          (other as Extract<ToolFoldItem, { kind: "thinking" }>).thinking;
+  });
+
+const sameDeckItems = (
+  left: readonly (ToolRow | SubagentProseRow)[],
+  right: readonly (ToolRow | SubagentProseRow)[],
+): boolean => sameReferences(left, right);
+
+function toolFoldRow(
+  id: number,
+  items: ToolFoldItem[],
+  previous: OutputZoneRow | undefined,
+): ToolFoldRow {
+  if (previous?.kind === "tool-fold" && sameFoldItems(previous.items, items)) {
+    return previous;
+  }
+  const calls = items.flatMap((item) => (item.kind === "tool" ? [item.tool] : []));
+  const counts = new Map<string, number>();
+  for (const call of calls) counts.set(call.name, (counts.get(call.name) ?? 0) + 1);
+  const summary = [...counts]
+    .slice(0, 3)
+    .map(([name, count]) => `${name}${count > 1 ? ` ×${count}` : ""}`)
+    .join(" · ");
+  return { kind: "tool-fold", id, items, actionCount: calls.length, summary };
+}
+
+function subagentDeckRow(
+  task: ToolEntry,
+  items: Array<ToolEntry | SubagentProseRow>,
+  previous: OutputZoneRow | undefined,
+): SubagentDeckRow {
+  const taskRow = visibleToolRow(task);
+  const visibleItems = items.map((item) =>
+    item.kind === "tool" ? visibleToolRow(item) : item,
+  );
+  if (
+    previous?.kind === "subagent-deck" &&
+    previous.task === taskRow &&
+    sameDeckItems(previous.items, visibleItems)
+  ) {
+    return previous;
+  }
+  const calls = items.filter((item): item is ToolEntry => item.kind === "tool");
+  return {
+    kind: "subagent-deck",
+    id: task.id,
+    task: taskRow,
+    items: visibleItems,
+    summary: subagentSummary(task, calls),
+  };
+}
+
+function pickerRow(
+  entry: PickerEntry,
+  active: boolean,
+  previous: OutputZoneRow | undefined,
+): PickerTranscriptRow {
+  if (
+    previous?.kind === "picker" &&
+    previous.pickerId === entry.pickerId &&
+    previous.title === entry.title &&
+    previous.rows === entry.rows &&
+    previous.hint === entry.hint &&
+    previous.active === active
+  ) {
+    return previous;
+  }
+  return { ...entry, active };
+}
+
+function buildSnapshot(
+  entries: readonly TranscriptEntry[],
+  previous: TranscriptSnapshot,
+): TranscriptSnapshot {
+  const previousById = new Map(previous.rows.map((row) => [row.id, row]));
+  const cardItemsByParent = new Map<string, Array<ToolEntry | SubagentProseRow>>();
+  for (const entry of entries) {
+    if ((entry.kind !== "tool" && entry.kind !== "subtext") || !entry.parentId) continue;
+    if (entry.kind === "tool" && entry.isError) continue;
+    const items = cardItemsByParent.get(entry.parentId) ?? [];
+    items.push(entry);
+    cardItemsByParent.set(entry.parentId, items);
+  }
+
+  const compactedTools = groupSettledTools(
+    entries.flatMap((entry): Array<ActivityItem<ToolEntry, ThinkingRow>> =>
+      entry.kind === "tool"
+        ? entry.parentId && !entry.isError
+          ? []
+          : cardItemsByParent.has(entry.toolId)
+            ? [null]
+            : [{ kind: "tool", tool: entry }]
+        : entry.kind === "thinking"
+          ? [{ kind: "thinking", thinking: entry }]
+          : entry.kind === "subtext"
+            ? []
+            : [null],
+    ),
+  );
+
+  let activePickerId: number | null = null;
+  for (const entry of entries) {
+    if (entry.kind === "picker") activePickerId = entry.id;
+    else if (entry.kind === "text" && entry.role === "user") activePickerId = null;
+  }
+
+  const rows: OutputZoneRow[] = [];
+  for (const entry of entries) {
+    if (entry.kind === "subtext") continue;
+    if (entry.kind === "thinking") {
+      if (!compactedTools.hidden.has(entry.id)) rows.push(entry);
+      continue;
+    }
+    if (entry.kind === "tool") {
+      const compacted = compactedTools.anchors.get(entry.id);
+      if (compacted) {
+        const visibleItems: ToolFoldItem[] = compacted.map((item) =>
+          item.kind === "tool"
+            ? { kind: "tool", tool: visibleToolRow(item.tool) }
+            : item,
+        );
+        rows.push(
+          toolFoldRow(
+            entry.id,
+            visibleItems,
+            previousById.get(entry.id),
+          ),
+        );
+        continue;
+      }
+      if (compactedTools.hidden.has(entry.id)) continue;
+      if (entry.parentId && !entry.isError) continue;
+      const items = cardItemsByParent.get(entry.toolId);
+      if (items?.length) {
+        rows.push(subagentDeckRow(entry, items, previousById.get(entry.id)));
+      } else {
+        rows.push(visibleToolRow(entry));
+      }
+      continue;
+    }
+    if (entry.kind === "picker") {
+      rows.push(pickerRow(entry, entry.id === activePickerId, previousById.get(entry.id)));
+      continue;
+    }
+    rows.push(entry);
+  }
+
+  const stableRows = sameReferences(previous.rows, rows) ? previous.rows : rows;
+  const paintingsById = new Map<string, PaintingRow>();
+  for (const row of stableRows) {
+    const paintingId =
+      row.kind === "render"
+        ? row.renderId
+        : row.kind === "artifact"
+          ? row.artifactId
+          : undefined;
+    // The old dock lookup used Array.find(), so a cross-kind wire-id collision
+    // binds to the first painting in transcript order.
+    if (paintingId !== undefined && !paintingsById.has(paintingId)) {
+      paintingsById.set(paintingId, row as PaintingRow);
+    }
+  }
+  const samePaintings =
+    paintingsById.size === previous.paintingsById.size &&
+    [...paintingsById].every(([id, painting]) => previous.paintingsById.get(id) === painting);
+
+  return {
+    revision: previous.revision + 1,
+    hasTranscriptContent: entries.length > 0,
+    rows: stableRows,
+    paintingsById: samePaintings ? previous.paintingsById : paintingsById,
+  };
+}
+
+export function createTranscriptProjection(): TranscriptProjection {
+  let entries: TranscriptEntry[] = [];
+  let streamingId: number | null = null;
+  let thinkingId: number | null = null;
+  const subtextIds = new Map<string, number>();
+  let openToolBatches: number[] = [];
+  let orphanToolBatch = -1;
+  let snapshot: TranscriptSnapshot = {
+    revision: 0,
+    hasTranscriptContent: false,
+    rows: [],
+    paintingsById: new Map(),
+  };
+
+  const foldThinking = (): boolean => {
+    const id = thinkingId;
+    if (id === null) return false;
+    thinkingId = null;
+    entries = entries.map((entry) =>
+      entry.kind === "thinking" && entry.id === id ? { ...entry, done: true } : entry,
+    );
+    return true;
+  };
+
+  const applyMessage = (
+    msg: ZoneMsg,
+    readNow: () => number,
+    tailIntents: TranscriptTailIntent[],
+  ): boolean => {
+    // Child prose routes before the root-stream boundary logic: a subagent
+    // must not close or fold its parent's currently streaming output.
+    if ((msg.type === "text_delta" || msg.type === "thinking_delta") && msg.parentId) {
+      const variant = msg.type === "text_delta" ? "text" : "thinking";
+      const key = `${msg.parentId}|${variant}`;
+      const openId = subtextIds.get(key);
+      if (openId !== undefined) {
+        entries = entries.map((entry) =>
+          entry.kind === "subtext" && entry.id === openId
+            ? { ...entry, text: entry.text + msg.text }
+            : entry,
+        );
+      } else {
+        const id = nextTranscriptId++;
+        subtextIds.set(key, id);
+        entries = [
+          ...entries,
+          {
+            kind: "subtext",
+            id,
+            parentId: msg.parentId,
+            variant,
+            text: msg.text,
+          },
+        ];
+      }
+      return true;
+    }
+
+    let changed = false;
+    // Thinking folds only when the turn's real output begins. Notices, errors,
+    // bang commands, and shell-only frames deliberately do not trigger it.
+    if (
+      msg.type === "text_delta" ||
+      msg.type === "render" ||
+      msg.type === "picker" ||
+      msg.type === "tool_use" ||
+      msg.type === "artifact" ||
+      msg.type === "turn_end"
+    ) {
+      changed = foldThinking();
+    }
+
+    switch (msg.type) {
+      case "user_prompt": {
+        tailIntents.push("arm-follow");
+        const id = nextTranscriptId++;
+        openToolBatches.push(id);
+        entries = [...entries, { kind: "text", id, role: "user", text: msg.text, done: true }];
+        return true;
+      }
+      case "thinking_delta": {
+        if (thinkingId !== null) {
+          const id = thinkingId;
+          entries = entries.map((entry) =>
+            entry.kind === "thinking" && entry.id === id
+              ? { ...entry, text: entry.text + msg.text }
+              : entry,
+          );
+        } else {
+          const id = nextTranscriptId++;
+          thinkingId = id;
+          entries = [...entries, { kind: "thinking", id, text: msg.text, done: false }];
+        }
+        return true;
+      }
+      case "text_delta": {
+        if (streamingId !== null) {
+          const id = streamingId;
+          entries = entries.map((entry) =>
+            entry.kind === "text" && entry.id === id
+              ? { ...entry, text: entry.text + msg.text }
+              : entry,
+          );
+        } else {
+          const id = nextTranscriptId++;
+          streamingId = id;
+          entries = [
+            ...entries,
+            { kind: "text", id, role: "assistant", text: msg.text, done: false },
+          ];
+        }
+        return true;
+      }
+      case "render": {
+        streamingId = null;
+        const id = nextTranscriptId++;
+        const index = entries.findIndex(
+          (entry) => entry.kind === "render" && entry.renderId === msg.id,
+        );
+        if (index >= 0) {
+          const updated = [...entries];
+          updated[index] = {
+            ...(updated[index] as RenderRow),
+            component: msg.component,
+            props: msg.props,
+          };
+          entries = updated;
+        } else {
+          entries = [
+            ...entries,
+            {
+              kind: "render",
+              id,
+              renderId: msg.id,
+              component: msg.component,
+              props: msg.props,
+            },
+          ];
+        }
+        return true;
+      }
+      case "picker": {
+        streamingId = null;
+        entries = [
+          ...entries,
+          {
+            kind: "picker",
+            id: nextTranscriptId++,
+            pickerId: msg.id,
+            title: msg.title,
+            rows: msg.rows,
+            hint: msg.hint,
+          },
+        ];
+        return true;
+      }
+      case "artifact": {
+        streamingId = null;
+        const id = nextTranscriptId++;
+        const index = entries.findIndex(
+          (entry) => entry.kind === "artifact" && entry.artifactId === msg.id,
+        );
+        if (index >= 0) {
+          const updated = [...entries];
+          updated[index] = {
+            ...(updated[index] as ArtifactRow),
+            html: msg.html,
+            title: msg.title,
+          };
+          entries = updated;
+        } else {
+          entries = [
+            ...entries,
+            {
+              kind: "artifact",
+              id,
+              artifactId: msg.id,
+              html: msg.html,
+              title: msg.title,
+            },
+          ];
+        }
+        return true;
+      }
+      case "tool_use": {
+        streamingId = null;
+        // A child tool splits that child's prose chronology, so prose after
+        // the call opens below it instead of extending the earlier row.
+        if (msg.parentId) {
+          subtextIds.delete(`${msg.parentId}|text`);
+          subtextIds.delete(`${msg.parentId}|thinking`);
+        }
+        // Prompts may queue while a turn is live; tools still belong to the
+        // oldest open turn, hence FIFO rather than "most recent prompt".
+        const batchId = openToolBatches[0] ?? orphanToolBatch;
+        entries = [
+          ...entries,
+          {
+            kind: "tool",
+            id: nextTranscriptId++,
+            toolId: msg.id,
+            name: msg.name,
+            detail: msg.detail,
+            input: msg.input,
+            parentId: msg.parentId,
+            batchId,
+            settled: false,
+            startedAt: readNow(),
+            ...(msg.replay ? { replayed: true } : {}),
+          },
+        ];
+        return true;
+      }
+      case "tool_result": {
+        entries = entries.map((entry) =>
+          entry.kind === "tool" && entry.toolId === msg.id
+            ? {
+                ...entry,
+                output: msg.output,
+                truncatedBytes: msg.truncatedBytes,
+                isError: msg.isError,
+              }
+            : entry,
+        );
+        return true;
+      }
+      case "turn_end": {
+        const id = streamingId;
+        streamingId = null;
+        subtextIds.clear();
+        const batchId = openToolBatches.shift() ?? orphanToolBatch--;
+        entries = entries.map((entry) => {
+          if (entry.kind === "text" && entry.id === id) return { ...entry, done: true };
+          if (entry.kind === "tool" && entry.batchId === batchId) {
+            return {
+              ...entry,
+              settled: true,
+              // A pending call at turn end was interrupted. Keep it expanded
+              // and explicit instead of folding it as successful activity.
+              ...(entry.output === undefined
+                ? { output: "(interrupted — no result)", isError: true }
+                : {}),
+            };
+          }
+          return entry;
+        });
+        return true;
+      }
+      case "error": {
+        streamingId = null;
+        entries = [
+          ...entries,
+          {
+            kind: "text",
+            id: nextTranscriptId++,
+            role: "assistant",
+            text: `**Error:** ${msg.message}`,
+            done: true,
+          },
+        ];
+        return true;
+      }
+      case "notice": {
+        // A notice is a status aside in transcript order. It leaves both the
+        // root text stream and open thinking state untouched.
+        entries = [
+          ...entries,
+          {
+            kind: "notice",
+            id: nextTranscriptId++,
+            text: msg.text,
+            noticeKind: msg.kind,
+            source: msg.source,
+          },
+        ];
+        return true;
+      }
+      case "bang_start": {
+        streamingId = null;
+        entries = [
+          ...entries,
+          {
+            kind: "bang",
+            id: nextTranscriptId++,
+            bangId: msg.id,
+            command: msg.command,
+            output: "",
+            done: false,
+          },
+        ];
+        return true;
+      }
+      case "bang_output": {
+        entries = entries.map((entry) =>
+          entry.kind === "bang" && entry.bangId === msg.id
+            ? { ...entry, output: entry.output + msg.data }
+            : entry,
+        );
+        return true;
+      }
+      case "bang_end": {
+        entries = entries.map((entry) =>
+          entry.kind === "bang" && entry.bangId === msg.id
+            ? { ...entry, exitCode: msg.exitCode, done: true }
+            : entry,
+        );
+        return true;
+      }
+      case "zone_reset": {
+        streamingId = null;
+        thinkingId = null;
+        // Stale parent/variant cursors would append replay into ids that were
+        // removed by this reset rather than creating fresh replay rows.
+        subtextIds.clear();
+        openToolBatches = [];
+        orphanToolBatch = -1;
+        tailIntents.push("reset-tail");
+        entries = [];
+        return true;
+      }
+
+      // Shell state, connection plumbing, and per-viewport request replies do
+      // not create output-zone rows. Listing every arm keeps additions to the
+      // wire union reviewable at compile time; a runtime-unknown arm still
+      // reaches the inert default below for version-skew compatibility.
+      case "prompt_options":
+      case "status":
+      case "permission_request":
+      case "permission_resolved":
+      case "session_created":
+      case "agents":
+      case "folder_picked":
+      case "subscription":
+      case "refused":
+      case "usage":
+      case "fs_tree":
+      case "fs_dir":
+      case "fs_file":
+      case "fs_file_diff":
+      case "fs_change_set":
+      case "fs_changed":
+      case "file_upload_done":
+      case "file_upload_error":
+      case "pong":
+      case "sessions":
+      case "session_ended":
+        return changed;
+      default: {
+        const exhaustive: never = msg;
+        void exhaustive;
+        return changed;
+      }
+    }
+  };
+
+  return {
+    apply(messages, readNow) {
+      const tailIntents: TranscriptTailIntent[] = [];
+      let changed = false;
+      for (const message of messages) {
+        if (applyMessage(message, readNow, tailIntents)) changed = true;
+      }
+      if (changed) snapshot = buildSnapshot(entries, snapshot);
+      return { snapshot, tailIntents };
+    },
+  };
+}


### PR DESCRIPTION
## What changed

- extract the stateful wire-to-view transcript projection from `RenderZone`
- isolate animation-frame and 50 ms fallback batching in a thin browser ingress
- return render-ready tool folds, subagent decks, picker state, and painting lookups
- keep thinking disclosure and DOM behavior in the renderer
- add sequence-level projection and ingress contract tests

## Why

`RenderZone` previously combined browser scheduling, protocol interpretation, transcript state, grouping policy, and rendering. This gives those responsibilities explicit boundaries without changing intended behavior.

## Impact

No intended user-facing behavior, public API, wire protocol, configuration, or dependency changes.

## Validation

- `yarn test` — 859/859 passing
- `yarn typecheck` — passing
- `yarn build` — passing
- `yarn test:e2e` — 104/104 passing
- isolated managed-browser matrix and visual suites — 7/7 passing
- `git diff --check` — passing

The combined local `yarn test:ui` wrapper times out with the same failure pattern on an untouched `next` snapshot; both constituent UI files pass independently on this branch.