### PR TITLE
Fix bang cwd display and workspace file links

### DIFF
--- a/server/adapters/mock.ts
+++ b/server/adapters/mock.ts
@@ -522,6 +522,7 @@ export class MockSession implements AgentSession {
    */
   private static readonly SCENARIOS: readonly MockScenario[] = [
     { id: "markdown-review", prompt: "revise the selected workspace change", match: /revise the selected workspace change/i, play: (m) => m.playMarkdownReview() },
+    { id: "workspace-file-link", prompt: "link the workspace readme", match: /link the workspace readme/i, play: (m) => m.playWorkspaceFileLink() },
     { id: "short-document", prompt: "one sentence document", match: /one sentence document/i, play: (m) => m.playShortDocument() },
     { id: "live-document", prompt: "live document demo", match: /live document demo/i, play: (m) => m.playLiveDocument() },
     { id: "responsive-document", prompt: "responsive document stress", match: /responsive document stress/i, play: (m) => m.playResponsiveDocumentStress() },
@@ -1134,6 +1135,14 @@ export class MockSession implements AgentSession {
   private playMarkdownReview() {
     this.beginTurn();
     const d = this.streamText(codeReviewTemplate(), 200);
+    this.endTurn(d);
+  }
+
+  /** Deterministic transcript link for the browser proof that a workspace
+   *  path opens in Mirafold's Files presenter instead of a localhost tab. */
+  private playWorkspaceFileLink() {
+    this.beginTurn();
+    const d = this.streamText("Here is [README.md](README.md).", 120, 4);
     this.endTurn(d);
   }
 

--- a/server/protocol.test.ts
+++ b/server/protocol.test.ts
@@ -103,11 +103,13 @@ const WIRE: WireByType = {
     type: "session_created",
     sessionId: "s1",
     cwd: "/home/u/proj",
+    shellCwd: "/home/u/proj/src",
     agent: "claude-code",
     resumed: false,
     demo: false,
     fallback: false,
   },
+  shell_cwd: { type: "shell_cwd", cwd: "/home/u/proj/src" },
   agents: {
     type: "agents",
     agents: [

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -232,6 +232,9 @@ export type ViewportMsgBody =
   | {
       type: "session_created";
       sessionId: string;
+      // The mutable working directory used by the next `!`/`!!` command.
+      // Optional for older daemons; absent means the immutable session cwd.
+      shellCwd?: string;
       cwd: string;
       agent?: AgentName;
       // The engine's model label as known at attach time — the status bar
@@ -244,6 +247,11 @@ export type ViewportMsgBody =
       demo?: boolean;
       fallback?: boolean;
     }
+  // Current bang-shell state for already-attached viewports. This is a
+  // replaceable snapshot, not transcript history: it is never sequenced,
+  // replayed, or persisted as a message. A fresh attach gets the same value
+  // from session_created.shellCwd above.
+  | { type: "shell_cwd"; cwd: string }
   // On connect, the server advertises which agents this daemon can run and
   // which have credentials (`live`) — the agent picker's source. No
   // agent is assumed; `default` is only a hint for pre-selection.

--- a/server/pty/bang.itest.ts
+++ b/server/pty/bang.itest.ts
@@ -163,7 +163,8 @@ test("bang `cd` persists inside the workspace, escapes reset with the terminal's
   await client.opened();
   await client.type("agents");
   client.send({ type: "create", agent: "claude-code", cwd: root } as never);
-  await client.type("session_created");
+  const created = (await client.type("session_created")) as Any;
+  assert.equal(created.shellCwd, root);
 
   const bang = async (id: string, command: string) => {
     client.send({ type: "bang", id, command } as never);
@@ -179,6 +180,8 @@ test("bang `cd` persists inside the workspace, escapes reset with the terminal's
   // ever typed in this test, a turn follows each bang — the transcript
   // reached the agent immediately (the mock answers every pushPrompt).
   await bang("cwd1", "cd child");
+  const inside = (await client.type("shell_cwd")) as Any;
+  assert.equal(inside.cwd, path.join(root, "child"));
   await client.type("turn_end", 30_000);
   await bang("cwd2", "pwd");
   assert.ok(outputOf("cwd2").includes(path.join(root, "child")), "cd did not persist");
@@ -186,6 +189,8 @@ test("bang `cd` persists inside the workspace, escapes reset with the terminal's
 
   // Escaping above the workspace is undone and announced, like the terminal.
   await bang("cwd3", "cd ../..");
+  const reset = (await client.type("shell_cwd")) as Any;
+  assert.equal(reset.cwd, root);
   const notice = (await client.type("notice", 20_000)) as Any;
   assert.equal(notice.text, `Shell cwd was reset to ${root}`);
   await client.type("turn_end", 30_000);
@@ -221,6 +226,8 @@ test("a silent `!!` bang runs, shows, replays and persists its cd — and the ag
   const start = (await client.type("bang_start")) as Any;
   assert.equal(start.silent, true);
   await client.waitFor((m) => m.type === "bang_end" && (m as Any).id === "s1", "bang_end s1", 20_000);
+  const moved = (await client.type("shell_cwd")) as Any;
+  assert.equal(moved.cwd, path.join(root, "child"));
   assert.match(outputOf("s1"), /shell-only/);
   // …and the mock — which answers EVERY pushPrompt with a turn — stays
   // silent, because no prompt was ever pushed.
@@ -237,7 +244,11 @@ test("a silent `!!` bang runs, shows, replays and persists its cd — and the ag
   await client.type("turn_end", 30_000);
 
   // A late viewport replays the silent row with its flag intact.
-  const { client: late } = await attachSession(bd.port, (client.received as Any[]).find((m) => m.type === "session_created")!.sessionId);
+  const { client: late, created: lateCreated } = await attachSession(
+    bd.port,
+    (client.received as Any[]).find((m) => m.type === "session_created")!.sessionId,
+  );
+  assert.equal(lateCreated.shellCwd, path.join(root, "child"));
   const replayed = (await late.waitFor(
     (m) => m.type === "bang_start" && (m as Any).id === "s1",
     "replayed silent bang_start",

--- a/server/sessions/bang-handlers.ts
+++ b/server/sessions/bang-handlers.ts
@@ -116,9 +116,9 @@ const applyCwdHandoff = (
   }
   const rel = path.relative(root, landed);
   if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) {
-    e.bangCwd = landed;
+    registry.setBangCwd(e, landed);
   } else {
-    e.bangCwd = e.cwd;
+    registry.setBangCwd(e, e.cwd);
     registry.broadcast(e, { type: "notice", text: `Shell cwd was reset to ${e.cwd}` });
   }
 };
@@ -180,7 +180,7 @@ const startBang = (
   };
   // The bang cwd can vanish between commands (we cd'd somewhere the agent
   // then deleted) — fall back to the workspace root, not a failed spawn.
-  if (!existsSync(e.bangCwd)) e.bangCwd = e.cwd;
+  if (!existsSync(e.bangCwd)) registry.setBangCwd(e, e.cwd);
   const runCwd = e.bangCwd;
   registry.broadcast(e, { type: "bang_start", command, id, ...(silent ? { silent: true } : {}) });
   try {

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -204,6 +204,7 @@ export function openConnection(
       type: "session_created",
       sessionId: e.id,
       cwd: e.cwd,
+      shellCwd: e.bangCwd,
       agent: e.agent,
       model: e.session.modelName,
       ...(resumed ? { resumed: true } : {}),

--- a/server/sessions/registry.test.ts
+++ b/server/sessions/registry.test.ts
@@ -1,6 +1,6 @@
 import { after, test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expandHomePath, foldUsage, resolveCwd, SessionRegistry } from "./registry";
@@ -106,6 +106,34 @@ test("prompt options are a replaceable unsequenced session snapshot, not transcr
       options: [{ trigger: "/", value: "/review", label: "review", kind: "command" }],
     },
   ]);
+  reg.end(entry.id);
+});
+
+test("a bang cwd commit is durable current metadata, not transcript history", () => {
+  const storeDir = mkdtempSync(path.join(os.tmpdir(), "mirafold-bang-cwd-store-"));
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-bang-cwd-root-"));
+  const child = path.join(root, "child");
+  mkdirSync(child);
+  const store = new SessionCheckpointStore(storeDir);
+  const reg = new SessionRegistry({
+    backend: MOCK_BACKEND,
+    deltaCoalesceMs: 0,
+    store,
+  });
+  const entry = reg.create({ cwd: root });
+  openSessions.push({ reg, id: entry.id });
+  const seen: WireMsg[] = [];
+  reg.attach(entry, (msg) => seen.push(msg));
+
+  reg.setBangCwd(entry, child);
+
+  assert.equal(entry.bangCwd, child);
+  assert.deepEqual(seen.filter((msg) => msg.type === "shell_cwd"), [
+    { type: "shell_cwd", cwd: child },
+  ]);
+  assert.equal(entry.ring.buffer.length, 0);
+  assert.equal(entry.ring.nextSeq, 1);
+  assert.equal(store.loadAll().sessions.get(entry.id)?.bangCwd, child);
   reg.end(entry.id);
 });
 

--- a/server/sessions/registry.ts
+++ b/server/sessions/registry.ts
@@ -498,6 +498,16 @@ export class SessionRegistry {
     entry.ring.offer(msg);
   }
 
+  /** Commit a bang cwd already confined by bang-handlers.ts, checkpoint the
+   * current shell state, and tell attached viewports without putting mutable
+   * terminal metadata into transcript history. */
+  setBangCwd(entry: SessionEntry, cwd: string) {
+    if (this.entries.get(entry.id) !== entry || entry.bangCwd === cwd) return;
+    entry.bangCwd = cwd;
+    this.checkpoint(entry);
+    this.fanout(entry, { type: "shell_cwd", cwd });
+  }
+
   private deliver(entry: SessionEntry, msg: SessionMsg) {
     const log = createLogger(`session ${entry.id}`);
     // The likeliest live failures (bad key, engine died, CLI missing)

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1437,6 +1437,35 @@ test("!! echo — the silent bang shows its `!!` strip and output, and the agent
   assert.equal(await page.locator(".stop-btn").count(), 0, "no turn is running");
 }));
 
+test("!! cd updates only the prompt cwd and survives a viewport reload", () => withFreshMockSession(browser, TOKEN, async (page) => {
+  const crumb = page.locator(".prompt-cwd");
+  await crumb.waitFor();
+  const rootTitle = await crumb.getAttribute("title");
+  const statusRoot = await page.locator(".sb-cwd").getAttribute("title");
+  assert.ok(rootTitle);
+  assert.ok(statusRoot);
+  const shellRoot = rootTitle.split(" — click to hide")[0];
+  const expectedTitle = `${shellRoot}/web — click to hide (the caret brings it back)`;
+
+  await page.locator("textarea").fill("!!cd web");
+  await page.keyboard.press("Enter");
+  await page.locator(".bang-block").last().locator(".bang-state", { hasText: "running" }).waitFor({ state: "detached" });
+  await page.waitForFunction(
+    (title) => document.querySelector(".prompt-cwd")?.getAttribute("title") === title,
+    expectedTitle,
+  );
+  assert.equal(await crumb.getAttribute("title"), expectedTitle);
+  assert.equal(
+    await page.locator(".sb-cwd").getAttribute("title"),
+    statusRoot,
+    "the immutable session root must not follow the bang shell",
+  );
+
+  await page.reload();
+  await page.locator(".prompt-cwd").waitFor();
+  assert.equal(await page.locator(".prompt-cwd").getAttribute("title"), expectedTitle);
+}));
+
 test("entering a session puts the caret in the prompt box — no click first", () => withFreshMockSession(browser, TOKEN, async (page, base) => {
   await page.goto(`${base}/`);
   await page.waitForSelector(".fleet-row");
@@ -1636,6 +1665,34 @@ const onFolderTreeFixture = async (body: () => Promise<void>) => {
     await page.waitForSelector("textarea", { timeout: 30_000 });
   }
 };
+
+test("E.2f: a transcript file link opens the file in Mirafold, never a localhost tab", () => withFreshMockSession(browser, "e2e-file-link-9c2f", async (p) => {
+  await installFsRecorder(p);
+  await typePrompt(p, MOCK_PROMPTS["workspace-file-link"]);
+  const link = p.locator(".markdown-file-link", { hasText: "README.md" }).last();
+  await link.waitFor({ timeout: 15_000 });
+  await p.waitForSelector(".activity-line", { state: "detached", timeout: 15_000 });
+
+  const sessionUrl = p.url();
+  const pageCount = p.context().pages().length;
+  assert.equal(await link.evaluate((element) => element.tagName), "BUTTON");
+  assert.equal(await link.getAttribute("href"), null, "the local file still has a browser href");
+
+  await link.click();
+  await p.waitForSelector(".folder-tree-view .fv-content", { timeout: 15_000 });
+  assert.equal(await p.locator(".folder-tree-file-name").innerText(), "README.md");
+  assert.match(await p.locator(".folder-tree-view .fv-content").innerText(), /Mirafold/);
+  assert.equal(p.url(), sessionUrl, "the session navigated when the file link was clicked");
+  assert.equal(
+    p.context().pages().length,
+    pageCount,
+    "the file link opened a second browser page",
+  );
+  assert.ok(
+    (await fsSent(p)).some((message) => message.type === "fs_read" && message.path === "README.md"),
+    "the click never requested README.md through the Files reader",
+  );
+}));
 
 test("E.3: the files panel lists the working tree, opens a file beside the transcript, drills back", () => onFolderTreeFixture(async () => {
   await page.locator(".ab-folder-tree").click();

--- a/server/testing/mock-prompts.ts
+++ b/server/testing/mock-prompts.ts
@@ -6,6 +6,7 @@ import { MockSession } from "../adapters/mock";
 export const MOCK_PROMPTS = MockSession.prompts as Readonly<
   Record<
     | "markdown-review"
+    | "workspace-file-link"
     | "short-document"
     | "live-document"
     | "responsive-document"

--- a/web/src/components/OutputZone.tsx
+++ b/web/src/components/OutputZone.tsx
@@ -13,7 +13,7 @@ import rehypeHighlight from "rehype-highlight";
 import type { Action } from "@protocol";
 import type { ZoneMsg } from "../session-bus";
 import { RenderBlock, RenderBoundary } from "../registry/RenderBlock";
-import { mdOverrides, mdUrlTransform } from "../registry/Md";
+import { workspaceMarkdown } from "../registry/Md";
 import { PinDock } from "./PinDock";
 import { InputNavigationStop } from "./InputNavigation";
 import { ToolBlock } from "./ToolBlock";
@@ -62,14 +62,22 @@ const toolBlockProps = (call: {
 
 // Memoized on the entry's text: a settled block's markdown tree is reused
 // as-is while later entries stream.
-const AssistantTurn = memo(function AssistantTurn({ text }: { text: string }) {
+type AssistantMarkdown = ReturnType<typeof workspaceMarkdown>;
+
+const AssistantTurn = memo(function AssistantTurn({
+  text,
+  markdown,
+}: {
+  text: string;
+  markdown: AssistantMarkdown;
+}) {
   return (
     <div className="turn turn-assistant markdown">
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeHighlight]}
-        urlTransform={mdUrlTransform}
-        components={mdOverrides}
+        urlTransform={markdown.urlTransform}
+        components={markdown.components}
       >
         {text}
       </ReactMarkdown>
@@ -288,6 +296,8 @@ type OutputZoneProps = {
   // so no scroll position can hide it.
   busy: boolean;
   focusPrompt: () => void;
+  workspaceRoot?: string;
+  onOpenWorkspaceFile?: (path: string) => void;
   onInputNavigationChange?: (state: InputNavigationState) => void;
 };
 
@@ -301,6 +311,8 @@ export const OutputZone = forwardRef<InputNavigationHandle, OutputZoneProps>(fun
   sendAction,
   busy,
   focusPrompt,
+  workspaceRoot,
+  onOpenWorkspaceFile,
   onInputNavigationChange,
 }, navigationRef) {
   // Pinning is pure output-zone state: wire ids (render or artifact) in pin
@@ -324,6 +336,10 @@ export const OutputZone = forwardRef<InputNavigationHandle, OutputZoneProps>(fun
   // true/false = the user's choice; absent = the row's own default.
   const [toolToggles, setToolToggles] = useState<ReadonlyMap<number, boolean>>(
     () => new Map(),
+  );
+  const assistantMarkdown = useMemo(
+    () => workspaceMarkdown(workspaceRoot, onOpenWorkspaceFile),
+    [workspaceRoot, onOpenWorkspaceFile],
   );
 
   useEffect(() => {
@@ -446,6 +462,7 @@ export const OutputZone = forwardRef<InputNavigationHandle, OutputZoneProps>(fun
         pinned={pinned}
         togglePin={togglePin}
         inputNavigation={inputNavigationFor(entry.id)}
+        assistantMarkdown={assistantMarkdown}
       />
     </RenderBoundary>
   );
@@ -603,6 +620,7 @@ function ZoneEntry({
   pinned,
   togglePin,
   inputNavigation,
+  assistantMarkdown,
 }: {
   entry: OutputZoneRow;
   toggleThinking: (id: number) => void;
@@ -613,6 +631,7 @@ function ZoneEntry({
   pinned: string[];
   togglePin: (renderId: string) => void;
   inputNavigation?: InputNavigationTarget;
+  assistantMarkdown: AssistantMarkdown;
 }) {
   if (entry.kind === "thinking") {
     return (
@@ -786,6 +805,6 @@ function ZoneEntry({
       <span className="turn-user-text">{entry.text}</span>
     </InputNavigationStop>
   ) : (
-    <AssistantTurn text={entry.text} />
+    <AssistantTurn text={entry.text} markdown={assistantMarkdown} />
   );
 }

--- a/web/src/components/PromptBox.tsx
+++ b/web/src/components/PromptBox.tsx
@@ -37,7 +37,7 @@ type PromptBoxProps = {
   onSend: (text: string) => void;
   busy: boolean;
   onInterrupt: () => void;
-  // The session's working dir, shown at the prompt like a terminal's
+  // The bang shell's current working dir, shown at the prompt like a terminal's
   // `~/Projects/foo ❯`. Shell-owned — rendered here, never by agent output,
   // so it can't be spoofed.
   cwd?: string;

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -99,6 +99,7 @@ export function Shell() {
   const [meta, setMeta] = useState<{
     sessionId?: string;
     cwd?: string;
+    shellCwd?: string;
     agent?: AgentName;
     model?: string;
     demo?: boolean;
@@ -156,6 +157,8 @@ export function Shell() {
   const folderTreeOpen = auxiliary === "folder-tree";
   const diffPanelOpen = auxiliary === "diff-panel";
   const [reviewPromptVisible, setReviewPromptVisible] = useState(false);
+  const fileOpenRequestId = useRef(0);
+  const [fileOpenRequest, setFileOpenRequest] = useState<{ id: number; path: string } | null>(null);
   const [promptDraft, setPromptDraft] = useState<PromptDraft>();
   const promptDraftId = useRef(0);
   const createReviewDraft = useCallback((text: string) => {
@@ -181,6 +184,12 @@ export function Shell() {
   const switchAuxiliary = (surface: WorkspaceSurface) => {
     if (auxiliary !== surface) toggleAuxiliary(surface);
   };
+  const openTranscriptFile = useCallback((path: string) => {
+    fileOpenRequestId.current += 1;
+    setFileOpenRequest({ id: fileOpenRequestId.current, path });
+    setReviewPromptVisible(false);
+    setAuxiliary("folder-tree");
+  }, []);
 
   // ── The theme and the settings card ─────────────────────────────────────
   // Shell-owned UI state (use-theme-slots.ts); the pill itself is two
@@ -267,12 +276,22 @@ export function Shell() {
         } else if (m.type === "prompt_options") {
           setPromptOptions(m.options);
         } else if (m.type === "session_created") {
-          setMeta({ sessionId: m.sessionId, cwd: m.cwd, agent: m.agent, model: m.model, demo: m.demo });
+          setFileOpenRequest(null);
+          setMeta({
+            sessionId: m.sessionId,
+            cwd: m.cwd,
+            shellCwd: m.shellCwd ?? m.cwd,
+            agent: m.agent,
+            model: m.model,
+            demo: m.demo,
+          });
           setNotices((n) => ({
             ...n,
             agentPicker: null,
             ...(m.fallback ? { session: true } : {}),
           }));
+        } else if (m.type === "shell_cwd") {
+          setMeta((current) => ({ ...current, shellCwd: m.cwd }));
         } else if (m.type === "refused") {
           // No session — the relay refused this subscription-backed
           // attach. Show the reason (also surfaced in the agent picker if we're there).
@@ -483,6 +502,7 @@ export function Shell() {
                 onSwitch={switchAuxiliary}
                 rootLabel={tildify(meta.cwd, daemonInfo.home)}
                 sessionKey={meta.sessionId}
+                fileOpenRequest={fileOpenRequest}
               />
               <DiffPanel
                 open={diffPanelOpen && Boolean(meta.sessionId)}
@@ -504,6 +524,8 @@ export function Shell() {
                 sendAction={bus.sendAction}
                 busy={busy}
                 focusPrompt={focusPrompt}
+                workspaceRoot={meta.cwd}
+                onOpenWorkspaceFile={openTranscriptFile}
                 onInputNavigationChange={updateInputNavigationState}
               />
             </div>
@@ -542,7 +564,7 @@ export function Shell() {
               onSend={send}
               busy={busy}
               onInterrupt={interrupt}
-              cwd={tildify(meta.cwd, daemonInfo.home)}
+              cwd={tildify(meta.shellCwd ?? meta.cwd, daemonInfo.home)}
               options={promptOptions}
               textareaRef={promptRef}
               containerRef={promptContainerRef}

--- a/web/src/components/folder-tree/FolderTreePanel.tsx
+++ b/web/src/components/folder-tree/FolderTreePanel.tsx
@@ -28,6 +28,9 @@ type FolderTreePanelProps = {
   rootLabel?: string;
   /** meta.sessionId — a change means a different workspace: reset + refetch. */
   sessionKey?: string;
+  /** One transcript file-link activation. Its monotonic id makes repeated
+   *  clicks on the same path distinct without replaying it on panel reopen. */
+  fileOpenRequest?: { id: number; path: string } | null;
 };
 
 type FileViewController = ReturnType<typeof useFileView>;
@@ -158,6 +161,7 @@ export function FolderTreePanel({
   onSwitch,
   rootLabel,
   sessionKey,
+  fileOpenRequest,
 }: FolderTreePanelProps) {
   const { store, expanded, rootOpen, setRootOpen, toggleDir, refreshTree } = useFolderTree({
     open,
@@ -223,6 +227,21 @@ export function FolderTreePanel({
   useEffect(() => {
     if (open && sessionKey) resetFile();
   }, [open, sessionKey]);
+
+  const handledFileOpenRequest = useRef<number | null>(null);
+  useEffect(() => {
+    if (
+      !open ||
+      !sessionKey ||
+      !fileOpenRequest ||
+      handledFileOpenRequest.current === fileOpenRequest.id
+    ) {
+      return;
+    }
+    handledFileOpenRequest.current = fileOpenRequest.id;
+    setMaximized(false);
+    openFile(fileOpenRequest.path, undefined, "content");
+  }, [open, sessionKey, fileOpenRequest, openFile]);
 
   if (!open) return null;
 

--- a/web/src/registry/Md.test.ts
+++ b/web/src/registry/Md.test.ts
@@ -4,7 +4,7 @@ import { createElement } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import ReactMarkdown from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
-import { Md, fenceLanguage, mdOverrides, nodeText } from "./Md";
+import { Md, fenceLanguage, mdOverrides, nodeText, workspaceMarkdown } from "./Md";
 
 const render = (text: string) => renderToStaticMarkup(createElement(Md, { text }));
 
@@ -20,6 +20,39 @@ test("a bare URL autolinks the same way", () => {
     render("Open http://192.168.1.50:8081 on your phone."),
     /<a href="http:\/\/192\.168\.1\.50:8081"/,
   );
+});
+
+test("a workspace file link becomes a Files action while ordinary web links stay anchors", () => {
+  const markdown = workspaceMarkdown("/home/kyle/a project", () => {});
+  const html = renderToStaticMarkup(
+    createElement(
+      ReactMarkdown,
+      { urlTransform: markdown.urlTransform, components: markdown.components },
+      "[file](</home/kyle/a project/src/app.ts:12>) [web](https://example.test/docs)",
+    ),
+  );
+  assert.match(
+    html,
+    /<button type="button" class="markdown-file-link" title="Open src\/app\.ts in Files">file<\/button>/,
+  );
+  assert.match(
+    html,
+    /<a href="https:\/\/example\.test\/docs" target="_blank" rel="noopener noreferrer">web<\/a>/,
+  );
+});
+
+test("a Windows workspace file survives the URL gate and becomes a Files action", () => {
+  const markdown = workspaceMarkdown("C:\\Users\\Kyle\\project", () => {});
+  const html = renderToStaticMarkup(
+    createElement(
+      ReactMarkdown,
+      { urlTransform: markdown.urlTransform, components: markdown.components },
+      "[file](C:/Users/Kyle/project/src/app.ts:7)",
+    ),
+  );
+  assert.match(html, /class="markdown-file-link"/);
+  assert.match(html, /title="Open src\/app\.ts in Files"/);
+  assert.ok(!html.includes("href="), `workspace file remained a browser href: ${html}`);
 });
 
 // Expo Go's deep-link schemes carry a mobile app built in a session to the

--- a/web/src/registry/Md.tsx
+++ b/web/src/registry/Md.tsx
@@ -9,6 +9,7 @@ import {
   type ReactNode,
 } from "react";
 import { CodeHead } from "./Code";
+import { workspacePathFromHref } from "../workspace-file-link";
 
 // remark-gfm's task-list checkbox (`- [x] thing`) renders as a bare
 // `<input disabled>` with no accessible name — a screen reader announces
@@ -94,15 +95,20 @@ function ScrollableMarkdownTable({
 // The markdown renderer overrides shared with OutputZone's turn text: anchors
 // get the safety rule (links open in a new tab, and react-markdown never emits
 // raw HTML from its source), and task-list items get an accessible checkbox label.
+type MarkdownAnchorProps = ComponentProps<"a"> & { node?: unknown };
+
+function MarkdownAnchor({ node: _node, href, children, ...props }: MarkdownAnchorProps) {
+  return href ? (
+    <a {...props} href={href} target="_blank" rel="noopener noreferrer">
+      {children}
+    </a>
+  ) : (
+    <span>{children}</span>
+  );
+}
+
 export const mdOverrides = {
-  a: ({ node: _node, href, children, ...props }: ComponentProps<"a"> & { node?: unknown }) =>
-    href ? (
-      <a {...props} href={href} target="_blank" rel="noopener noreferrer">
-        {children}
-      </a>
-    ) : (
-      <span>{children}</span>
-    ),
+  a: (props: MarkdownAnchorProps) => <MarkdownAnchor {...props} />,
   code: ({ node: _node, className, children, ...props }: ComponentProps<"code"> & { node?: unknown }) => (
     <code
       {...props}
@@ -134,6 +140,51 @@ export const mdOverrides = {
     return <li {...props}>{children}</li>;
   },
 };
+
+/**
+ * Transcript Markdown gets one shell-owned addition to the shared renderer:
+ * links naming a file in this session open Mirafold's Files presenter. The
+ * same href remains subject to mdUrlTransform unless it is a proven workspace
+ * path; that exception is what lets a Windows drive path reach the component
+ * instead of being mistaken for an unknown URL scheme.
+ */
+export function workspaceMarkdown(
+  workspaceRoot: string | undefined,
+  onOpenWorkspaceFile: ((path: string) => void) | undefined,
+) {
+  if (!workspaceRoot || !onOpenWorkspaceFile) {
+    return { components: mdOverrides, urlTransform: mdUrlTransform };
+  }
+  return {
+    urlTransform: (url: string) =>
+      workspacePathFromHref(url, workspaceRoot) ? url : mdUrlTransform(url),
+    components: {
+      ...mdOverrides,
+      a: ({ node: _node, href, children, className, title, ...props }: MarkdownAnchorProps) => {
+        const path = workspacePathFromHref(href, workspaceRoot);
+        return path ? (
+          <button
+            type="button"
+            className={["markdown-file-link", className].filter(Boolean).join(" ")}
+            title={title ?? `Open ${path} in Files`}
+            onClick={() => onOpenWorkspaceFile(path)}
+          >
+            {children}
+          </button>
+        ) : (
+          <MarkdownAnchor
+            {...props}
+            className={className}
+            title={title}
+            href={href}
+          >
+            {children}
+          </MarkdownAnchor>
+        );
+      },
+    },
+  };
+}
 
 const unwrapParagraph = {
   p: ({ children }: { children?: React.ReactNode }) => <>{children}</>,

--- a/web/src/styles/05-transcript.css
+++ b/web/src/styles/05-transcript.css
@@ -309,12 +309,23 @@
   margin-top: 0;
 }
 
-.markdown a {
+.markdown :is(a, .markdown-file-link) {
   color: var(--info);
 }
 
-.response-document .markdown a {
+.response-document .markdown :is(a, .markdown-file-link) {
   text-underline-offset: 0.16em;
+}
+
+.markdown-file-link {
+  appearance: none;
+  border: 0;
+  padding: 0;
+  background: none;
+  color: inherit;
+  font: inherit;
+  text-decoration: underline;
+  cursor: pointer;
 }
 
 .markdown code {

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -717,6 +717,7 @@ export function createTranscriptProjection(): TranscriptProjection {
       case "permission_request":
       case "permission_resolved":
       case "session_created":
+      case "shell_cwd":
       case "agents":
       case "folder_picked":
       case "subscription":

--- a/web/src/turn-state.test.ts
+++ b/web/src/turn-state.test.ts
@@ -132,6 +132,7 @@ test("a no-op frame returns the previous state object; a real change returns a n
   const ignored: ZoneMsg[] = [
     { type: "render", component: "card", props: {}, id: "r1" },
     { type: "bang_output", data: "…", id: "b1" },
+    { type: "shell_cwd", cwd: "/work/child" },
     { type: "thinking_delta", text: "still thinking" },
     { type: "status", state: "thinking" },
     { type: "usage", inputTokens: 1, outputTokens: 1 },

--- a/web/src/workspace-file-link.test.ts
+++ b/web/src/workspace-file-link.test.ts
@@ -1,0 +1,45 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { workspacePathFromHref } from "./workspace-file-link";
+
+test("workspace file links resolve absolute and relative targets under the session root", () => {
+  const root = "/home/kyle/Projects/a project";
+  assert.equal(
+    workspacePathFromHref("/home/kyle/Projects/a%20project/src/app.ts", root),
+    "src/app.ts",
+  );
+  assert.equal(workspacePathFromHref("docs/guide%20one.md", root), "docs/guide one.md");
+  assert.equal(workspacePathFromHref("./README.md", root), "README.md");
+});
+
+test("workspace file links discard standard line and fragment locations", () => {
+  const root = "/work/project";
+  assert.equal(workspacePathFromHref("/work/project/src/app.ts:42:7", root), "src/app.ts");
+  assert.equal(workspacePathFromHref("README.md#L12-L18", root), "README.md");
+  assert.equal(workspacePathFromHref("docs/guide.md#install", root), "docs/guide.md");
+});
+
+test("workspace file links reject URLs, outside paths, traversal, queries, and malformed escapes", () => {
+  const root = "/work/project";
+  for (const href of [
+    "https://example.test/file.ts",
+    "exp://127.0.0.1:8081",
+    "mailto:kyle@example.test",
+    "//example.test/file.ts",
+    "/work/project-two/file.ts",
+    "/etc/passwd",
+    "../outside.ts",
+    "src/../../outside.ts",
+    "src/app.ts?raw=1",
+    "src/%ZZ.ts",
+  ]) {
+    assert.equal(workspacePathFromHref(href, root), null, href);
+  }
+});
+
+test("workspace file links support Windows drive roots without weakening containment", () => {
+  const root = "C:\\Users\\Kyle\\project";
+  assert.equal(workspacePathFromHref("C:/Users/Kyle/project/src/app.ts:9", root), "src/app.ts");
+  assert.equal(workspacePathFromHref("/C:/Users/Kyle/project/README.md", root), "README.md");
+  assert.equal(workspacePathFromHref("C:/Users/Kyle/other/app.ts", root), null);
+});

--- a/web/src/workspace-file-link.ts
+++ b/web/src/workspace-file-link.ts
@@ -1,0 +1,71 @@
+/**
+ * Turn a Markdown href authored by an agent into the root-relative path the
+ * shell's existing fs_read surface accepts. Absolute paths must stay inside
+ * the session root; relative paths are rooted there. URL schemes and
+ * traversal are never file links.
+ *
+ * Agent clients commonly suffix file links with `:line[:column]` or a hash
+ * fragment. The Files presenter does not navigate to a line, but it can still
+ * open the named file, so those location suffixes are removed here.
+ */
+export function workspacePathFromHref(
+  href: string | undefined,
+  workspaceRoot: string | undefined,
+): string | null {
+  if (!href || !workspaceRoot || href.length > 4_096) return null;
+  // A query is meaningful to a web server, not to Mirafold's file reader.
+  // An encoded `?` remains available to the rare POSIX filename containing it.
+  if (href.includes("?")) return null;
+
+  const hash = href.indexOf("#");
+  const encodedPath = hash === -1 ? href : href.slice(0, hash);
+  let candidate: string;
+  try {
+    candidate = decodeURIComponent(encodedPath);
+  } catch {
+    return null;
+  }
+  if (!candidate || candidate.includes("\0")) return null;
+
+  const windowsRoot = /^[A-Za-z]:[\\/]/.test(workspaceRoot);
+  const posixRoot = workspaceRoot.startsWith("/");
+  if (!windowsRoot && !posixRoot) return null;
+
+  // A drive path is a filesystem path, not a URL scheme. Every other scheme
+  // (http:, mailto:, javascript:, exp:, …) belongs to the normal URL gate.
+  const windowsCandidate = /^\/?[A-Za-z]:[\\/]/.test(candidate);
+  if (/^[A-Za-z][A-Za-z0-9+.-]*:/.test(candidate) && !windowsCandidate) return null;
+  if (candidate.startsWith("//")) return null;
+
+  // Codex-style clickable file targets carry locations after the filename.
+  candidate = candidate.replace(/:\d+(?::\d+)?$/, "");
+  if (!candidate) return null;
+
+  const slash = (value: string) => value.replace(/\\/g, "/");
+  const trimRoot = (value: string) => {
+    const normalized = slash(value);
+    return normalized === "/" || /^[A-Za-z]:\/$/.test(normalized)
+      ? normalized
+      : normalized.replace(/\/+$/, "");
+  };
+  const root = trimRoot(workspaceRoot);
+  let target = slash(candidate);
+  if (windowsRoot && /^\/[A-Za-z]:\//.test(target)) target = target.slice(1);
+
+  const targetAbsolute = target.startsWith("/") || /^[A-Za-z]:\//.test(target);
+  let relative: string;
+  if (targetAbsolute) {
+    const comparableRoot = windowsRoot ? root.toLowerCase() : root;
+    const comparableTarget = windowsRoot ? target.toLowerCase() : target;
+    const prefix = comparableRoot.endsWith("/") ? comparableRoot : `${comparableRoot}/`;
+    if (!comparableTarget.startsWith(prefix)) return null;
+    relative = target.slice(prefix.length);
+  } else {
+    relative = target;
+  }
+
+  const segments = relative.split("/");
+  if (segments.some((segment) => segment === "..")) return null;
+  const clean = segments.filter((segment) => segment !== "" && segment !== ".").join("/");
+  return clean && clean.length <= 4_096 ? clean : null;
+}


### PR DESCRIPTION
## Summary

- propagate and persist bang shell directory changes so the prompt path follows both ! cd and !! cd while the session workspace root remains unchanged
- open agent-authored workspace file links in the existing jailed Files presenter instead of a localhost browser tab
- preserve ordinary web and Expo link behavior, workspace containment, and secret-file denial

## Verification

- yarn typecheck
- yarn build
- yarn test — 1,028 passed
- yarn test:server — 159 passed
- focused real-Chrome regressions for bang cwd persistence and transcript file-link navigation