### PR TITLE
Release 0.8.0 review: four Codex-reviewer findings fixed

### DIFF
--- a/server/adapters/codex-events.ts
+++ b/server/adapters/codex-events.ts
@@ -14,7 +14,9 @@ const log = createLogger("codex-events");
 // Reaching the live-output ceiling is said once on the stream itself: an
 // interrupted command settles from that stream, and a silent cut would read
 // as "that was all the output" (release review 2026-09-01).
-export const STREAM_CAP_MARKER = `\n(… live output capped at ${Math.round(OUTPUT_CAP_BYTES / 1000)} KB — the settled result reports how much was cut …)`;
+export const streamCapMarker = (cap: number) =>
+  `\n(… live output capped at ${Math.round(cap / 1000)} KB — the settled result reports how much was cut …)`;
+export const STREAM_CAP_MARKER = streamCapMarker(OUTPUT_CAP_BYTES);
 
 // The `codex app-server` v2 notification stream (`item/*`, `turn/*`,
 // `thread/*`) normalized into SessionMsg. Shapes come from the binary's own
@@ -125,6 +127,7 @@ export class CodexEventMapper {
   // Streamed tool output (TS.11): UTF-8 bytes forwarded per running item, capped
   // like the final output so a chatty command cannot flood the ring.
   private streamed = new Map<string, number>();
+  private capMarked = new Set<string>();
   // Latest normalized fileChange snapshot per running item. Codex publishes
   // full structured snapshots, not textual patch deltas; the signature keeps
   // duplicate completion snapshots from repainting the same row.
@@ -151,6 +154,8 @@ export class CodexEventMapper {
       workspaceDir: string;
       modelName: () => string | undefined;
       providerDiagnostic: (value: unknown) => string;
+      /** Live-output ceiling per running item; tests set it, production inherits the env cap. */
+      outputCapBytes?: number;
     },
   ) {
     this.checklist = new ChecklistPainter(options.emit);
@@ -187,6 +192,7 @@ export class CodexEventMapper {
     this.prose.clear();
     this.phaseOf.clear();
     this.streamed.clear();
+    this.capMarked.clear();
     this.fileChangeSnapshots.clear();
     this.subagentProse.clear();
     this.thinkingStreamed.clear();
@@ -517,17 +523,26 @@ export class CodexEventMapper {
    *  for a row already announced, capped at the same size as final output. */
   private streamToolOutput(itemId: string, delta: string) {
     if (!delta || !this.announced.has(itemId)) return;
+    const cap = this.options.outputCapBytes ?? OUTPUT_CAP_BYTES;
     const sent = this.streamed.get(itemId) ?? 0;
-    if (sent >= OUTPUT_CAP_BYTES) return;
-    const room = OUTPUT_CAP_BYTES - sent;
+    // Past the ceiling nothing more streams — but the ceiling itself is said
+    // once, even when it was zero to begin with.
+    const marker = this.capMarked.has(itemId) ? "" : streamCapMarker(cap);
+    if (sent >= cap) {
+      if (marker) {
+        this.capMarked.add(itemId);
+        this.options.emit({ type: "tool_output_delta", id: itemId, text: marker });
+      }
+      return;
+    }
+    const room = cap - sent;
     const bytes = Buffer.from(delta, "utf8");
     const truncated = bytes.length > room;
     const reached = bytes.length >= room;
     const text = truncated ? utf8Prefix(bytes, room) : delta;
-    this.streamed.set(itemId, reached ? OUTPUT_CAP_BYTES : sent + bytes.length);
-    const marker = reached ? STREAM_CAP_MARKER : "";
-    if (!text && !marker) return;
-    this.options.emit({ type: "tool_output_delta", id: itemId, text: text + marker });
+    this.streamed.set(itemId, reached ? cap : sent + bytes.length);
+    if (reached) this.capMarked.add(itemId);
+    this.options.emit({ type: "tool_output_delta", id: itemId, text: text + (reached ? marker : "") });
   }
 
   /** A collab call (spawn / wait / send…) is a tool row named by the engine's

--- a/server/adapters/codex-events.ts
+++ b/server/adapters/codex-events.ts
@@ -11,6 +11,11 @@ import { convertMermaidCharts } from "./mermaid-chart";
 
 const log = createLogger("codex-events");
 
+// Reaching the live-output ceiling is said once on the stream itself: an
+// interrupted command settles from that stream, and a silent cut would read
+// as "that was all the output" (release review 2026-09-01).
+export const STREAM_CAP_MARKER = `\n(… live output capped at ${Math.round(OUTPUT_CAP_BYTES / 1000)} KB — the settled result reports how much was cut …)`;
+
 // The `codex app-server` v2 notification stream (`item/*`, `turn/*`,
 // `thread/*`) normalized into SessionMsg. Shapes come from the binary's own
 // schema (`codex app-server generate-json-schema`); the CA.1 spike in
@@ -517,10 +522,12 @@ export class CodexEventMapper {
     const room = OUTPUT_CAP_BYTES - sent;
     const bytes = Buffer.from(delta, "utf8");
     const truncated = bytes.length > room;
+    const reached = bytes.length >= room;
     const text = truncated ? utf8Prefix(bytes, room) : delta;
-    this.streamed.set(itemId, truncated ? OUTPUT_CAP_BYTES : sent + bytes.length);
-    if (!text) return;
-    this.options.emit({ type: "tool_output_delta", id: itemId, text });
+    this.streamed.set(itemId, reached ? OUTPUT_CAP_BYTES : sent + bytes.length);
+    const marker = reached ? STREAM_CAP_MARKER : "";
+    if (!text && !marker) return;
+    this.options.emit({ type: "tool_output_delta", id: itemId, text: text + marker });
   }
 
   /** A collab call (spawn / wait / send…) is a tool row named by the engine's
@@ -552,11 +559,20 @@ export class CodexEventMapper {
       typeof item.agentsStates === "object" && item.agentsStates !== null
         ? Object.entries(item.agentsStates as Record<string, { status?: unknown; message?: unknown }>)
         : [];
-    const lines = states.map(([thread, st]) => {
+    // Engine-sized fan-out: build lines only up to the output ceiling and
+    // say how many were left, instead of materializing every state first
+    // (release review 2026-09-01).
+    const lines: string[] = [];
+    let budget = OUTPUT_CAP_BYTES - 32; // room for the "… N more" line
+    for (const [thread, st] of states) {
       const status = typeof st?.status === "string" ? st.status : "?";
       const message = typeof st?.message === "string" && st.message ? ` — ${firstLine(st.message, 160)}` : "";
-      return `${thread}: ${status}${message}`;
-    });
+      const line = `${thread}: ${status}${message}`;
+      budget -= Buffer.byteLength(line, "utf8") + 1;
+      if (budget < 0) break;
+      lines.push(line);
+    }
+    if (lines.length < states.length) lines.push(`… ${states.length - lines.length} more`);
     const failed = states.some(([, st]) => st?.status === "errored" || st?.status === "notFound");
     // The state fan-out is engine-sized: capped like every other result.
     const capped = capOutput(lines.join("\n"));

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -11,6 +11,7 @@ import type { AppServerClient, AppServerSpawn, JsonRpcId } from "./codex-app-ser
 import { MIRAFOLD_MCP } from "./render-mcp-cmd";
 import { MIRAFOLD_CONTEXT } from "../render-tools";
 import { OUTPUT_CAP_BYTES } from "./types";
+import { STREAM_CAP_MARKER } from "./codex-events";
 
 // The Codex app-server notification→WireMsg mapping and the turn grammar, on
 // a scripted in-memory app-server — no engine, no network. The session is
@@ -1954,9 +1955,30 @@ test("streamed command output applies the final-output ceiling in UTF-8 bytes, n
     .filter((m) => m.type === "tool_output_delta" && m.id === "bytes")
     .map((m) => m.text)
     .join("");
-  assert.ok(Buffer.byteLength(streamed, "utf8") <= OUTPUT_CAP_BYTES);
-  assert.ok(Buffer.byteLength(streamed, "utf8") >= OUTPUT_CAP_BYTES - 3);
+  // The ceiling holds for the bytes, and crossing it is said exactly once —
+  // an interrupted command settles from this stream (release review 2026-09-01).
+  const body = streamed.replace(STREAM_CAP_MARKER, "");
+  assert.ok(Buffer.byteLength(body, "utf8") <= OUTPUT_CAP_BYTES);
+  assert.ok(Buffer.byteLength(body, "utf8") >= OUTPUT_CAP_BYTES - 3);
+  assert.equal(streamed.split(STREAM_CAP_MARKER).length - 1, 1, "the cap marker appears once");
   assert.doesNotMatch(streamed, /must not pass/);
+  s.close();
+});
+
+test("a stream that lands exactly on the ceiling is marked too, and stays silent after", async () => {
+  const exact = "a".repeat(OUTPUT_CAP_BYTES);
+  const { s, msgs, awaitTurnEnd } = makeSession([
+    ["turn/started", {}],
+    ["item/started", { item: { type: "commandExecution", id: "exact", command: "x", status: "inProgress" } }],
+    ["item/commandExecution/outputDelta", { itemId: "exact", delta: exact }],
+    ["item/commandExecution/outputDelta", { itemId: "exact", delta: "after the ceiling" }],
+    DONE,
+  ]);
+  s.pushPrompt("go");
+  await awaitTurnEnd();
+  const streamed = msgs.filter((m) => m.type === "tool_output_delta" && m.id === "exact").map((m) => m.text).join("");
+  assert.equal(streamed.split(STREAM_CAP_MARKER).length - 1, 1);
+  assert.doesNotMatch(streamed, /after the ceiling/);
   s.close();
 });
 
@@ -2051,7 +2073,12 @@ test("engine-sized completion text is capped on every result path (PR #80 review
     const res = msgs.find((m) => m.type === "tool_result" && m.id === id);
     assert.ok(res && res.type === "tool_result", `${id} resolved`);
     assert.ok(Buffer.byteLength(res.output, "utf8") <= OUTPUT_CAP_BYTES + 64, `${id} capped`);
-    assert.ok((res.truncatedBytes ?? 0) > 0, `${id} reports the elision`);
+    // The elision is reported either way: capOutput's byte count, or the
+    // collab fan-out's own "… N more" line (it stops materializing states at
+    // the ceiling rather than building them all first).
+    assert.ok((res.truncatedBytes ?? 0) > 0 || /… \d+ more$/.test(res.output), `${id} reports the elision`);
   }
+  const collab = msgs.find((m) => m.type === "tool_result" && m.id === "cb1");
+  assert.ok(collab && collab.type === "tool_result" && /… \d+ more$/.test(collab.output), "the fan-out was bounded before it was built");
   s.close();
 });

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -11,7 +11,7 @@ import type { AppServerClient, AppServerSpawn, JsonRpcId } from "./codex-app-ser
 import { MIRAFOLD_MCP } from "./render-mcp-cmd";
 import { MIRAFOLD_CONTEXT } from "../render-tools";
 import { OUTPUT_CAP_BYTES } from "./types";
-import { STREAM_CAP_MARKER } from "./codex-events";
+import { CodexEventMapper, STREAM_CAP_MARKER, streamCapMarker } from "./codex-events";
 
 // The Codex app-server notification→WireMsg mapping and the turn grammar, on
 // a scripted in-memory app-server — no engine, no network. The session is
@@ -2081,4 +2081,23 @@ test("engine-sized completion text is capped on every result path (PR #80 review
   const collab = msgs.find((m) => m.type === "tool_result" && m.id === "cb1");
   assert.ok(collab && collab.type === "tool_result" && /… \d+ more$/.test(collab.output), "the fan-out was bounded before it was built");
   s.close();
+});
+
+test("a zero live-output budget still says the ceiling was hit, once (review 2026-09-01)", () => {
+  const emitted: WireMsg[] = [];
+  const mapper = new CodexEventMapper({
+    emit: (m) => emitted.push(m as WireMsg),
+    workspaceDir: tmp,
+    modelName: () => undefined,
+    providerDiagnostic: (v) => String(v),
+    outputCapBytes: 0,
+  });
+  mapper.handle("turn/started", {});
+  mapper.handle("item/started", { item: { type: "commandExecution", id: "c0", command: "x", status: "inProgress" } });
+  mapper.handle("item/commandExecution/outputDelta", { itemId: "c0", delta: "first bytes" });
+  mapper.handle("item/commandExecution/outputDelta", { itemId: "c0", delta: "more bytes" });
+  const deltas = emitted
+    .filter((m): m is Extract<WireMsg, { type: "tool_output_delta" }> => m.type === "tool_output_delta" && m.id === "c0")
+    .map((m) => m.text);
+  assert.deepEqual(deltas, [streamCapMarker(0)], "exactly one marker, no output bytes");
 });

--- a/server/sessions/replay-ring.test.ts
+++ b/server/sessions/replay-ring.test.ts
@@ -136,3 +136,13 @@ test("superseding keeps fields an earlier partial tool_update carried (review 20
   assert.equal(kept.detail, "Updated a.ts", "the earlier update's detail survives");
   assert.deepEqual(kept.input, { changes: [{ path: "a.ts", kind: "update", diff: "+x" }] }, "the later update's input wins");
 });
+
+test("an explicitly-undefined field in a superseding tool_update does not erase the carried value (cold review 2026-09-01)", () => {
+  const { r } = ring();
+  r.offer({ type: "tool_use", name: "apply_patch", id: "p1", input: {} });
+  r.offer({ type: "tool_update", id: "p1", detail: "Updated a.ts" });
+  r.offer({ type: "tool_update", id: "p1", detail: undefined, input: { changes: [] } });
+  const kept = r.buffer.find((m) => m.type === "tool_update") as Extract<WireMsg, { type: "tool_update" }>;
+  assert.equal(kept.detail, "Updated a.ts");
+  assert.deepEqual(kept.input, { changes: [] });
+});

--- a/server/sessions/replay-ring.test.ts
+++ b/server/sessions/replay-ring.test.ts
@@ -124,3 +124,15 @@ test("only the latest tool_update per row is retained; a snapshot burst cannot e
   assert.equal(r.bytes, r.buffer.reduce((n, m) => n + msgBytes(m), 0), "the byte ledger stays exact");
   assert.equal(delivered.length, 7, "every update was still delivered live");
 });
+
+test("superseding keeps fields an earlier partial tool_update carried (review 2026-09-01)", () => {
+  const { r } = ring();
+  r.offer({ type: "tool_use", name: "apply_patch", id: "p1", input: { changes: [] } });
+  r.offer({ type: "tool_update", id: "p1", detail: "Updated a.ts" });
+  r.offer({ type: "tool_update", id: "p1", input: { changes: [{ path: "a.ts", kind: "update", diff: "+x" }] } });
+  const updates = r.buffer.filter((m) => m.type === "tool_update");
+  assert.equal(updates.length, 1);
+  const kept = updates[0] as Extract<WireMsg, { type: "tool_update" }>;
+  assert.equal(kept.detail, "Updated a.ts", "the earlier update's detail survives");
+  assert.deepEqual(kept.input, { changes: [{ path: "a.ts", kind: "update", diff: "+x" }] }, "the later update's input wins");
+});

--- a/server/sessions/replay-ring.test.ts
+++ b/server/sessions/replay-ring.test.ts
@@ -110,3 +110,17 @@ test("review 2026-08-29: a cursor canResume accepts is one the replay can actual
     assert.equal(tail[0]?.seq, after + 1, `resume after ${after} must replay from ${after + 1}, no hole`);
   }
 });
+
+test("only the latest tool_update per row is retained; a snapshot burst cannot evict its own row (release review 2026-09-01)", () => {
+  const { r, delivered } = ring();
+  r.offer({ type: "tool_use", name: "apply_patch", id: "p1", input: { changes: [] } });
+  for (let i = 1; i <= 5; i++) {
+    r.offer({ type: "tool_update", id: "p1", input: { changes: [{ path: "a", kind: "update", diff: "x".repeat(i * 100) }] } });
+  }
+  r.offer({ type: "tool_update", id: "p2", input: {} });
+  const updates = r.buffer.filter((m) => m.type === "tool_update");
+  assert.deepEqual(updates.map((m) => m.id), ["p1", "p2"], "one retained update per row");
+  assert.ok(JSON.stringify(updates[0]).includes("x".repeat(500)), "the latest snapshot is the one kept");
+  assert.equal(r.bytes, r.buffer.reduce((n, m) => n + msgBytes(m), 0), "the byte ledger stays exact");
+  assert.equal(delivered.length, 7, "every update was still delivered live");
+});

--- a/server/sessions/replay-ring.ts
+++ b/server/sessions/replay-ring.ts
@@ -146,11 +146,21 @@ export class ReplayRing {
     // the latest per row is worth retaining: a burst of growing patch
     // snapshots must not multiply through the ring and evict the very row
     // it refreshes (release review 2026-09-01). Live delivery is untouched.
+    let retained: SessionMsg = msg;
     if (msg.type === "tool_update") {
-      const stale = this.buffer.findIndex((m) => m.type === "tool_update" && m.id === msg.id);
-      if (stale >= 0) this.bytes -= msgBytes(this.buffer.splice(stale, 1)[0]);
+      const id = msg.id;
+      const stale = this.buffer.findIndex((m) => m.type === "tool_update" && m.id === id);
+      if (stale >= 0) {
+        const [prior] = this.buffer.splice(stale, 1);
+        this.bytes -= msgBytes(prior);
+        // `detail` and `input` are independently optional on the wire, so the
+        // one retained update carries every field the row has been told,
+        // latest value winning — a late attacher sees what a live viewport saw.
+        const { seq: _seq, ...carried } = prior as SessionMsg & { seq?: number };
+        retained = { ...carried, ...msg } as SessionMsg;
+      }
     }
-    const stamped = { ...msg, seq: this.nextSeq++ };
+    const stamped = { ...retained, seq: this.nextSeq++ };
     this.buffer.push(stamped);
     this.bytes += msgBytes(stamped);
     this.trim();

--- a/server/sessions/replay-ring.ts
+++ b/server/sessions/replay-ring.ts
@@ -142,6 +142,14 @@ export class ReplayRing {
    *  tool input) stay shared, so an adapter must not mutate a message after
    *  emitting it. Returns the stamped copy. */
   push(msg: SessionMsg): SessionMsg {
+    // A tool_update replaces its row's structured input wholesale, so only
+    // the latest per row is worth retaining: a burst of growing patch
+    // snapshots must not multiply through the ring and evict the very row
+    // it refreshes (release review 2026-09-01). Live delivery is untouched.
+    if (msg.type === "tool_update") {
+      const stale = this.buffer.findIndex((m) => m.type === "tool_update" && m.id === msg.id);
+      if (stale >= 0) this.bytes -= msgBytes(this.buffer.splice(stale, 1)[0]);
+    }
     const stamped = { ...msg, seq: this.nextSeq++ };
     this.buffer.push(stamped);
     this.bytes += msgBytes(stamped);

--- a/server/sessions/replay-ring.ts
+++ b/server/sessions/replay-ring.ts
@@ -145,7 +145,8 @@ export class ReplayRing {
     // A tool_update replaces its row's structured input wholesale, so only
     // the latest per row is worth retaining: a burst of growing patch
     // snapshots must not multiply through the ring and evict the very row
-    // it refreshes (release review 2026-09-01). Live delivery is untouched.
+    // it refreshes (release review 2026-09-01). A live viewport receives the
+    // same merged copy — idempotent for it, since it applies only present fields.
     let retained: SessionMsg = msg;
     if (msg.type === "tool_update") {
       const id = msg.id;
@@ -157,7 +158,10 @@ export class ReplayRing {
         // one retained update carries every field the row has been told,
         // latest value winning — a late attacher sees what a live viewport saw.
         const { seq: _seq, ...carried } = prior as SessionMsg & { seq?: number };
-        retained = { ...carried, ...msg } as SessionMsg;
+        // An explicitly-undefined field in the newer update is "unchanged",
+        // never "erase what the earlier one carried".
+        const present = Object.fromEntries(Object.entries(msg).filter(([, value]) => value !== undefined));
+        retained = { ...carried, ...present } as SessionMsg;
       }
     }
     const stamped = { ...retained, seq: this.nextSeq++ };

--- a/web/src/transcript-projection.test.ts
+++ b/web/src/transcript-projection.test.ts
@@ -650,3 +650,20 @@ test("a turn that dies by error orphans anchorless narration the same as turn_en
   const texts = result.snapshot.rows.filter((r): r is TextRow => r.kind === "text" && r.role === "assistant").map((r) => r.text);
   assert.deepEqual(texts, ["child says hi\n", "**Error:** adapter crashed"]);
 });
+
+test("a request-scoped error (terminal: false) ends no turn, so it orphans nothing (cold review 2026-09-01)", () => {
+  const result = createTranscriptProjection().apply(
+    [
+      { type: "user_prompt", text: "go" },
+      { type: "text_delta", text: "child hi\n", parentId: "task" },
+      { type: "error", message: "requests are arriving too fast", terminal: false },
+      { type: "tool_use", name: "Agent", detail: "delegate", id: "task", input: {} },
+      { type: "tool_result", output: "done", id: "task" },
+      { type: "turn_end" },
+    ] as ZoneMsg[],
+    () => 0,
+  );
+  const rows = result.snapshot.rows;
+  assert.equal(rows.filter((r) => r.kind === "text" && r.role === "assistant" && r.text.startsWith("child")).length, 0, "not narrated inline");
+  assert.equal(rows.filter((r) => r.kind === "subagent-deck").length, 1, "grouped under its anchor once it lands");
+});

--- a/web/src/transcript-projection.test.ts
+++ b/web/src/transcript-projection.test.ts
@@ -637,3 +637,16 @@ test("an orphaned subagent's reasoning is a thinking row, never the assistant sp
   assert.equal(rows.filter((r) => r.kind === "text" && r.role === "assistant").length, 0, "reasoning never reads as prose");
   assert.deepEqual(rows.filter((r) => r.kind === "thinking").map((r) => r.kind === "thinking" && r.text), ["secret child reasoning"]);
 });
+
+test("a turn that dies by error orphans anchorless narration the same as turn_end (review 2026-09-01)", () => {
+  const result = createTranscriptProjection().apply(
+    [
+      { type: "user_prompt", text: "go" },
+      { type: "text_delta", text: "child says hi\n", parentId: "evicted-task" },
+      { type: "error", message: "adapter crashed" },
+    ] as ZoneMsg[],
+    () => 0,
+  );
+  const texts = result.snapshot.rows.filter((r): r is TextRow => r.kind === "text" && r.role === "assistant").map((r) => r.text);
+  assert.deepEqual(texts, ["child says hi\n", "**Error:** adapter crashed"]);
+});

--- a/web/src/transcript-projection.test.ts
+++ b/web/src/transcript-projection.test.ts
@@ -598,3 +598,42 @@ test("streamed output survives an interruption and the settled row releases the 
   assert.equal(done.output, "a\nok\n");
   assert.equal(done.streamed, undefined, "the authoritative result releases the streamed copy");
 });
+
+test("subagent narration whose anchor row never arrived is shown inline, not dropped (release review 2026-09-01)", () => {
+  const result = createTranscriptProjection().apply(
+    [
+      { type: "user_prompt", text: "go" },
+      { type: "text_delta", text: "child says hi\n", parentId: "evicted-task" },
+      { type: "turn_end" },
+    ] as ZoneMsg[],
+    () => 0,
+  );
+  const texts = result.snapshot.rows.filter((r): r is TextRow => r.kind === "text" && r.role === "assistant").map((r) => r.text);
+  assert.deepEqual(texts, ["child says hi\n"]);
+  // With the anchor present the same narration groups under it, as before.
+  const anchored = createTranscriptProjection().apply(
+    [
+      { type: "user_prompt", text: "go" },
+      { type: "tool_use", name: "Agent", detail: "delegate", id: "task", input: {} },
+      { type: "text_delta", text: "child says hi\n", parentId: "task" },
+      { type: "tool_result", output: "done", id: "task" },
+      { type: "turn_end" },
+    ] as ZoneMsg[],
+    () => 0,
+  );
+  assert.equal(anchored.snapshot.rows.filter((r) => r.kind === "text" && r.role === "assistant").length, 0);
+});
+
+test("an orphaned subagent's reasoning is a thinking row, never the assistant speaking (cold review 2026-09-01)", () => {
+  const result = createTranscriptProjection().apply(
+    [
+      { type: "user_prompt", text: "go" },
+      { type: "thinking_delta", text: "secret child reasoning", parentId: "evicted-task" },
+      { type: "turn_end" },
+    ] as ZoneMsg[],
+    () => 0,
+  );
+  const rows = result.snapshot.rows;
+  assert.equal(rows.filter((r) => r.kind === "text" && r.role === "assistant").length, 0, "reasoning never reads as prose");
+  assert.deepEqual(rows.filter((r) => r.kind === "thinking").map((r) => r.kind === "thinking" && r.text), ["secret child reasoning"]);
+});

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -305,6 +305,18 @@ const orphanNarration = (entry: SubagentProseRow): TextRow | ThinkingRow =>
     ? { kind: "thinking", id: entry.id, text: entry.text, done: true }
     : { kind: "text", id: entry.id, role: "assistant", text: entry.text, done: true, phase: "commentary" };
 
+/** At a turn's end, narration whose anchor row is still absent is never
+ *  getting one (evicted before this viewport attached): mark it orphaned so
+ *  the snapshot narrates it inline. Entries already anchored are untouched. */
+function orphanAnchorless(entries: readonly TranscriptEntry[]): TranscriptEntry[] {
+  const anchoredToolIds = new Set(entries.flatMap((entry) => (entry.kind === "tool" ? [entry.toolId] : [])));
+  return entries.map((entry) =>
+    entry.kind === "subtext" && !entry.orphaned && !anchoredToolIds.has(entry.parentId)
+      ? { ...entry, orphaned: true }
+      : entry,
+  );
+}
+
 function buildSnapshot(
   entries: readonly TranscriptEntry[],
   previous: TranscriptSnapshot,
@@ -681,12 +693,8 @@ export function createTranscriptProjection(): TranscriptProjection {
         streamingId = null;
         subtextIds.clear();
         const batchId = openToolBatches.shift() ?? orphanToolBatch--;
-        const anchoredToolIds = new Set(entries.flatMap((entry) => (entry.kind === "tool" ? [entry.toolId] : [])));
-        entries = entries.map((entry) => {
+        entries = orphanAnchorless(entries).map((entry) => {
           if (entry.kind === "text" && entry.id === id) return { ...entry, done: true };
-          if (entry.kind === "subtext" && !entry.orphaned && !anchoredToolIds.has(entry.parentId)) {
-            return { ...entry, orphaned: true };
-          }
           if (entry.kind === "tool" && entry.batchId === batchId) {
             return {
               ...entry,
@@ -711,9 +719,11 @@ export function createTranscriptProjection(): TranscriptProjection {
         return true;
       }
       case "error": {
+        // A terminal error ends the turn without a turn_end (the adapter-crash
+        // path): anchorless narration is just as orphaned here.
         streamingId = null;
         entries = [
-          ...entries,
+          ...orphanAnchorless(entries),
           {
             kind: "text",
             id: nextTranscriptId++,

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -65,6 +65,9 @@ export type SubagentProseRow = {
   parentId: string;
   variant: "text" | "thinking";
   text: string;
+  /** Its anchor row was still absent when its turn ended — the row was
+   *  evicted from the replay ring before this viewport attached. */
+  orphaned?: boolean;
 };
 
 export type ThinkingRow = {
@@ -295,6 +298,13 @@ function pickerRow(
   return { ...entry, active };
 }
 
+// A subagent's reasoning stays reasoning (collapsed, never the assistant's
+// voice); its narration reads as commentary.
+const orphanNarration = (entry: SubagentProseRow): TextRow | ThinkingRow =>
+  entry.variant === "thinking"
+    ? { kind: "thinking", id: entry.id, text: entry.text, done: true }
+    : { kind: "text", id: entry.id, role: "assistant", text: entry.text, done: true, phase: "commentary" };
+
 function buildSnapshot(
   entries: readonly TranscriptEntry[],
   previous: TranscriptSnapshot,
@@ -335,7 +345,17 @@ function buildSnapshot(
 
   const rows: OutputZoneRow[] = [];
   for (const entry of entries) {
-    if (entry.kind === "subtext") continue;
+    if (entry.kind === "subtext") {
+      // Anchorless when its turn ended: the anchor is never coming (evicted
+      // from the replay ring before attach) — narrate inline rather than
+      // nowhere. Before the turn ends it stays hidden, since an anchor may
+      // still be on its way.
+      if (entry.orphaned) {
+        const prev = previousById.get(entry.id);
+        rows.push(prev && (prev.kind === "text" || prev.kind === "thinking") && prev.text === entry.text ? prev : orphanNarration(entry));
+      }
+      continue;
+    }
     if (entry.kind === "thinking" || entry.kind === "text") {
       if (!compactedTools.hidden.has(entry.id)) rows.push(entry);
       continue;
@@ -661,8 +681,12 @@ export function createTranscriptProjection(): TranscriptProjection {
         streamingId = null;
         subtextIds.clear();
         const batchId = openToolBatches.shift() ?? orphanToolBatch--;
+        const anchoredToolIds = new Set(entries.flatMap((entry) => (entry.kind === "tool" ? [entry.toolId] : [])));
         entries = entries.map((entry) => {
           if (entry.kind === "text" && entry.id === id) return { ...entry, done: true };
+          if (entry.kind === "subtext" && !entry.orphaned && !anchoredToolIds.has(entry.parentId)) {
+            return { ...entry, orphaned: true };
+          }
           if (entry.kind === "tool" && entry.batchId === batchId) {
             return {
               ...entry,

--- a/web/src/transcript-projection.ts
+++ b/web/src/transcript-projection.ts
@@ -720,10 +720,12 @@ export function createTranscriptProjection(): TranscriptProjection {
       }
       case "error": {
         // A terminal error ends the turn without a turn_end (the adapter-crash
-        // path): anchorless narration is just as orphaned here.
+        // path): anchorless narration is just as orphaned here. A
+        // request-scoped error (terminal: false) ends nothing — same reading
+        // as turn-busy and the daemon's session state.
         streamingId = null;
         entries = [
-          ...orphanAnchorless(entries),
+          ...(msg.terminal === false ? entries : orphanAnchorless(entries)),
           {
             kind: "text",
             id: nextTranscriptId++,


### PR DESCRIPTION
Fixes for the legitimate findings the Codex reviewer posted on release PR #82, routed through `next` first per docs/RELEASING.md; the release branch takes this branch after merge.

- replay ring retains only the latest `tool_update` per row (patch-snapshot bursts)
- live-output ceiling is marked once on the stream (interrupted commands)
- collab fan-out bounded before materializing (`… N more`)
- orphaned subagent narration shown inline after its turn ends; reasoning stays a thinking row

The fifth finding (top-level `compact_boundary`) was verified false against the SDK types. Each fix carries a test shown to fail on revert; cold-reviewed. Tier 1 1101/1101, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VgEDp11LAc2DuWSuWgwC55