### PR TITLE
Phase CX: agents know they're in Mirafold; `!!` runs a shell command with no agent turn

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -2738,6 +2738,206 @@ is one complete single-pass `$next` chunk.
   the explicitly enumerated 87-file safe run counts. Full original Phase body
   → **PLAN-ARCHIVE.md, “Moved 2026-08-19 (Phase IH — completed body).”**
 
+## Three phases from Kyle's 2026-08-25 usage notes (Kyle-directed; each opens ONLY on his express request naming it)
+
+Kyle used Mirafold for a day and brought back nine findings. Investigated
+2026-08-25 (three code sweeps, findings recorded per phase below); every
+decision was settled with him the same day. Recommended order: **CX → TR →
+CA** (smallest first; CX's paragraph also stops an agent misattributing
+Codex's sandbox to "a Mirafold session policy"). Each phase is one branch
+off fresh `next`, one PR, merged before the next is cut.
+
+## Phase CX — Agent context + the silent bang (written + opened 2026-08-25; Kyle-directed)
+
+- [ ] **Step CX.1 — Tell the agent where it is**
+  - Finding: the only environment text any engine receives is one sentence
+    in `RENDER_GUIDANCE` ("Your output renders in a web app…"). No name, no
+    "not a terminal". Agents assume a terminal/desktop and say so.
+  - Goal: every engine knows it is inside Mirafold, a browser app, without
+    spending context on anything more (Kyle: ~40 words, nothing about the
+    surfaces).
+  - Build: append one paragraph to `RENDER_GUIDANCE` (agent-neutral — Claude
+    gets it via `systemPrompt.append`, Codex/Gemini/OpenCode via the
+    first-turn prepend, all already wired): *"You are running inside
+    Mirafold, a browser app that re-skins this coding agent. The user reads
+    your output in a web page (sometimes on a phone), not in a terminal, a
+    desktop app, or an IDE — don't refer them to a terminal, Ctrl-C, or
+    'open in your editor.'"*
+  - Files: `server/render-tools.ts`; Tier-1 test that the paragraph reaches
+    each adapter's injection point (`claude-code.test.ts` system prompt
+    append, `RenderGuidanceOnce` carry for the other three).
+  - Done when: Tier-1 proves all four adapters carry it; a live turn
+    (Kyle-run) asking "what environment am I in?" names Mirafold and not a
+    terminal.
+
+- [ ] **Step CX.2 — `!!` runs a command with no agent turn**
+  - Finding: `!` (the bang line) runs in a PTY and then pushes the transcript
+    to the agent as its own model turn (`bang-handlers.ts`) — faithful to
+    Claude Code's terminal `!`. There is no way to just use the shell.
+  - Decisions (Kyle, 2026-08-25): `!` stays exactly as it is (fidelity);
+    `!!` = same PTY path, same broadcast/replay to every viewport (shell-
+    owned, not secret), same `cd` persistence and jail, same 400 ms
+    throttle, and **the agent never sees it — not even as later context.**
+  - Build: additive only. `bang` client message gains `silent?: true`;
+    `bang_start` gains `silent?: true` so every viewport and the replay ring
+    draw the row right; `bang-handlers.ts` skips `markModelTurnStarted` and
+    `pushPrompt` when silent (no false-busy window, no queued-follow-up slot
+    consumed); `Shell.tsx`'s intercept becomes `^!(!?)\s*(.+)$`; the bang
+    row shows a `!!` glyph. Prompt completions unchanged.
+  - Files: `server/protocol.ts`, `server/sessions/bang-handlers.ts`,
+    `web/src/components/Shell.tsx`, `OutputZone.tsx` (bang row),
+    `transcript-projection.ts`, `styles/06-tools.css`; tests: Tier-2
+    `bang.itest.ts` (silent → the session's `pushPrompt` is never called,
+    output still broadcast + replayed, cwd persists across `!!` then `!`),
+    Tier-1 projection, Tier-3 e2e (`!!echo hi` → `!!` row with output, the
+    activity line never starts, the mock received no prompt).
+  - Done when: the e2e proves a `!!` command runs, shows, replays, and the
+    mock adapter's prompt log stays empty.
+
+## Phase TR — Transcript readability (written 2026-08-25; NOT YET OPENED)
+
+Findings (2026-08-25 sweep): per-call bodies are always collapsed except on
+error (`ToolBlock.tsx`); the higher-level fold ("worked · N actions",
+`tool-visibility.ts`) already exists but forms only after `turn_end`, only
+for runs of ≥2 successful calls, and any prose between two calls splits the
+run — so a narrating agent produces a one-by-one parade forever. A manual
+expand is lost when a row reflows into the fold (remount). There is no
+jump-to-bottom affordance (only the `End` key with the scroller focused).
+Prose code fences render as a bare `<pre>` with no copy button while
+`render_code` has a header strip + `CopyButton`. Folder rows carry a folder
+glyph beside the chevron.
+
+- [ ] **Step TR.1 — The fold forms live, absorbs short narration, keeps
+  the user's expands**
+  - Decisions (Kyle): fold **during** the turn — "working · N actions"
+    growing, only the in-flight call shown beneath it as its own row;
+    flips to "worked · N actions" at turn end. Narration of **≤ 2 lines**
+    between calls is absorbed into the fold (shown inside, in order, like
+    interior thinking); a longer paragraph stays visible and ends the run.
+    Failed/interrupted calls stay outside and open, as today. A manual
+    expand survives the reflow.
+  - Build: `tool-visibility.ts` relaxes the `settled` requirement to
+    "finished + successful" for live folding with the running call as the
+    trailing boundary; short-text absorption beside thinking absorption;
+    tool disclosure state lifted into `OutputZone` keyed by tool id (the
+    `expandedThinking` pattern). Fold label by turn state.
+  - Files: `web/src/tool-visibility.ts` (+test), `transcript-projection.ts`
+    (+test), `components/OutputZone.tsx`, `ToolBlock.tsx`; mock scenario
+    `tool-activity` gains a one-line narration between calls and a longer
+    paragraph; `server/testing/shell-effects.e2e.ts`.
+  - Done when: e2e shows, mid-turn, one growing `.tool-activity-group` with
+    only the running call outside it; the short narration is inside the
+    fold and the paragraph outside; a click-expanded call is still expanded
+    after `turn_end`; the failing call still stands alone, open.
+
+- [ ] **Step TR.2 — Jump to latest**
+  - Decision (Kyle): a small round pill with a single `↓`, bottom-right of
+    the transcript scroller inside `.zone-row`, ~12 px above the scroller's
+    bottom edge (above the activity line / prompt box, out of the 76ch
+    reading column); bottom-center on the phone. Visible only while
+    follow-tail is detached; fades out on reaching the bottom or sending a
+    prompt. Click = what `End` does (`armFollow` + scroll). No count, no
+    label; `aria-label="Jump to latest"`.
+  - Build: `use-follow-tail.ts` surfaces `following` as render state;
+    the pill component; CSS in `01-frame.css`.
+  - Files: `web/src/use-follow-tail.ts` (+test), `components/OutputZone.tsx`,
+    `styles/01-frame.css`; e2e in `document.e2e.ts` or a new
+    `follow-tail.e2e.ts`.
+  - Done when: e2e — scroll up during a streaming mock turn → pill visible;
+    click → at bottom, following, pill gone; never visible while at bottom;
+    phone viewport places it bottom-center.
+
+- [ ] **Step TR.3 — Prose code fences get `render_code`'s header strip**
+  - Decision (Kyle, "option 2"): a fenced code block the agent types in
+    prose renders with the same header strip as the `render_code` painting
+    — language on the left (when the fence names one), `copy` on the right
+    — so the two ways of showing code are one object.
+  - Build: a `pre` override in `registry/Md.tsx` (today it overrides only
+    `a`/`code`/`table`/`li`) that wraps the highlighted `<code>` in the
+    shared head from `registry/Code.tsx` (extract the head into a small
+    shared component; `CopyButton` copies the raw fence text). Applies
+    wherever `Md` renders — turn prose and card text alike.
+  - Files: `web/src/registry/Md.tsx`, `registry/Code.tsx`,
+    `registry/CopyButton.tsx`, `styles/05-transcript.css` /
+    `07-registry.css`; a mock scenario turn containing a fence; e2e.
+  - Done when: e2e — a fenced block in a mock turn shows the head with the
+    language and a `copy` that flips to `copied`; `render_code` unchanged.
+
+- [ ] **Step TR.4 — No folder icon on folder rows**
+  - Decision (Kyle): drop the folder glyph from directory rows and the root
+    row; keep the rotating chevron; files keep their icons; keep an empty
+    spacer where the glyph was so names align in one column.
+  - Files: `components/folder-tree/FolderTreeRows.tsx`,
+    `FolderTreePanel.tsx` (root row), `styles/02-folder-tree.css`; e2e.
+  - Done when: e2e — no `.folder-tree-node-icon-folder` /
+    `-folder-open` in the tree; a dir name and a file name at the same
+    depth share the same x.
+
+## Phase CA — Codex on app-server: terminal-equal permissions (written 2026-08-25; NOT YET OPENED)
+
+**Finding (verified 2026-08-25).** Mirafold passes Codex **no** sandbox or
+approval settings (`codex.ts` leaves `sandboxMode`/`approvalPolicy` unset
+on purpose) and never writes `~/.codex/config.toml`; the `.git`-is-read-only
+rule Kyle hit is Codex's own workspace-write sandbox, identical in the
+terminal. The real mismatch: the adapter drives Codex through
+`@openai/codex-sdk`, which spawns **`codex exec`** — Codex's
+*non-interactive* mode. In the terminal, with `approval_policy =
+"on-request"`, a sandbox block (writing `.git` on commit, network, a path
+outside the workspace) makes Codex **ask** "retry outside the sandbox?";
+under `exec` nobody can be asked (`resolvePermission` is a no-op, the SDK
+has no approval callback), so the command fails and the model improvises —
+which is why Kyle ended up hand-editing `config.toml`. Codex is the only
+adapter without a working approval round-trip. **Target (Kyle): no
+difference for the user between Codex in the terminal and Codex in
+Mirafold.** The fix is Codex's `app-server` JSON-RPC protocol — what its
+own TUI and the VS Code extension use — whose approval requests map onto
+the existing `permission_request` / `permission_resolved` messages and the
+permission bar. `app-server` is already spawned for the model and skills
+catalogs (`codex-model-list.ts`, `codex-skills-list.ts`).
+
+- [ ] **Step CA.1 — The spike (throwaway, time-boxed)**
+  - Goal: watch the protocol do what the docs say before any product code.
+  - Build: drive `codex app-server` by hand from a scratch folder against
+    the installed `codex-cli` (0.149.1 today): initialize; new thread + one
+    turn; the full event stream (item shapes vs the exec-JSON ones the
+    mapper knows); an approval request when the sandbox blocks a `git
+    commit`, a network call, and an out-of-workspace write — and what
+    answering approve/deny does; thread resume; the first-open "trust this
+    folder?" dialog (surfaced, or client-owned?); how the `-c` config
+    overrides and `model_provider` binding ride along. Record all of it,
+    including the no-go list, in `server/adapters/codex.spike.md`.
+  - Done when: the spike doc records a real observed approval round trip
+    (a sandboxed commit produced a request; approving it made it succeed)
+    and names every place terminal-equal behavior is or isn't reachable.
+
+- [ ] **Step CA.2 — The transport**
+  - Build: `codex-app-server.ts` — a JSON-RPC-over-stdio client (the
+    `jsonrpc-oneshot.ts` patterns, made long-lived) replacing the SDK spawn
+    in `codex-binding.ts` / `codex.ts`; same config overrides and provider
+    binding; `codex-events.ts` adapted to the app-server item stream;
+    resume preserved. Dependency call recorded: whether `@openai/codex-sdk`
+    still earns its place or is removed.
+  - Done when: Tier-2 `codex.test.ts` green on the new transport with a
+    scripted app-server stub; interrupt, resume, `/model`, `/effort` intact.
+
+- [ ] **Step CA.3 — The approval round trip**
+  - Build: app-server approval requests → `permission_request` (tool +
+    detail, with the "retry outside the sandbox" meaning stated in the
+    shell's own words, engine words badged with `source`); the permission
+    bar's answer → the protocol's approve/deny; a `PermissionLedger` like
+    the other adapters; answers already sync across viewports.
+  - Done when: Tier-2 proves request → bar → answer → command proceeds or
+    is denied, and a denied request never runs.
+
+- [ ] **Step CA.4 — Fidelity acceptance (live, Kyle-run)**
+  - `codex-live.ltest.ts`: in a workspace-write sandbox, the agent commits
+    → Mirafold prompts → approve → the commit lands; deny → it doesn't;
+    `~/.codex/config.toml` byte-identical before and after (never written);
+    a relay viewport answers the same prompt. Kyle's verdict that it feels
+    like the terminal is the bar.
+
+---
+
 ## Phase PN — Panes (file views beside the transcript)
 
 **ON HOLD — do not build file panes for now (Kyle, 2026-08-25).** This phase

--- a/PLAN.md
+++ b/PLAN.md
@@ -2747,9 +2747,13 @@ CA** (smallest first; CX's paragraph also stops an agent misattributing
 Codex's sandbox to "a Mirafold session policy"). Each phase is one branch
 off fresh `next`, one PR, merged before the next is cut.
 
-## Phase CX — Agent context + the silent bang (written + opened 2026-08-25; Kyle-directed)
+## Phase CX — Agent context + the silent bang (opened + ✅ COMPLETE 2026-08-25; Kyle-directed; PR `feature/agent-context-silent-bang` → `next`)
 
-- [ ] **Step CX.1 — Tell the agent where it is**
+- [x] **Step CX.1 — Tell the agent where it is** — done 2026-08-25:
+  `MIRAFOLD_CONTEXT` opens `RENDER_GUIDANCE` under "## Where you are"; Tier-1
+  proves the paragraph reaches Claude's `systemPrompt.append` and the
+  first-turn prepend of Codex, Gemini and OpenCode. Live check (the
+  "what environment am I in?" turn) is Kyle's to run.
   - Finding: the only environment text any engine receives is one sentence
     in `RENDER_GUIDANCE` ("Your output renders in a web app…"). No name, no
     "not a terminal". Agents assume a terminal/desktop and say so.
@@ -2770,7 +2774,17 @@ off fresh `next`, one PR, merged before the next is cut.
     (Kyle-run) asking "what environment am I in?" names Mirafold and not a
     terminal.
 
-- [ ] **Step CX.2 — `!!` runs a command with no agent turn**
+- [x] **Step CX.2 — `!!` runs a command with no agent turn** — done 2026-08-25:
+  additive `silent?: true` on `bang` and `bang_start`; the handler skips the
+  context accumulator, `markModelTurnStarted` and `pushPrompt` for a silent
+  bang (cwd handoff and the 400 ms gate unchanged); `!!` glyph on the row,
+  tightened to the `!` column, with a hover title saying the agent never
+  sees it. Proven: Tier-1 (projection row, bus frame), Tier-2
+  (`bang.itest.ts`: flag on start + replay, output flows, no turn for 1.5 s
+  while the mock answers every prompt, `cd` carries into a following `!`
+  that DOES turn), Tier-3 (`app.e2e.ts`: `!!echo` strip + output, nothing
+  follows the block, no activity line). Full suites green: Tier-1 924,
+  Tier-2 153, Tier-3 116.
   - Finding: `!` (the bang line) runs in a PTY and then pushes the transcript
     to the agent as its own model turn (`bang-handlers.ts`) — faithful to
     Claude Code's terminal `!`. There is no way to just use the shell.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ in [docs/local-models.md](docs/local-models.md).
 Inside a session:
 
 - Type ordinary prompts in the command box.
-- Prefix a command with `!` to run it in Mirafold's interactive shell.
+- Prefix a command with `!` to run it in Mirafold's interactive shell; the
+  agent then sees the transcript as its own turn, as in the terminal. Prefix
+  it with `!!` to run it the same way but shell-only — the agent never sees
+  it.
 - Open `/` for mission control and `/s/<session-id>` for a session viewport.
 - Use the Files and Changes workspaces to inspect the current directory and
   its Git working-tree changes.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,8 @@ The daemon delegates by responsibility:
 - [`server/security/`](../server/security/) owns local authentication,
   executable trust, and tool-permission policy.
 - [`server/pty/`](../server/pty/) owns the interactive `!` pseudo-terminal
-  (PTY) shell.
+  (PTY) shell (`!` hands the finished transcript to the agent as its own
+  turn; `!!` is shell-only — the agent never sees it).
 - [`server/relay/`](../server/relay/) owns pairing, encryption, the daemon's
   outbound relay client, and its transport contract.
 

--- a/server/adapters/claude-code.test.ts
+++ b/server/adapters/claude-code.test.ts
@@ -6,6 +6,7 @@ import { mkdtempSync } from "node:fs";
 import type { query, Options } from "@anthropic-ai/claude-agent-sdk";
 import type { WireMsg } from "../protocol";
 import { ClaudeCodeSession } from "./claude-code";
+import { MIRAFOLD_CONTEXT, RENDER_GUIDANCE } from "../render-tools";
 
 // The Claude Code SDK-message→WireMsg mapping and the turn grammar, on
 // synthetic SDKMessages — no CLI, no network. The session is real; only the
@@ -816,6 +817,14 @@ test("recovery: Claude receives the saved SDK resume id and exposes its live com
 
   assert.equal(options?.resume, s.resumeId);
   assert.equal(options?.sessionId, undefined);
+  // The environment fact rides the same system-prompt append as the render
+  // guidance — the one injection point Claude has.
+  assert.deepEqual(options?.systemPrompt, {
+    type: "preset",
+    preset: "claude_code",
+    append: RENDER_GUIDANCE,
+  });
+  assert.ok(RENDER_GUIDANCE.includes(MIRAFOLD_CONTEXT));
   assert.deepEqual(
     seen.find((msg) => msg.type === "prompt_options"),
     {

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -7,6 +7,7 @@ import type { Codex, CodexOptions, ThreadEvent } from "@openai/codex-sdk";
 import type { WireMsg } from "../protocol";
 import { CodexSession, resolveRolloutModel, rolloutDateDir } from "./codex";
 import { MIRAFOLD_MCP } from "./render-mcp-cmd";
+import { MIRAFOLD_CONTEXT } from "../render-tools";
 
 // L.2b2: the Codex event→WireMsg mapping and the turn grammar, on synthetic
 // ThreadEvents — no engine, no network. The session is real; only its private
@@ -169,6 +170,7 @@ test("first turn carries RENDER_GUIDANCE + the deferred-tools addendum; later tu
   assert.equal(prompts.length, 2);
   // The guidance block, the deferral instruction, and the user's own text.
   assert.ok(prompts[0].includes("## Generative UI"));
+  assert.ok(prompts[0].includes(MIRAFOLD_CONTEXT), "the environment fact rides the first turn");
   assert.ok(prompts[0].includes("DEFERRED"));
   assert.ok(prompts[0].includes("tool search"));
   assert.ok(prompts[0].endsWith("first ask"));

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -8,6 +8,7 @@ import { GeminiCliSession } from "./gemini-cli";
 import type { GeminiModelCatalog } from "./gemini-model-list";
 import { isWorkspaceTrusted } from "../sessions/workspace-trust";
 import { MIRAFOLD_MCP, renderMcpCommand } from "./render-mcp-cmd";
+import { MIRAFOLD_CONTEXT } from "../render-tools";
 
 const RENDER_MCP_COMMAND = renderMcpCommand().command;
 
@@ -684,6 +685,7 @@ test("guidance skips slash-leading turns and rides the first prose turn instead"
     args = spawnArgs(argsLog);
     const prompt = args[args.indexOf("-p") + 1];
     assert.match(prompt, /## Generative UI/);
+    assert.ok(prompt.includes(MIRAFOLD_CONTEXT), "the environment fact rides the first prose turn");
     assert.match(prompt, /hello$/);
 
     s.pushPrompt("again");

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -4,7 +4,7 @@ import path from "node:path";
 import os from "node:os";
 import { mkdtempSync } from "node:fs";
 import type { WireMsg } from "../protocol";
-import { RENDER_GUIDANCE } from "../render-tools";
+import { MIRAFOLD_CONTEXT, RENDER_GUIDANCE } from "../render-tools";
 import { OpenCodeSession } from "./opencode";
 import type { OpenCodeEvent, OpenCodeTransport } from "./opencode-client";
 import { waitFor } from "../testing/wait-for";
@@ -1199,6 +1199,7 @@ test("BUGFIX3: an unavailable fork falls back to a disclosed fresh session", asy
   );
   const text = (fake.prompts[1]?.["parts"] as { text: string }[])[0]?.text ?? "";
   assert.ok(text.startsWith(RENDER_GUIDANCE), "a fresh engine session receives fresh guidance");
+  assert.ok(text.includes(MIRAFOLD_CONTEXT), "the environment fact rides the guidance");
   feed(idle(`${SES}_2`));
   await awaitTurnEnd(2);
   session.close();

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -202,7 +202,9 @@ export type SessionMsgBody =
   // program echoes typed input (echo on), that echo arrives here as ordinary
   // PTY output — exactly the terminal's behavior; password prompts turn echo
   // off, so a password never reaches the wire, the ring, or other viewports.
-  | { type: "bang_start"; command: string; id: string }
+  // `silent` marks a `!!` command: shell only — its transcript never reaches
+  // the agent, so viewports draw the `!!` glyph (replay included).
+  | { type: "bang_start"; command: string; id: string; silent?: true }
   | { type: "bang_output"; data: string; id: string }
   // exitCode null = killed by signal (user stop, session close).
   | { type: "bang_end"; id: string; exitCode: number | null };
@@ -611,7 +613,9 @@ export type ClientMsg =
   // Run `command` in a PTY in the session's cwd — the `!` path,
   // never routed through the model. `id` is client-minted so the issuing
   // viewport can correlate the broadcast stream and own the stdin affordance.
-  | { type: "bang"; command: string; id: string }
+  // `silent` (the `!!` form): run it, show it, and never hand the transcript
+  // to the agent — not as a turn, not as later context.
+  | { type: "bang"; command: string; id: string; silent?: true }
   // EPHEMERAL SECRET PATH: a line typed into the running command's stdin
   // (possibly a password). Written to the PTY and nothing else — never
   // broadcast, never buffered, never logged, never re-serialized into a

--- a/server/pty/bang.itest.ts
+++ b/server/pty/bang.itest.ts
@@ -197,6 +197,57 @@ test("bang `cd` persists inside the workspace, escapes reset with the terminal's
   await bd.stop();
 });
 
+test("a silent `!!` bang runs, shows, replays and persists its cd — and the agent never hears of it", async () => {
+  const bd = await startDaemon();
+  const root = realpathSync(mkdtempSync(path.join(os.tmpdir(), "mirafold-bang-silent-")));
+  mkdirSync(path.join(root, "child"));
+  const client = new TestClient(bd.port);
+  await client.opened();
+  await client.type("agents");
+  client.send({ type: "create", agent: "claude-code", cwd: root } as never);
+  await client.type("session_created");
+  const outputOf = (id: string) =>
+    (client.received as Any[])
+      .filter((m) => m.type === "bang_output" && m.id === id)
+      .map((m) => m.data)
+      .join("");
+  const modelTraffic = () =>
+    (client.received as Any[]).filter((m) => m.type === "turn_end" || m.type === "text_delta").length;
+
+  // The silent form: the start frame carries the flag (so every viewport and
+  // the replay ring draw `!!`), the output flows, the cd sticks…
+  client.send({ type: "bang", id: "s1", command: "cd child && echo shell-only", silent: true } as never);
+  const start = (await client.type("bang_start")) as Any;
+  assert.equal(start.silent, true);
+  await client.waitFor((m) => m.type === "bang_end" && (m as Any).id === "s1", "bang_end s1", 20_000);
+  assert.match(outputOf("s1"), /shell-only/);
+  // …and the mock — which answers EVERY pushPrompt with a turn — stays
+  // silent, because no prompt was ever pushed.
+  await new Promise((r) => setTimeout(r, 1500));
+  assert.equal(modelTraffic(), 0, "a silent bang must not start a model turn");
+
+  // The cd carried into the next command, and a plain `!` still hands its
+  // transcript to the agent — the seam works both ways in one session.
+  client.send({ type: "bang", id: "p1", command: "pwd" } as never);
+  const plain = (await client.type("bang_start")) as Any;
+  assert.equal("silent" in plain, false, "a plain bang carries no silent flag");
+  await client.waitFor((m) => m.type === "bang_end" && (m as Any).id === "p1", "bang_end p1", 20_000);
+  assert.ok(outputOf("p1").includes(path.join(root, "child")), "the silent cd did not persist");
+  await client.type("turn_end", 30_000);
+
+  // A late viewport replays the silent row with its flag intact.
+  const { client: late } = await attachSession(bd.port, (client.received as Any[]).find((m) => m.type === "session_created")!.sessionId);
+  const replayed = (await late.waitFor(
+    (m) => m.type === "bang_start" && (m as Any).id === "s1",
+    "replayed silent bang_start",
+  )) as Any;
+  assert.equal(replayed.silent, true);
+
+  late.close();
+  client.close();
+  await bd.stop();
+});
+
 test("a command that swaps the cwd handoff for a FIFO can't stall the daemon (audit f.3)", async () => {
   const bd = await startDaemon();
   const { client } = await createSession(bd.port);

--- a/server/render-tools.ts
+++ b/server/render-tools.ts
@@ -62,11 +62,27 @@ const TOOL_DESCRIPTIONS: Record<RenderToolName, string> = {
     "Render a mermaid diagram (flowchart, sequenceDiagram, stateDiagram-v2, classDiagram, erDiagram) from its source text. Use for ANY architecture/flow/relationship picture — never ASCII-art diagrams, and never a raw ```mermaid fence (that renders as literal code here). Data plots stay render_chart.",
 };
 
-/** The generative-UI tool-preference nudge, shared across all three adapters:
- *  Claude appends it to the claude_code system-prompt preset (Session
- *  options); Codex and Gemini have no system-prompt hook, so their
- *  adapters prepend it ahead of the first user turn instead. */
+/** The one thing every engine is told about its environment — deliberately
+ *  ~40 words and nothing about the surfaces, so it costs almost no context
+ *  (Kyle, 2026-08-25). Without it agents assume a terminal or desktop app
+ *  and hand the user terminal instructions, and one blamed Codex's own
+ *  sandbox on "a Mirafold session policy". */
+export const MIRAFOLD_CONTEXT =
+  "You are running inside Mirafold, a browser app that re-skins this coding " +
+  "agent. The user reads your output in a web page (sometimes on a phone), " +
+  "not in a terminal, a desktop app, or an IDE — don't refer them to a " +
+  "terminal, Ctrl-C, or \"open in your editor\".";
+
+/** The guidance every adapter injects, shared across all four: Claude appends
+ *  it to the claude_code system-prompt preset (Session options); Codex,
+ *  Gemini and OpenCode have no system-prompt hook, so their adapters prepend
+ *  it ahead of the first user turn instead. Opens with MIRAFOLD_CONTEXT so
+ *  the environment fact rides the same single injection point. */
 export const RENDER_GUIDANCE = `
+## Where you are
+
+${MIRAFOLD_CONTEXT}
+
 ## Generative UI
 
 Your output renders in a web app whose output zone can mount real UI

--- a/server/sessions/bang-handlers.ts
+++ b/server/sessions/bang-handlers.ts
@@ -30,10 +30,11 @@ const BANG_CONTEXT_CAP = envInt("BANG_CONTEXT_CAP", 16_000);
 // agent-context tail above keeps accumulating — only the broadcast stops.
 const BANG_OUTPUT_CAP_BYTES = envInt("BANG_OUTPUT_CAP_BYTES", 262_144);
 
-// Minimum gap between `!` commands per session: each bang costs a model
+// Minimum gap between `!` commands per session: each `!` bang costs a model
 // turn, so a hostile client bursting bangs is a token-burn vector, not just
-// PTY churn. Humans never trip 400ms — the same threshold the action bridge
-// uses.
+// PTY churn (a silent `!!` costs no turn but keeps the same gate — the PTY
+// churn alone is worth throttling). Humans never trip 400ms — the same
+// threshold the action bridge uses.
 const BANG_MIN_INTERVAL_MS = envInt("BANG_MIN_INTERVAL_MS", 400);
 
 // A handoff file bigger than the longest legal path was not written by the
@@ -125,9 +126,18 @@ const applyCwdHandoff = (
  * Run one `!` command in the session's PTY and drive its whole
  * lifecycle — the bang_start/…/bang_end grammar, the head-kept wire budget
  * (what viewports and the replay ring see), and the tail-kept context
- * accumulator that rides into the agent's next prompt.
+ * accumulator that rides into the agent's next prompt. A `silent` (`!!`)
+ * command runs the same PTY path and shows the same output, but the
+ * transcript stops at the wire: no accumulator, no model turn — the shell
+ * used as a shell.
  */
-const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, id: string) => {
+const startBang = (
+  registry: SessionRegistry,
+  e: SessionEntry,
+  command: string,
+  id: string,
+  silent: boolean,
+) => {
   // Tail-kept accumulator, capped as data arrives — a long-running
   // command (`!yes`) must not grow server memory until exit.
   let output = "";
@@ -171,7 +181,7 @@ const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, 
   // then deleted) — fall back to the workspace root, not a failed spawn.
   if (!existsSync(e.bangCwd)) e.bangCwd = e.cwd;
   const runCwd = e.bangCwd;
-  registry.broadcast(e, { type: "bang_start", command, id });
+  registry.broadcast(e, { type: "bang_start", command, id, ...(silent ? { silent: true } : {}) });
   try {
     // Out-of-band cwd handoff file (pty.ts) — never part of the PTY stream.
     // Inside the try: a failing mkdtemp must error the session, not the daemon.
@@ -180,7 +190,7 @@ const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, 
       command,
       runCwd,
       (data) => {
-        keepContextTail(data);
+        if (!silent) keepContextTail(data);
         broadcastWireHead(data);
       },
       (exitCode) => {
@@ -191,6 +201,13 @@ const startBang = (registry: SessionRegistry, e: SessionEntry, command: string, 
             data: `(… ${wireElided} bytes elided …)\n`,
             id,
           });
+        }
+        if (silent) {
+          // `!!`: the command is over and nothing follows — bang_end is a
+          // true idle edge here, and the cwd still carries to the next bang.
+          registry.broadcast(e, { type: "bang_end", id, exitCode });
+          applyCwdHandoff(registry, e, runCwd, cwdFile);
+          return;
         }
         // The transcript below starts a model turn of its own. Record that
         // before bang_end derives fleet/gate state so there is no false-idle
@@ -248,7 +265,8 @@ export type BangHandlers = {
 export function createBangHandlers({ registry, getEntry, sendError, viewport }: BangDeps): BangHandlers {
   const start = (msg: Bang): void => {
     // The `!` passthrough: run it in a PTY in the session's bang
-    // cwd; the finished transcript reaches the agent as its own turn.
+    // cwd; the finished transcript reaches the agent as its own turn —
+    // unless `silent` (`!!`), in which case it reaches nobody.
     const entry = getEntry();
     if (!entry || typeof msg.command !== "string" || !msg.command.trim()) return;
     // `id` is a client-minted string (ClientMsg). Validate the RAW value —
@@ -273,7 +291,8 @@ export function createBangHandlers({ registry, getEntry, sendError, viewport }: 
       return;
     }
     entry.lastBangAt = Date.now();
-    startBang(registry, entry, msg.command, msg.id);
+    // Exactly `true` — a hostile client's truthy string is not a silent bang.
+    startBang(registry, entry, msg.command, msg.id, msg.silent === true);
   };
 
   const input = (msg: BangInput): void => {

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1413,6 +1413,36 @@ test("! cd .. — silent success says so, the escape is announced, and the agent
   });
 });
 
+test("!! echo — the silent bang shows its `!!` strip and output, and the agent never answers", async () => {
+  // The previous test's turn must be fully over first: its trailing painting
+  // would otherwise land after this block (a bang row is a hard document
+  // boundary) and read as an answer to the silent command.
+  await page.waitForSelector(".activity-line", { state: "detached", timeout: 30_000 });
+  await page.locator("textarea").click();
+  await page.keyboard.type("!!echo shell-only");
+  await page.keyboard.press("Enter");
+
+  const block = page.locator(".bang-block").last();
+  await block.locator(".bang-glyph-silent").waitFor();
+  assert.equal(await block.locator(".bang-glyph").innerText(), "!!");
+  await block.locator(".bang-output").waitFor();
+  assert.match(await block.locator(".bang-output").innerText(), /shell-only/);
+  await block.locator(".bang-state", { hasText: "running" }).waitFor({ state: "detached" });
+
+  // The mock answers every prompt it is handed within a second or so; give
+  // it three and prove nothing followed this block — no turn, no document.
+  await page.waitForTimeout(3000);
+  const after = await block.evaluate((el) => {
+    let n = 0;
+    for (let s = el.nextElementSibling; s; s = s.nextElementSibling) {
+      if (s.classList.contains("response-document") || s.classList.contains("turn-assistant")) n++;
+    }
+    return n;
+  });
+  assert.equal(after, 0, "a !! command must not start an agent turn");
+  assert.equal(await page.locator(".activity-line").count(), 0, "no turn is running");
+});
+
 test("entering a session puts the caret in the prompt box — no click first", async () => {
   await page.goto(`${base}/`);
   await page.waitForSelector(".fleet-row");

--- a/web/src/components/OutputZone.tsx
+++ b/web/src/components/OutputZone.tsx
@@ -573,7 +573,12 @@ function ZoneEntry({
           className="turn turn-user turn-bang"
           navigation={inputNavigation}
         >
-          <span className="glyph bang-glyph">!</span>
+          <span
+            className={entry.silent ? "glyph bang-glyph bang-glyph-silent" : "glyph bang-glyph"}
+            title={entry.silent ? "Shell only — the agent never sees this command" : undefined}
+          >
+            {entry.silent ? "!!" : "!"}
+          </span>
           <span className="turn-user-text">
             {entry.command}
             {!entry.done && <span className="bang-state">running…</span>}

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -388,10 +388,13 @@ export function Shell() {
   // its own turn, exactly as the terminal harness does.
   const send = (text: string) => {
     setReviewPromptVisible(false);
-    const m = text.match(/^!\s*(.+)$/s);
+    // `!!` is the silent form: same shell, same output, but the agent is
+    // never told — the user is just using the terminal.
+    const m = text.match(/^!(!?)\s*(.+)$/s);
     if (m) {
-      const command = m[1].trim();
-      setBang({ my: { id: bus.sendBang(command), command }, tail: "" });
+      const silent = m[1] === "!";
+      const command = m[2].trim();
+      setBang({ my: { id: bus.sendBang(command, silent), command }, tail: "" });
     } else {
       bus.sendPrompt(text);
     }

--- a/web/src/session-bus.test.ts
+++ b/web/src/session-bus.test.ts
@@ -88,6 +88,21 @@ test("every request mints a correlation id its frame carries, so each surface ma
   assert.equal(new Set(Object.values(ids)).size, 7, "ids are distinct");
 });
 
+test("a silent (!!) bang sends silent: true, and a plain ! sends no flag at all", (t) => {
+  const { bus, sock } = setup(t);
+  const before = sock().sent.length;
+  bus.sendBang("ls");
+  bus.sendBang("ls", true);
+  const frames = sock().parsedSent().slice(before) as { type: string; silent?: unknown }[];
+  assert.deepEqual(
+    frames.map((f) => [f.type, "silent" in f, f.silent]),
+    [
+      ["bang", false, undefined],
+      ["bang", true, true],
+    ],
+  );
+});
+
 test("connection listeners see transitions, and a relay refusal code arrives as its reason", (t) => {
   const { bus, sock } = setup(t);
   const seen: [boolean, string | undefined][] = [];

--- a/web/src/session-bus.ts
+++ b/web/src/session-bus.ts
@@ -32,8 +32,9 @@ export interface SessionBus {
    *  daemon/platform failure rejects with the shell-owned explanation. */
   pickFolder(cwd?: string): Promise<string | undefined>;
   sendPrompt(text: string): void;
-  /** Returns the minted bang id so the issuing viewport can correlate. */
-  sendBang(command: string): string;
+  /** Returns the minted bang id so the issuing viewport can correlate.
+   *  `silent` is the `!!` form: the agent never sees the transcript. */
+  sendBang(command: string, silent?: boolean): string;
   sendBangInput(id: string, data: string): void;
   killBang(id: string): void;
   interrupt(): void;
@@ -130,9 +131,9 @@ export function createSessionBus(): SessionBus {
     },
     // Run a shell command in the session's cwd (the `!` path). The id
     // is minted here so this viewport can correlate the broadcast stream.
-    sendBang(command: string): string {
+    sendBang(command: string, silent = false): string {
       const id = mintId("bang");
-      socket.send({ type: "bang", command, id });
+      socket.send({ type: "bang", command, id, ...(silent ? { silent: true } : {}) });
       return id;
     },
     // EPHEMERAL: PTY stdin (possibly a password) — the server writes it to

--- a/web/src/styles/06-tools.css
+++ b/web/src/styles/06-tools.css
@@ -279,9 +279,15 @@
 
 /* The `!` passthrough. The strip echoes the command-strip look
    with an amber `!` in place of the green `❯`; output is a plain mono block
-   streaming live below it. */
+   streaming live below it. The silent `!!` form doubles the glyph, tightened
+   so it holds the single glyph's column. */
 .turn-bang .bang-glyph {
   color: var(--warn-fg);
+}
+
+.turn-bang .bang-glyph-silent {
+  letter-spacing: -0.18em;
+  margin-right: 0.18em;
 }
 
 .bang-state {

--- a/web/src/transcript-projection.test.ts
+++ b/web/src/transcript-projection.test.ts
@@ -356,6 +356,22 @@ test("bang start, output, and end update one stable row", () => {
     { output: endRow.output, done: endRow.done, exitCode: endRow.exitCode },
     { output: "/tmp", done: true, exitCode: 0 },
   );
+  assert.equal(endRow.silent, undefined, "a plain ! row carries no silent flag");
+});
+
+test("a silent (!!) bang row carries the flag from bang_start through its end", () => {
+  const projection = createTranscriptProjection();
+  const rows = apply(
+    projection,
+    { type: "bang_start", id: "s", command: "git status", silent: true },
+    { type: "bang_output", id: "s", data: "clean" },
+    { type: "bang_end", id: "s", exitCode: 0 },
+  );
+  const row = rowsOf(rows, "bang")[0]!;
+  assert.deepEqual(
+    { silent: row.silent, output: row.output, done: row.done },
+    { silent: true, output: "clean", done: true },
+  );
 });
 
 test("unchanged rows retain identity; unmatched updates still publish like the existing state map", () => {

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -84,6 +84,8 @@ export type BangRow = {
   output: string;
   exitCode?: number | null;
   done: boolean;
+  /** The `!!` form — shell only, the agent never saw it. */
+  silent?: true;
 };
 
 export type PickerTranscriptRow = {
@@ -653,6 +655,7 @@ export function createTranscriptProjection(): TranscriptProjection {
             command: msg.command,
             output: "",
             done: false,
+            ...(msg.silent ? { silent: true as const } : {}),
           },
         ];
         return true;


### PR DESCRIPTION
## Phase CX — from Kyle's 2026-08-25 usage findings

**CX.1 — Tell the agent where it is.** A ~40-word `MIRAFOLD_CONTEXT` paragraph now opens `RENDER_GUIDANCE` ("## Where you are"), so every engine — Claude via `systemPrompt.append`, Codex/Gemini/OpenCode via the first-turn prepend — knows it is inside Mirafold, a browser app, not a terminal/desktop/IDE. Nothing about the surfaces (context cost). Tier-1 asserts the paragraph at all four injection points.

**CX.2 — `!!` = shell only.** `!` is unchanged (PTY, then the transcript goes to the agent as its own turn — terminal fidelity). `!!` runs the same PTY path, broadcasts and replays the same output, keeps `cd` persistence and the 400 ms gate, and **never reaches the agent** — no context accumulator, no model turn. Additive wire fields only: `bang.silent?: true` (validated as exactly `true`) and `bang_start.silent?: true` so every viewport and the replay ring draw the `!!` glyph.

Also: the three phases written from the findings (CX / TR / CA) land in PLAN.md here; CX is checked off.

## Verification
- Tier-1 `yarn test`: 924/924 (new: projection silent row, bus frame shape, four adapter guidance assertions)
- Tier-2 `yarn test:server`: 153/153 (new: `bang.itest.ts` silent bang — flag on start + replay, output flows, no turn while the mock answers every prompt, `cd` carries into a following `!` that does turn)
- Tier-3 e2e: 116/116 in headless Chrome (new: `app.e2e.ts` `!!echo` strip + output, nothing follows the block, no activity line)
- Left for Kyle: the live "what environment am I in?" turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)