### PR TITLE
sync: main → next after v0.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, Gemini CLI, or OpenCode — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Runbook step 7 — brings the `release: v0.6.1` bump and the release merge (25a929e) back to `next`. Fixed snapshot of `main`'s tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011UUjZMBEiMqES5hXYkXH9P