### PR TITLE
fix: the ten automated-review findings on release PR #71

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,8 +42,10 @@ not reuse them.
   without it). A local `prepare-commit-msg` hook appends it automatically —
   if a commit somehow lacks it, `git rebase --signoff` repairs the branch.
 - A feature pull request stays open even after its checks pass. Complete the
-  requested review and refactor work there, then ask Kyle explicitly whether
-  to merge when it appears ready. Opening the pull request or getting green
+  requested review and refactor work there, read the automated review
+  comments the bots post on every PR and fix the legitimate ones (the
+  procedure is in `docs/RELEASING.md`, "Three mechanics to know"), then ask
+  Kyle explicitly whether to merge when it appears ready. Opening the pull request or getting green
   checks is not merge approval; merge only after Kyle says yes.
 - `docs/RELEASING.md` is the canonical branch and release runbook.
 - **No handoff files in the tree.** Session state belongs in memory and in

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -20,13 +20,28 @@ rebuilds on every push to `main`). Flow b keeps them in lockstep by making a
 | `feature/*`, `fix/*`, `refactor/*` | working branches, cut from `next` | none — name them anything, force-push freely |
 | `release/x.y.z` | short-lived release prep, cut from `next` (or from `main` for a hotfix) | none — it exists for hours |
 
-Two mechanics to know:
+Three mechanics to know:
 
 - **Every commit headed for a PR needs a DCO sign-off** — commit with
   `git commit -s`. The DCO check is required on both protected branches.
 - **An open or green feature PR is not approval to merge it.** Keep the PR
   open through the requested review and refactor passes. When it appears
   ready, ask Kyle explicitly whether to merge; merge only after he approves.
+- **Every PR gets automated review comments — read them before any merge.**
+  Two bots review each PR on open: CodeQL's code-quality scan (inline
+  "unused import" style notes) and the Codex reviewer (inline P1/P2 findings
+  with a claimed failure). They post minutes after the PR opens, so a
+  PR that "went green" can still be carrying findings. Before asking for
+  merge approval on a feature PR, and before merging a release PR, pull
+  every comment (`gh api repos/mirafold/mirafold/pulls/<n>/comments`,
+  plus `/issues/<n>/comments` and `/pulls/<n>/reviews`), verify each claim
+  against the code — a reviewer's failure scenario is a hypothesis, not a
+  finding, until it is reproduced — and fix the legitimate ones with a test
+  per class. On a release PR the fixes go to a `fix/*` branch off `next`,
+  merge into `next`, and `next` merges into the release branch; never
+  commit them on `release/*` directly, or staging only receives them via
+  the post-release sync. Adopted 2026-08-29 (v0.6.0: ten findings, all
+  legitimate, first seen after the release PR was already green).
 - **A `v*` tag publishes only `main`'s current tip.** The release workflow's
   first step fails any tag pointing elsewhere (a feature branch, an old `main`
   commit). The tag trigger itself is branch-blind by platform design; the
@@ -37,8 +52,10 @@ Two mechanics to know:
 
 1. **Feature work**: branch off `next`, commit with `-s`, and open a PR into
    `next`. Keep implementation follow-ups and refactors on that open PR.
-   Once the work and required checks appear ready, ask Kyle explicitly for
-   merge approval; leave the PR open until he gives it. Repeat until `next`
+   Once the work and required checks appear ready, read the automated
+   review comments (mechanic above) and address the legitimate ones on the
+   same PR; then ask Kyle explicitly for merge approval and leave the PR
+   open until he gives it. Repeat until `next`
    holds the release you want.
 2. **Cut the release branch**: `git switch -c release/x.y.z origin/next`.
    On it, regenerate the bundled-license notices and commit any change —
@@ -47,7 +64,11 @@ Two mechanics to know:
 3. **Bump the version** in `package.json` to `x.y.z` on that branch — commit
    `release: vx.y.z` (signed off). npm refuses to republish an existing
    version, so a missing bump kills the publish at the last step.
-4. **PR `release/x.y.z` → `main`**, merge on green.
+4. **PR `release/x.y.z` → `main`.** When the checks are green, read the
+   automated review comments on it; a legitimate finding goes through
+   `next` first (mechanic above), and the release branch takes the refreshed
+   `next` with `git merge origin/next` — the PR updates itself and the checks
+   re-run. Merge when green with the findings addressed.
 5. **Tag and push — this is the publish, and it's a human act** (the signing
    key lives only on the release manager's machine):
 

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,10 +37,12 @@ Three mechanics to know:
   plus `/issues/<n>/comments` and `/pulls/<n>/reviews`), verify each claim
   against the code — a reviewer's failure scenario is a hypothesis, not a
   finding, until it is reproduced — and fix the legitimate ones with a test
