### PR TITLE
fix: the three v0.6.0 release follow-ups

### DIFF
--- a/scripts/packaged-pass.mjs
+++ b/scripts/packaged-pass.mjs
@@ -61,6 +61,12 @@ const daemon = spawn(process.execPath, [path.join(PKG, "dist-server", "index.js"
     GOOGLE_API_KEY: "",
     CLAUDE_CONFIG_DIR: path.join(ws, ".no-claude"),
     CODEX_HOME: path.join(ws, ".no-codex"),
+    // The daemon's OWN state, not only the engines': with the release
+    // manager's real session store visible, the packaged daemon shows the
+    // session list instead of the agent picker and the first check times
+    // out (v0.6.0, 2026-08-30). Same isolation the itest harness applies.
+    MIRAFOLD_SESSION_DIR: path.join(ws, ".mirafold-sessions"),
+    MIRAFOLD_LOG_FILE: "",
     // Off, or agent picker gains a second step (the N backend picker) on any
     // machine that happens to be running Ollama — which is not what this pass
     // is measuring, and would make it pass or fail by accident.

--- a/server/testing/follow-tail.e2e.ts
+++ b/server/testing/follow-tail.e2e.ts
@@ -19,17 +19,21 @@ after(async () => {
 const bottomGap = (page: Page) =>
   page.locator(".output-zone").evaluate((el) => el.scrollHeight - el.scrollTop - el.clientHeight);
 
-/** Enough transcript to overflow the viewport (template turns paint a
- *  component each, so three is plenty at either geometry). */
+/** Enough transcript to overflow the viewport. The mock deals replies from a
+ *  shuffled deck with randomized details, so a fixed three turns can come up
+ *  short (it did, 2026-08-29: overflow=0 on a compact draw); send until the
+ *  overflow is really there, bounded by one full deck. */
 const fillTranscript = async (page: Page, send: (text: string) => Promise<void>) => {
-  for (const n of [1, 2, 3]) {
+  const overflow = () =>
+    page.locator(".output-zone").evaluate((el) => el.scrollHeight - el.clientHeight);
+  let n = 0;
+  while (n < 6 && (n < 3 || (await overflow()) <= 300)) {
+    n += 1;
     await send(`tell me about the fold, take ${n}`);
     await waitTurnIdle(page);
   }
-  const overflow = await page
-    .locator(".output-zone")
-    .evaluate((el) => el.scrollHeight - el.clientHeight);
-  assert.ok(overflow > 300, `the transcript must overflow for this proof (overflow=${overflow})`);
+  const got = await overflow();
+  assert.ok(got > 300, `the transcript must overflow for this proof (overflow=${got} after ${n} turns)`);
 };
 
 const wheelUpOverTranscript = async (page: Page, dy: number) => {

--- a/web/src/registry/Code.test.ts
+++ b/web/src/registry/Code.test.ts
@@ -67,4 +67,8 @@ test("the code painting's scrolling body is keyboard-reachable (axe scrollable-r
   // this element whenever the mock dealt a tall code painting (2026-08-29).
   const html = renderToStaticMarkup(createElement(Code, { code: "const a = 1;\n".repeat(40), lang: "ts" }));
   assert.match(html, /<pre class="rc-code-body"><code class="hljs language-ts" tabindex="0">/);
+  // No lang → bare fence → no hljs class; the body still scrolls and still
+  // needs the tab stop (Codex review on PR #74).
+  const plain = renderToStaticMarkup(createElement(Code, { code: "x\n".repeat(40) }));
+  assert.match(plain, /<pre class="rc-code-body"><code tabindex="0">/);
 });

--- a/web/src/registry/Code.test.ts
+++ b/web/src/registry/Code.test.ts
@@ -1,7 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createElement, isValidElement, type ReactElement } from "react";
-import { codeFence, highlightedLines, splitNodeLines } from "./Code";
+import { renderToStaticMarkup } from "react-dom/server";
+import { Code, codeFence, highlightedLines, splitNodeLines } from "./Code";
 
 test("codeFence: the fence always outruns any backtick run inside the code", () => {
   assert.equal(codeFence("const a = 1;", "ts"), "```ts\nconst a = 1;\n```");
@@ -57,4 +58,13 @@ test("splitNodeLines: a token element spanning a newline is cut into per-line cl
   assert.equal(secondHalf.props.className, "hljs-comment");
   assert.equal(secondHalf.props.children, "b */");
   assert.equal(y, "y");
+});
+
+test("the code painting's scrolling body is keyboard-reachable (axe scrollable-region-focusable)", () => {
+  // The body is a scroll container (max-height + long lines). Like the prose
+  // fence in Md.tsx, the highlighted <code> carries the tab stop so a keyboard
+  // user can reach and scroll it; the follow-tail e2e failed axe on exactly
+  // this element whenever the mock dealt a tall code painting (2026-08-29).
+  const html = renderToStaticMarkup(createElement(Code, { code: "const a = 1;\n".repeat(40), lang: "ts" }));
+  assert.match(html, /<pre class="rc-code-body"><code class="hljs language-ts" tabindex="0">/);
 });

--- a/web/src/registry/Code.tsx
+++ b/web/src/registry/Code.tsx
@@ -108,8 +108,11 @@ export function Code({ code, lang, filename, highlight }: ComponentProps<"code">
             // The body scrolls (max-height, long lines); a scroll region with
             // no tab stop is unreachable by keyboard — axe
             // scrollable-region-focusable, serious. Same rule as the prose
-            // fence in Md.tsx, so both code surfaces read as one object.
-            tabIndex={className?.split(/\s+/).includes("hljs") ? 0 : undefined}
+            // fence in Md.tsx, so both code surfaces read as one object —
+            // but unconditional here: every <code> in a painting IS the
+            // body (Md's hljs check only tells fences from inline code, and
+            // a painting with no lang gets no hljs class at all).
+            tabIndex={0}
           >
             {lines.map((segment, i) => (
               <span

--- a/web/src/registry/Code.tsx
+++ b/web/src/registry/Code.tsx
@@ -103,7 +103,14 @@ export function Code({ code, lang, filename, highlight }: ComponentProps<"code">
         const lines = splitNodeLines(children);
         const hl = highlightedLines(highlight, lines.length);
         return (
-          <code className={className}>
+          <code
+            className={className}
+            // The body scrolls (max-height, long lines); a scroll region with
+            // no tab stop is unreachable by keyboard — axe
+            // scrollable-region-focusable, serious. Same rule as the prose
+            // fence in Md.tsx, so both code surfaces read as one object.
+            tabIndex={className?.split(/\s+/).includes("hljs") ? 0 : undefined}
+          >
             {lines.map((segment, i) => (
               <span
                 key={i}


### PR DESCRIPTION
The three items the v0.6.0 release surfaced, each proven before fixing.

- **a11y — the code painting's scrolling body gets a tab stop.** `pre.rc-code-body` scrolls (max-height, long lines) with nothing focusable inside — axe `scrollable-region-focusable`, serious; a keyboard user could not reach or scroll it. Mirrors the prose fence in `Md.tsx` (tab stop on the highlighted `<code>`). Unit test renders the painting and asserts the tab stop; it fails against the old code.
- **e2e — `follow-tail` fills the transcript until it really overflows.** The mock deals from a shuffled randomized deck, so three fixed turns could land a compact draw (`overflow=0`, CI 2026-08-29). The setup now sends until the overflow is there, bounded by one deck.
- **release — the packaged smoke isolates the daemon's own session store.** `scripts/packaged-pass.mjs` isolated the engines' state but not Mirafold's; on a machine with saved sessions the packaged daemon showed the session list instead of the agent picker and the first check timed out (v0.6.0 verification failed 0/1 for that reason alone). Now sets `MIRAFOLD_SESSION_DIR` + `MIRAFOLD_LOG_FILE=""` like the itest harness.

Tier-1 1032/1032, typecheck clean. Local follow-tail characterization on the fixed code is running (was 2 failures in 8 before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UUjZMBEiMqES5hXYkXH9P