-  per class. On a release PR the fixes go to a `fix/*` branch off `next`,
-  merge into `next`, and `next` merges into the release branch; never
-  commit them on `release/*` directly, or staging only receives them via
-  the post-release sync. Adopted 2026-08-29 (v0.6.0: ten findings, all
+  per class. On a release PR the fixes go to a `fix/*` branch off `next`
+  and merge into `next` (so staging has them regardless of the release);
+  then merge **that fix branch** — never all of `next` — into the release
+  branch, so work that landed on `next` after the cut cannot ride into
+  production unselected. Never commit fixes on `release/*` directly, or
+  staging only receives them via the post-release sync. Adopted 2026-08-29 (v0.6.0: ten findings, all
   legitimate, first seen after the release PR was already green).
 - **A `v*` tag publishes only `main`'s current tip.** The release workflow's
   first step fails any tag pointing elsewhere (a feature branch, an old `main`
@@ -66,9 +68,9 @@ Three mechanics to know:
    version, so a missing bump kills the publish at the last step.
 4. **PR `release/x.y.z` → `main`.** When the checks are green, read the
    automated review comments on it; a legitimate finding goes through
-   `next` first (mechanic above), and the release branch takes the refreshed
-   `next` with `git merge origin/next` — the PR updates itself and the checks
-   re-run. Merge when green with the findings addressed.
+   `next` first (mechanic above), and the release branch takes the fix
+   branch with `git merge origin/fix/<name>` — the PR updates itself and the
+   checks re-run. Merge when green with the findings addressed.
 5. **Tag and push — this is the publish, and it's a human act** (the signing
    key lives only on the release manager's machine):
 

--- a/server/adapters/codex-events.ts
+++ b/server/adapters/codex-events.ts
@@ -82,6 +82,13 @@ export class CodexEventMapper {
   private thinkingAnnounced = false;
   private totals?: TokenTotals;
   private turnBaseline?: TokenTotals;
+  // Σ of the event's per-response `last` over this turn — the preferred
+  // figure. `total` is the THREAD's cumulative count and survives a
+  // `thread/resume` (the rollout persists it), so a mapper born after a
+  // daemon restart has no baseline for it: total − 0 on the first turn
+  // would re-report every pre-restart token, on top of the checkpointed
+  // usage the registry already restored (review 2026-08-29).
+  private turnLast?: TokenTotals;
 
   constructor(
     private readonly options: {
@@ -97,17 +104,16 @@ export class CodexEventMapper {
   /** A turn is starting: usage is measured from here, paintings re-anchor. */
   beginTurn() {
     this.turnBaseline = this.totals;
+    this.turnLast = undefined;
     this.thinkingAnnounced = false;
   }
 
   /** The turn ended (any status): emit its usage once, then reset. */
   endTurn() {
-    if (this.totals) {
-      const base = this.turnBaseline ?? { inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0 };
-      const inputTokens = this.totals.inputTokens - base.inputTokens;
-      const outputTokens =
-        this.totals.outputTokens - base.outputTokens +
-        (this.totals.reasoningOutputTokens - base.reasoningOutputTokens);
+    const turn = this.turnLast ?? this.turnDelta();
+    if (turn) {
+      const inputTokens = turn.inputTokens;
+      const outputTokens = turn.outputTokens + turn.reasoningOutputTokens;
       if (inputTokens > 0 || outputTokens > 0) {
         this.options.emit({
           type: "usage",
@@ -118,10 +124,23 @@ export class CodexEventMapper {
       }
     }
     this.turnBaseline = this.totals;
+    this.turnLast = undefined;
     this.checklist.reset();
     this.prose.clear();
     this.thinkingStreamed.clear();
     this.announced.clear();
+  }
+
+  /** The fallback when the engine sends no per-response `last`: this turn's
+   *  movement of the thread total. */
+  private turnDelta(): TokenTotals | undefined {
+    if (!this.totals) return undefined;
+    const base = this.turnBaseline ?? { inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0 };
+    return {
+      inputTokens: this.totals.inputTokens - base.inputTokens,
+      outputTokens: this.totals.outputTokens - base.outputTokens,
+      reasoningOutputTokens: this.totals.reasoningOutputTokens - base.reasoningOutputTokens,
+    };
   }
 
   /** One notification for the session's thread. `turn/completed` is the
@@ -155,8 +174,18 @@ export class CodexEventMapper {
         this.emitChecklist(Array.isArray(p["plan"]) ? (p["plan"] as unknown[]) : []);
         break;
       case "thread/tokenUsage/updated": {
-        const total = asTotals((p["tokenUsage"] as { total?: unknown } | undefined)?.total);
+        const usage = p["tokenUsage"] as { total?: unknown; last?: unknown } | undefined;
+        const total = asTotals(usage?.total);
         if (total) this.totals = total;
+        const last = asTotals(usage?.last);
+        if (last) {
+          const sum = this.turnLast ?? { inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0 };
+          this.turnLast = {
+            inputTokens: sum.inputTokens + last.inputTokens,
+            outputTokens: sum.outputTokens + last.outputTokens,
+            reasoningOutputTokens: sum.reasoningOutputTokens + last.reasoningOutputTokens,
+          };
+        }
         break;
       }
       case "error": {

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -317,6 +317,39 @@ test("happy stream: full notification→WireMsg mapping, exactly one turn_end", 
   s.close();
 });
 
+test("review 2026-08-29: a resumed thread's first turn reports only its own tokens", async () => {
+  // After a daemon restart the mapper is new but `total` is the thread's
+  // cumulative count (the rollout persists it) — the whole pre-restart
+  // history, which the registry has already restored from its checkpoint.
+  // The event's per-response `last` is the turn's own figure; it sums across
+  // the turn's responses.
+  const resumed = (total: [number, number, number], last: [number, number, number]): Notification => [
+    "thread/tokenUsage/updated",
+    {
+      tokenUsage: {
+        total: { inputTokens: total[0], outputTokens: total[1], reasoningOutputTokens: total[2] },
+        last: { inputTokens: last[0], outputTokens: last[1], reasoningOutputTokens: last[2] },
+      },
+    },
+  ];
+  const { s, msgs, awaitTurnEnd } = makeSession(
+    [resumed([900_100, 40_010, 5_005], [100, 10, 5]), resumed([900_300, 40_040, 5_015], [200, 30, 10]), DONE],
+    [resumed([900_350, 40_045, 5_016], [50, 5, 1]), DONE],
+  );
+  s.pushPrompt("one");
+  await awaitTurnEnd(1);
+  s.pushPrompt("two");
+  await awaitTurnEnd(2);
+  assert.deepEqual(
+    msgs.filter((m) => m.type === "usage").map((m) => [m.inputTokens, m.outputTokens]),
+    [
+      [300, 55],
+      [50, 6],
+    ],
+  );
+  s.close();
+});
+
 test("usage is per turn: the second turn reports only its own tokens", async () => {
   const { s, msgs, awaitTurnEnd } = makeSession([usage(100, 10), DONE], [usage(160, 25, 5), DONE]);
   s.pushPrompt("one");

--- a/server/relay/relay-url.test.ts
+++ b/server/relay/relay-url.test.ts
@@ -127,3 +127,23 @@ test("presentsOnEntitlement: the hosted default, or an operator's own backend �
   assert.equal(presentsOnEntitlement(selfHost, { MIRAFOLD_ENTITLEMENT_URL: "http://127.0.0.1:1/api/entitlement" }), true);
   assert.equal(presentsOnEntitlement(resolveRelayPlan({}), {}), false);
 });
+
+test("review 2026-08-29: the hosted relay spelled out by hand keeps the hosted semantics", async () => {
+  const { presentsOnEntitlement } = await import("./relay-url");
+  // A user who copies the default into .env must get exactly what leaving it
+  // unset gets: the hosted app origin (the relay host serves no app) and the
+  // license gate — never an "explicit" self-host plan with a twin-fallback QR.
+  const byHand = resolveRelayPlan({ MIRAFOLD_RELAY_URL: DEFAULT_RELAY_URL, MIRAFOLD_LICENSE_KEY: "mf_x" });
+  assert.deepEqual(byHand, resolveRelayPlan({ MIRAFOLD_LICENSE_KEY: "mf_x" }));
+  assert.equal(byHand.kind === "dial" && byHand.appUrl, DEFAULT_APP_URL);
+  assert.equal(presentsOnEntitlement(byHand, {}), true);
+  // Same origin, any spelling: a path or trailing slash still means hosted.
+  const withPath = resolveRelayPlan({ MIRAFOLD_RELAY_URL: `${DEFAULT_RELAY_URL}/`, MIRAFOLD_LICENSE_KEY: "mf_x" });
+  assert.equal(withPath.kind === "dial" && withPath.source, "default");
+  // And without an entitlement it stands down like the bake does — dialing
+  // the gated relay unentitled is a guaranteed refusal either way.
+  assert.deepEqual(resolveRelayPlan({ MIRAFOLD_RELAY_URL: DEFAULT_RELAY_URL }), { kind: "off", reason: "unentitled-default" });
+  // An explicit app origin still rides it.
+  const appToo = resolveRelayPlan({ MIRAFOLD_RELAY_URL: DEFAULT_RELAY_URL, MIRAFOLD_LICENSE_KEY: "mf_x", MIRAFOLD_APP_URL: "https://app.example" });
+  assert.equal(appToo.kind === "dial" && appToo.appUrl, "https://app.example");
+});

--- a/server/relay/relay-url.test.ts
+++ b/server/relay/relay-url.test.ts
@@ -137,9 +137,10 @@ test("review 2026-08-29: the hosted relay spelled out by hand keeps the hosted s
   assert.deepEqual(byHand, resolveRelayPlan({ MIRAFOLD_LICENSE_KEY: "mf_x" }));
   assert.equal(byHand.kind === "dial" && byHand.appUrl, DEFAULT_APP_URL);
   assert.equal(presentsOnEntitlement(byHand, {}), true);
-  // Same origin, any spelling: a path or trailing slash still means hosted.
-  const withPath = resolveRelayPlan({ MIRAFOLD_RELAY_URL: `${DEFAULT_RELAY_URL}/`, MIRAFOLD_LICENSE_KEY: "mf_x" });
-  assert.equal(withPath.kind === "dial" && withPath.source, "default");
+  // Same origin, any spelling: a trailing slash still means hosted — and the
+  // dial uses the canonical URL, because the client appends /daemon verbatim.
+  const withSlash = resolveRelayPlan({ MIRAFOLD_RELAY_URL: `${DEFAULT_RELAY_URL}/`, MIRAFOLD_LICENSE_KEY: "mf_x" });
+  assert.deepEqual(withSlash, byHand);
   // And without an entitlement it stands down like the bake does — dialing
   // the gated relay unentitled is a guaranteed refusal either way.
   assert.deepEqual(resolveRelayPlan({ MIRAFOLD_RELAY_URL: DEFAULT_RELAY_URL }), { kind: "off", reason: "unentitled-default" });

--- a/server/relay/relay-url.ts
+++ b/server/relay/relay-url.ts
@@ -96,7 +96,10 @@ export function resolveRelayPlan(env: {
   if (!entitled) return { kind: "off", reason: "unentitled-default" };
   return {
     kind: "dial",
-    url: raw || DEFAULT_RELAY_URL,
+    // The canonical spelling, not the user's: the dial appends DAEMON_PATH
+    // verbatim and the relay routes only the exact path — a trailing slash
+    // would dial //daemon and never connect.
+    url: DEFAULT_RELAY_URL,
     origin: hostedOrigin,
     source: "default",
     appUrl: appUrl ?? DEFAULT_APP_URL,

--- a/server/relay/relay-url.ts
+++ b/server/relay/relay-url.ts
@@ -13,6 +13,11 @@
 // pairing through the hosted relay loads the viewport from the hosted static
 // origin; an explicit relay with no MIRAFOLD_APP_URL keeps the HTTP-twin
 // fallback (dev + stub, where one host plays both parts — see index.ts).
+//
+// The hosted relay's own origin spelled out by hand is still the hosted
+// relay: it keeps the hosted app origin (the relay host serves no app — a
+// twin-fallback QR there is a dead link) and the entitlement gate (review
+// 2026-08-29).
 import { envOff } from "../env";
 
 export const DEFAULT_RELAY_URL = "wss://relay.mirafold.sh";
@@ -81,18 +86,18 @@ export function resolveRelayPlan(env: {
   const raw = env.MIRAFOLD_RELAY_URL?.trim();
   const appUrl = env.MIRAFOLD_APP_URL?.trim().replace(/\/+$/, "") || undefined;
   if (raw && envOff(raw)) return { kind: "off", reason: "opt-out" };
+  const hostedOrigin = relayOriginOf(DEFAULT_RELAY_URL) as string;
   if (raw) {
     const origin = relayOriginOf(raw);
-    return origin
-      ? { kind: "dial", url: raw, origin, source: "explicit", appUrl }
-      : { kind: "off", reason: "malformed-url", raw };
+    if (!origin) return { kind: "off", reason: "malformed-url", raw };
+    if (origin !== hostedOrigin) return { kind: "dial", url: raw, origin, source: "explicit", appUrl };
   }
   const entitled = !!(env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim() || env.MIRAFOLD_LICENSE_KEY?.trim());
   if (!entitled) return { kind: "off", reason: "unentitled-default" };
   return {
     kind: "dial",
-    url: DEFAULT_RELAY_URL,
-    origin: relayOriginOf(DEFAULT_RELAY_URL) as string,
+    url: raw || DEFAULT_RELAY_URL,
+    origin: hostedOrigin,
     source: "default",
     appUrl: appUrl ?? DEFAULT_APP_URL,
   };

--- a/server/relay/subscription.ts
+++ b/server/relay/subscription.ts
@@ -17,7 +17,7 @@
 
 import { createLogger } from "../log";
 import { inflightSlot, minInterval } from "../throttle";
-import { DEFAULT_ENTITLEMENT_URL, MAX_REASON_CHARS, postLicenseKey, resolveEntitlementUrl } from "./entitlement";
+import { MAX_REASON_CHARS, postLicenseKey, resolveEntitlementUrl } from "./entitlement";
 
 const log = createLogger("billing");
 

--- a/server/sessions/replay-ring.test.ts
+++ b/server/sessions/replay-ring.test.ts
@@ -67,3 +67,20 @@ test("offer merges same-lane deltas inside the window; anything else flushes fir
   assert.equal(last?.type === "text_delta" ? last.text : undefined, "late");
   assert.deepEqual(delivered.map((m) => m.seq), [1, 2, 3, 4, 5]);
 });
+
+test("review 2026-08-29: a cursor canResume accepts is one the replay can actually honor at a cap", () => {
+  // A delta still coalescing at the count cap: the flush inside replayAfter()
+  // pushes it and evicts the oldest retained message. The verdict must be
+  // judged against THAT ring, or the viewport keeps its transcript while
+  // silently missing the evicted message.
+  const { r } = ring({ countCap: 3, coalesceMs: 50 });
+  for (let i = 0; i < 4; i++) r.push({ type: "status", state: "thinking" });
+  assert.deepEqual(r.buffer.map((m) => m.seq), [2, 3, 4]);
+  r.offer({ type: "text_delta", text: "still coalescing" });
+  assert.equal(r.canResume(1), false, "seq 2 is about to fall off");
+  for (const after of [2, 3, 4]) {
+    if (!r.canResume(after)) continue;
+    const tail = r.replayAfter(after);
+    assert.equal(tail[0]?.seq, after + 1, `resume after ${after} must replay from ${after + 1}, no hole`);
+  }
+});

--- a/server/sessions/replay-ring.ts
+++ b/server/sessions/replay-ring.ts
@@ -129,8 +129,13 @@ export class ReplayRing {
 
   /** Can a viewport that last saw `afterSeq` resume with a tail replay? Only
    *  if nothing after it has fallen off the ring, and it isn't from some
-   *  other life (a seq we never issued). */
+   *  other life (a seq we never issued). The window is flushed FIRST: the
+   *  replay that follows a yes flushes too, and at a cap that flush evicts
+   *  the oldest message — judged against the pre-flush edge, a cursor there
+   *  would resume past a hole the viewport never learns about (review
+   *  2026-08-29). */
   canResume(afterSeq: number): boolean {
+    this.flush();
     if (!this.tailResumeSafe) return false;
     if (!Number.isInteger(afterSeq) || afterSeq < 0 || afterSeq >= this.nextSeq) return false;
     const firstBuffered = this.buffer[0]?.seq ?? this.nextSeq;

--- a/server/testing/activity.e2e.ts
+++ b/server/testing/activity.e2e.ts
@@ -4,7 +4,6 @@
 import { test, before, after } from "node:test";
 import { MOCK_PROMPTS } from "./mock-prompts";
 import assert from "node:assert/strict";
-import path from "node:path";
 import { type Browser } from "playwright-core";
 import { launchChrome, withFreshMockSession, assertAxeClean } from "./e2e-harness";
 

--- a/server/testing/diff-panel.e2e.ts
+++ b/server/testing/diff-panel.e2e.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import { type Browser, type BrowserContext, type Page } from "playwright-core";
 import type { ClientMsg } from "../protocol";
 import { assertApartOnScreen, assertAxeClean, launchChrome, noSideScroll } from "./e2e-harness";
-import { fixtureGit as git, startDaemon, TestClient, type Daemon, createSession as seedSession } from "./itest-harness";
+import { fixtureGit as git, startDaemon, type Daemon, createSession as seedSession } from "./itest-harness";
 
 // CR.2–CR.4 in a real browser against a real daemon and real Git: responsive
 // review, every honest state, line/hunk selection, editable prompt drafts,

--- a/server/testing/document.e2e.ts
+++ b/server/testing/document.e2e.ts
@@ -5,10 +5,9 @@
 import { test, before, after } from "node:test";
 import { MOCK_PROMPTS } from "./mock-prompts";
 import assert from "node:assert/strict";
-import path from "node:path";
 import { THEMES } from "../../web/src/themes/manifest";
 import { type Browser, type Locator, type Page } from "playwright-core";
-import { launchChrome, withFreshMockSession, typePrompt, assertAxeClean, noSideScroll, settled } from "./e2e-harness";
+import { launchChrome, withFreshMockSession, typePrompt, assertAxeClean, noSideScroll } from "./e2e-harness";
 
 let browser: Browser;
 before(async () => {
@@ -315,7 +314,7 @@ test("LD.2: document measure, hierarchy, rich lane, local overflow, and short-an
 test("LD.3: response documents reflow across folder tree, file view, pin dock, and narrow desktop", async () => {
   await withFreshMockSession(browser, "live-document-responsive-18c4", async (p) => {
     await p.setViewportSize({ width: 1440, height: 1000 });
-    const prompt = await settleLiveDocument(p);
+    await settleLiveDocument(p);
 
     const measure = () => readResponsiveDocumentLayout(p);
 

--- a/server/testing/shell-effects.e2e.ts
+++ b/server/testing/shell-effects.e2e.ts
@@ -8,7 +8,7 @@ import assert from "node:assert/strict";
 import { readFileSync, rmSync } from "node:fs";
 import path from "node:path";
 import { type Browser, type Page } from "playwright-core";
-import { launchChrome, withFreshMockSession, assertAxeClean, settled } from "./e2e-harness";
+import { launchChrome, withFreshMockSession, assertAxeClean } from "./e2e-harness";
 
 let browser: Browser;
 before(async () => {


### PR DESCRIPTION
The CodeQL and Codex review bots left ten inline findings on the v0.6.0 release PR (#71) after it went green. Each was verified against the code before fixing; all ten are legitimate.

## Codex (3 × P2), one test per class
- **relay-url** — `MIRAFOLD_RELAY_URL` set to the default hosted URL resolved as an *explicit* self-host plan: no `appUrl` (QR pointed at the relay's HTTP twin, which serves no app) and the license gate skipped. The hosted origin, however spelled, now takes the same path as unset.
- **replay-ring** — `canResume` judged against the pre-flush ring; the replay's own flush could evict the oldest message at a cap, so a viewport told `resumed: true` kept a transcript with a hole. Flush first. The new test fails against the old code.
- **codex-events** — `thread/tokenUsage/updated`'s `total` is the thread's cumulative count and survives `thread/resume` (the rollout persists it); a mapper born after a daemon restart reported all pre-restart tokens on its first turn, on top of the registry's restored checkpoint. Per-turn usage now sums the event's per-response `last`; total − baseline stays as the fallback.

## CodeQL (7)
Seven unused imports / one unused local removed (`subscription.ts`, four e2e files). Each confirmed to have no other use site.

## Workflow
`docs/RELEASING.md` gains a third mechanic — read the automated review comments before any merge, with the route for a release-time finding (this PR: fix branch off `next` → `next` → merge `next` into `release/0.6.0`). `CLAUDE.md`'s git-workflow bullet points at it.

Tier-1: 1031/1031 locally, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UUjZMBEiMqES5hXYkXH9P