### PR TITLE
release: v0.8.1 hotfix

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -3863,15 +3863,17 @@ command output not streamed; a dozen notification kinds unhandled.
 - [x] **TS.10 — Image views** — done 2026-08-31 (`view_image`/`image_generation` rows, the picture painted inline through the image tool's own jail and byte cap; outside the workspace the row stands alone). `imageView` → a `view_image path` row plus
   the image itself painted inline (workspace-jailed, byte-capped, the
   existing render_image path) — faithful and better than the terminal.
-- [x] **TS.11 — Streamed command output** — done 2026-08-31 (additive `tool_output_delta`; the running row's head carries the last line, its body the stream; capped like final output; Mirafold process-locally enables current Codex's `apply_patch_streaming_events`, whose `patchUpdated` snapshots refresh a file-change row through additive `tool_update`; `turn/diff` remains classified ignored — the Codex ledger's unmapped lists are empty). Additive wire
+- [x] **TS.11 — Streamed command output** — done 2026-08-31 (additive `tool_output_delta`; the running row's head carries the last line, its body the stream; capped like final output; `patchUpdated` snapshots refresh a file-change row through additive `tool_update` when the engine emits them; the stable completed file-change item remains authoritative; `turn/diff` remains classified ignored — the Codex ledger's unmapped lists are empty). Additive wire
   `tool_output_delta { id, text, parentId? }` from
   `item/commandExecution/outputDelta`; the browser appends to the running
   row; `tool_result` still closes it. Current Codex no longer emits the
   deprecated `item/fileChange/outputDelta`: its full
   `item/fileChange/patchUpdated` snapshots replace one announced patch row's
   detail/input through `tool_update`, and completion closes that same row.
-  The feature-gated notification is enabled by a process-local `-c` override,
-  never by changing the user's Codex configuration.
+  The release initially enabled the feature-gated notification through a
+  process-local `-c` override. CF.HF removed that override after Codex 0.152
+  began intentionally warning about the under-development feature; stable
+  completion still carries and paints the full structured diff.
 - [x] **TS.12 — The other engines' guards** — done 2026-08-31, with one honest gap: Claude's ledger is compile-time exhaustive (`compact_boundary` was already surfaced; `tool_progress` and `task_*` stay unmapped → reported when they arrive); OpenCode: the adapter exports its handled/ignored ledgers and a Tier-4 test pulls the server's own OpenAPI document (`/doc`) and fails on any unclassified event/part kind — **not runnable on this machine: the global `opencode` install is broken (its postinstall never fetched the platform binary), so the test skips with that reason; Kyle's OpenCode sessions on 08-13/08-18 predate the break**; Gemini: the runtime guard only (sunset, no live tier). Claude: an exhaustive ledger
   `satisfies Record<SDKMessage["type"], "handled" | "ignored">` (compile
   error on an SDK bump that adds a kind) + `compact_boundary` surfaced as
@@ -3946,7 +3948,10 @@ here, not chased on this branch.
   additive, checkpointed `tool_update` messages (the retired textual event
   remains version-skew compatibility, not the live claim); (4) Mirafold now
   process-locally enables the installed engine's otherwise-disabled
-  `apply_patch_streaming_events`, so those current events actually arrive;
+  `apply_patch_streaming_events`, so those current events actually arrived
+  in 0.8.0; CF.HF later reversed that release choice because current Codex
+  correctly labels the feature unstable, while stable completion preserves
+  the final structured diff;
   (5) failed or unsynthesizable Mirafold render calls fall back to honest tool rows in
   Claude, Codex, and Gemini, matching OpenCode; (6) unified-diff hunk content
   beginning `--`/`++` is no longer mistaken for file headers; (7) expanded
@@ -4029,6 +4034,44 @@ named from daily use, each pinned in Tier 3 and falsified both ways:
   caught a stuck-empty-dock class (fixed, CF.2 wording above); the
   bughunt found and fixed the dead-session key leak. Gates on the final
   tree: typecheck; Tier 1 1,097/1,097; visual 11/11; Tier 3 130/130.
+
+- [x] **CF.HF — v0.8.0 cross-agent startup/event corrective pass
+  (2026-09-01, complete)** — branch
+  `fix/codex-mcp-startup-handshake` from current `next`. Verified against the
+  captured Codex rollout and installed Codex 0.152 / Gemini CLI 0.57 /
+  OpenCode 1.18.25 contracts. Seven confirmed classes are regression-pinned
+  and fixed: (1) remove Mirafold's forced under-development Codex
+  `apply_patch_streaming_events` flag and its startup warning while retaining
+  final structured diffs; (2) make the injected Codex renderer required and
+  surface its exact startup-status diagnostic; (3) replace the false
+  "ALWAYS available" prompt with one bounded, protocol-correct discovery pass
+  that forbids resource-list APIs; (4) kill a rejected Codex app-server before
+  a retry can orphan it; (5) map Gemini 0.57 warning/error severity without
+  ending a live turn and surface fatal `result(status:"error")` payloads;
+  (6) remove Gemini's `--allowed-mcp-server-names mirafold` flag, which was
+  excluding every user-configured MCP server rather than merely trusting ours;
+  (7) make OpenCode reject startup when its injected renderer reports failure
+  or misses the shared deadline instead of knowingly sending a model prompt
+  with zero render tools. Claude's in-process renderer and changed event paths
+  have no corresponding confirmed defect. Residual, named: Gemini's
+  `stream-json` protocol publishes no per-server MCP startup state and its
+  generic stderr hint becomes ambiguous once the user's MCP servers are
+  correctly inherited, so Mirafold cannot honestly hard-require only its
+  renderer without an upstream status channel. The captured renderer's
+  low-level connection closure did not recur in 30 fresh raw MCP handshakes
+  or 60 fresh Codex thread starts, so no speculative transport change was
+  made; required startup now prevents inference and retry spirals when that
+  failure does occur. Focused gates are green:
+  Codex/protocol 85/85, Gemini 36/36, OpenCode 63/63. Full gates are green:
+  typecheck, Tier 1 1113/1113, production build, and render-MCP integration
+  5/5, server integration 161/161, and production-browser end-to-end 130/130.
+  The exact branch tarball passed the global-install packaged smoke 9/9. One
+  real packaged Codex subscription turn repeated the captured graph-only
+  request: it completed with four charts and no unstable-feature warning,
+  renderer failure, resource-list retry, unexpected permission, or browser
+  error. The required fresh-agent cold review covered all 13 changed files
+  and the surrounding lifecycles against the exact installed protocol
+  contracts; it returned no confirmed findings and changed nothing.
 
 **Open records (Kyle's calls):**
 - **Intermittent:** the artifact-pin e2e failed once in eight clean

--- a/PLAN.md
+++ b/PLAN.md
@@ -4035,7 +4035,7 @@ named from daily use, each pinned in Tier 3 and falsified both ways:
   bughunt found and fixed the dead-session key leak. Gates on the final
   tree: typecheck; Tier 1 1,097/1,097; visual 11/11; Tier 3 130/130.
 
-- [x] **CF.HF — v0.8.0 cross-agent startup/event corrective pass
+- [x] **CF.HF — v0.8.1 cross-agent startup/event hotfix
   (2026-09-01, complete)** — branch
   `fix/codex-mcp-startup-handshake` from current `next`. Verified against the
   captured Codex rollout and installed Codex 0.152 / Gemini CLI 0.57 /
@@ -4072,6 +4072,13 @@ named from daily use, each pinned in Tier 3 and falsified both ways:
   error. The required fresh-agent cold review covered all 13 changed files
   and the surrounding lifecycles against the exact installed protocol
   contracts; it returned no confirmed findings and changed nothing.
+
+- [ ] **CF.HF.REL — publish v0.8.1 (2026-09-01, in progress)** — PR #86
+  merged the reviewed repair into `next`; `release/0.8.1` was cut from the
+  v0.8.0 `main` tip and contains only that repair plus the package-version
+  bump. Release-branch gates, the PR into `main`, signed tag, registry-byte
+  verification, published-package smoke, and fixed-snapshot `main` → `next`
+  sync remain.
 
 **Open records (Kyle's calls):**
 - **Intermittent:** the artifact-pin e2e failed once in eight clean

--- a/docs/ADAPTERS.md
+++ b/docs/ADAPTERS.md
@@ -266,15 +266,16 @@ them. The rules, for the next adapter author:
 | Tool records (`tool_use`/`tool_result`) | ✅ full input, diffs | ✅ (`command_execution`, `file_change`, `mcp_tool_call`, `web_search`; only `status: "failed"` maps to `isError` — a completed command with a nonzero exit stays non-error, its exit code annotated in the output, matching the Codex TUI) | ✅ (tool parts; built-in `write`/`edit` normalize to the shared `Write` code painter / `Edit` diff painter with workspace-relative paths; error output capped by `capOutput` like success) | ✅ | ✅ |
 | Subagent lane (`parentId` on calls, prose, asks — the subagent deck; Phase SA) | ✅ calls (`parent_tool_use_id`) + prose from parent-tagged COMPLETE messages (the SDK never streams subagent token deltas — SA.0 probe), budget-capped; asks ride the parent `canUseTool` unattributed | ⚠ partial (TS.9): collab calls (`spawn_agent`/`wait`/`send_message`…) are engine-named rows carrying the prompt and each child's state; a child's lifecycle (`subAgentActivity`) narrates under its spawn row via `parentId`; the child's INNER calls and prose still need per-thread `app-server` subscriptions the adapter does not open | ✅ full lane: child sessions on the same global stream map to the spawn part id (`state.metadata.sessionId` join, transitive for configured nesting), prose budget-capped, `permission.asked` surfaced ATTRIBUTED (`permission_request.parentId`) and replied via the session-agnostic `POST /permission/{requestID}/reply`; a child's render call gets an honest tool record, never a painting | ❌ the headless stream exposes no subagent lane | ✅ scripted three-spawn fan-out with narration |
 | Live todo checklist (`render` todo-list) | ✅ (TaskCreate/Update fold) | ✅ (`todo_list` item) | ✅ (`todo.updated`) | ❌ | ✅ |
-| Interactive permissions (`permission_request`) | ✅ full round-trip via `canUseTool` + inherited `settings.json` | ✅ full round-trip: `item/*/requestApproval` → the bar → `{decision}` / granted profile; fail-closed on timeout/close; PLUS a folder-trust ask before the first `thread/start` | ✅ full round-trip: `permission.asked` → reply `once`/`reject` (never `always` — that would persist into the user's own OpenCode state) | ❌ headless can't prompt → user's own tool approvals inherited; only our render server is scoped-allowed | ✅ (`dangerous` keyword) |
+| Interactive permissions (`permission_request`) | ✅ full round-trip via `canUseTool` + inherited `settings.json` | ✅ full round-trip: `item/*/requestApproval` → the bar → `{decision}` / granted profile; fail-closed on timeout/close; PLUS a folder-trust ask before the first `thread/start` | ✅ full round-trip: `permission.asked` → reply `once`/`reject` (never `always` — that would persist into the user's own OpenCode state) | ❌ headless can't prompt → user's own tool approvals inherited; only the injected render-server entry carries `trust: true` | ✅ (`dangerous` keyword) |
 | Usage (`usage` msg) | ✅ tokens + cumulative `total_cost_usd` | ✅ tokens (`cached_input_tokens` is a subset of input — never re-added) | ✅ tokens + cost per assistant message, summed into one per-turn `usage` | ✅ per-model token breakdown | ✅ |
 | Interrupt | SDK `interrupt()` | `turn/interrupt`; discovered-local turns also use it at the configurable eight-minute outer deadline | `POST /session/:id/abort`; the grace deadline starts independently of that finite HTTP call. If idle misses the deadline, fork the conversation to a new engine-session id before the next prompt so a late old idle cannot end it; bounded fork failure degrades to a disclosed fresh session | kill child process | clear timers |
-| Render-MCP injection | **in-process** SDK MCP server (`render-tools.ts`) | subprocess stdio MCP via `-c mcp_servers.*` on the app-server spawn (`render-mcp.ts`) | subprocess stdio MCP via the **`OPENCODE_CONFIG_CONTENT` env var** (additive merge; no file the user owns is read, written, or created) | subprocess stdio MCP via **per-session `<cwd>/.gemini/settings.json`** (merged non-destructively; note: drops a file in the user's project dir) | emits `render` directly |
+| Render-MCP injection | **in-process** SDK MCP server (`render-tools.ts`) | required subprocess stdio MCP via `-c mcp_servers.*` on the app-server spawn (`render-mcp.ts`); `thread/start` rejects before inference on failure | subprocess stdio MCP via the **`OPENCODE_CONFIG_CONTENT` env var** (additive merge; no file the user owns is read, written, or created); startup waits for `GET /mcp` to report it connected | subprocess stdio MCP via **per-session `<cwd>/.gemini/settings.json`** (merged non-destructively; note: drops a file in the user's project dir) | emits `render` directly |
 | Model override env | `DEFAULT_MODEL` | `CODEX_MODEL` | `OPENCODE_MODEL` (`provider/model`; a bare id can't name a provider so it pins nothing) | `GEMINI_MODEL` | — |
 | Credential signal (`agentHasCredentials`) | `ANTHROPIC_API_KEY` \|\| `ANTHROPIC_AUTH_TOKEN` \|\| `ANTHROPIC_BASE_URL` | `OPENAI_API_KEY` \|\| `$CODEX_HOME/auth.json` (ChatGPT login) | binary present: a stored `auth.json` → `api-key`, else the free Zen gateway → `gateway`; the TRUE per-provider kind is classified at session start from the running engine's catalog | `GEMINI_API_KEY` \|\| `GOOGLE_API_KEY` (individual-account Google login stopped serving Gemini CLI requests in 2026) | none → mock is the fallback for every agent |
 
 Known asymmetries, accepted deliberately (each is I3 at work, not debt):
-Gemini has no thinking stream and pays a process spawn per turn. Codex moved to
+Gemini has no thinking stream, pays a process spawn per turn, and its
+`stream-json` surface exposes no per-server MCP startup status. Codex moved to
 the `app-server` protocol (Phase CA, 2026-08-25), which closed its two old
 gaps — it now streams token deltas and carries the interactive approval
 round-trip — so Codex's permission bar is live; what a headless Gemini still
@@ -330,7 +331,9 @@ for a tool rarely paints (Phase TS, 2026-08-30):
   `ALL_TOOLS` (≥0.147; custom/local providers still see them directly). The
   adapter's developer instructions therefore open with a where-are-the-tools
   note (`codex-prompt.ts`) that names all three paths with exact call shapes
-  and makes loading the tool the first step of any structured reply.
+  and makes loading the tool the first step of any structured reply. The note
+  also forbids resource-list APIs as tool discovery and stops after one failed
+  pass; it never tells the model that an absent tool is secretly present.
   A 16-turn replay of real prompts (PLAN TS.3) measured that note — and a
   per-turn paint reminder tried after it (TS.5, reverted) — as no-ops:
   Codex paints on early advisory turns and then answers in prose for the
@@ -387,19 +390,20 @@ ceiling is the same UTF-8 byte budget as final tool output—never JavaScript
 character count.
 
 Current Codex does not emit the deprecated `item/fileChange/outputDelta`.
-Instead, each `item/fileChange/patchUpdated` carries the latest complete
-structured patch snapshot when `features.apply_patch_streaming_events` is
-enabled. Mirafold enables that feature only for its app-server process through
-a `-c` override; it does not alter the user's Codex configuration. Additive
-`tool_update` replaces the announced row's detail/input in place, so an
-initially empty `fileChange` becomes the real multi-file diff as it evolves
-and the completed item closes that same row. The retired textual event remains
-accepted only for older Codex version skew; it is not the basis of the
-current-engine fidelity claim.
+Its stable `item/started` / `item/completed` file-change items carry structured
+changes, and the completed item is the authoritative full diff. Codex also has
+an intermediate `item/fileChange/patchUpdated` snapshot behind the
+under-development `apply_patch_streaming_events` feature. Mirafold does not
+enable that unstable feature: Codex 0.152 intentionally warns whenever a
+client does. The mapper still accepts `patchUpdated` if the user's own engine
+emits it, using additive `tool_update` to refresh the open row, but final diff
+painting never depends on it. The retired textual event remains accepted only
+for older Codex version skew.
 
 **Edit painting (TS.6).** `Write` shows the new content; `Edit` and the
 registry's `render_diff` share the line differ; Codex `apply_patch` shows one
-normalized block per file, refreshed from its live patch snapshots.
+normalized block per file from the stable completed item (and refreshes it
+earlier when the engine happens to emit live patch snapshots).
 Unified-diff file headers are ignored only before
 the first hunk, so changed source beginning with `--` or `++` remains visible,
 and a move heading names both paths. The shared differ trims equal edges and
@@ -412,8 +416,10 @@ Adapter obligations for either path:
 1. Auto-allow **only our** render server (Claude: `mcp__ui__*` in
    `permissions.ts`; Codex: per-server `default_tools_approval_mode`; OpenCode:
    the render server is the only MCP added via `OPENCODE_CONFIG_CONTENT` and the
-   user's own permission rules otherwise apply; Gemini:
-   `--allowed-mcp-server-names mirafold`). Never blanket-approve the user's other
+   user's own permission rules otherwise apply; Gemini: `trust: true` on only
+   the injected project entry). Never pass Gemini's
+   `--allowed-mcp-server-names mirafold`: that flag is a server allowlist and
+   silently removes every user-configured MCP server. Never blanket-approve the user's other
    tools to make ours run — that's forcing a posture the terminal doesn't have.
    OpenCode advertises MCP tools as `mirafold_<tool>`, so the adapter recognizes
    its own render calls by the `mirafold_` prefix and paints them, suppressing

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A faithful browser re-skin of the terminal coding agent you already use — Claude Code, Codex, Gemini CLI, or OpenCode — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",

--- a/server/adapters/codex-binding.ts
+++ b/server/adapters/codex-binding.ts
@@ -61,9 +61,9 @@ export function codexEngineDefaultModel(
 }
 
 /** The per-process config every Codex session passes as `-c` overrides:
- *  Mirafold's render MCP server, live structured patch snapshots, the
- *  provider the pick promised, and — for an API-key pick — the auth mode
- *  that makes app-server honor the env key.
+ *  Mirafold's required render MCP server, the provider the pick promised,
+ *  and — for an API-key pick — the auth mode that makes app-server honor the
+ *  env key.
  *  Everything else (sandbox, approvals, model defaults, the user's own MCP
  *  servers) is inherited from `~/.codex/config.toml` untouched. */
 export function codexSessionConfig(
@@ -71,14 +71,15 @@ export function codexSessionConfig(
   binding: Record<string, unknown>,
 ): Record<string, unknown> {
   return {
-    // Current app-server keeps structured patchUpdated notifications behind
-    // this feature. Process-local only: completion remains the authoritative
-    // fallback, and no value is persisted into the user's config.toml.
-    features: { apply_patch_streaming_events: true },
     mcp_servers: {
       [MIRAFOLD_MCP]: {
         command: RENDER_MCP.command,
         args: RENDER_MCP.args,
+        // A turn whose renderer never initialized cannot honor Mirafold's
+        // structured-output contract. Codex's stable `required` setting makes
+        // thread/start wait for this server and reject before model inference
+        // if startup fails; the next prompt can retry with a fresh process.
+        required: true,
         // Mirafold's own render tools only emit validated UI messages; the
         // headless engine cannot prompt for their approval.
         default_tools_approval_mode: "approve",

--- a/server/adapters/codex-events.ts
+++ b/server/adapters/codex-events.ts
@@ -255,6 +255,29 @@ export class CodexEventMapper {
           this.options.emit({ type: "notice", text: this.options.providerDiagnostic(p["message"]), kind: "warning", source: "codex" });
         }
         break;
+      case "mcpServer/startupStatus/updated":
+        // User-configured MCP servers remain Codex's administration. The one
+        // server Mirafold itself injects is different: without it the model
+        // cannot honor the render guidance, so surface Codex's exact startup
+        // diagnostic instead of leaving the user with missing tools.
+        if (
+          p["name"] === MIRAFOLD_MCP &&
+          p["status"] === "failed"
+        ) {
+          const detail =
+            typeof p["error"] === "string" && p["error"]
+              ? this.options.providerDiagnostic(p["error"])
+              : "Codex reported no diagnostic.";
+          this.options.emit({
+            type: "notice",
+            text:
+              "Mirafold render tools failed to start: " +
+              inertToken(detail, 500),
+            kind: "warning",
+            source: "codex",
+          });
+        }
+        break;
       case "model/rerouted": {
         const to = typeof p["toModel"] === "string" ? p["toModel"] : typeof p["model"] === "string" ? p["model"] : "";
         const from = typeof p["fromModel"] === "string" ? p["fromModel"] : "";

--- a/server/adapters/codex-ledger.ts
+++ b/server/adapters/codex-ledger.ts
@@ -47,6 +47,7 @@ export const CODEX_HANDLED_METHODS = [
   "configWarning",
   "guardianWarning",
   "model/rerouted",
+  "mcpServer/startupStatus/updated",
 ] as const;
 export const CODEX_IGNORED_METHODS: Record<string, string> = {
   "thread/started": "the session consumes it on thread/start",
@@ -79,7 +80,6 @@ export const CODEX_IGNORED_METHODS: Record<string, string> = {
   "process/exited": "background process plumbing not represented in the transcript",
   "item/commandExecution/terminalInteraction": "interactive-terminal plumbing not represented in the transcript",
   "mcpServer/oauthLogin/completed": "MCP server administration",
-  "mcpServer/startupStatus/updated": "MCP server administration",
   "mcpServer/event/stream/notification": "MCP server administration",
   "account/updated": "account administration",
   "account/login/completed": "account administration",

--- a/server/adapters/codex-prompt.ts
+++ b/server/adapters/codex-prompt.ts
@@ -13,15 +13,18 @@ import { MIRAFOLD_MCP } from "./render-mcp-cmd";
  * prompts): 15 paintings — the model almost never went looking. So this
  * note rides at the TOP of the developer instructions, names all three
  * paths with the exact call shapes, and makes loading a render tool the
- * first step of any reply with a structured core. It is true in every
- * configuration and rides only on thread start.
+ * first step of any reply with a structured core. It also states the failure
+ * boundary literally: discovery is one pass, and resource-list APIs are not
+ * tool discovery. The note rides only on thread start.
  */
 export const CODEX_DEFERRED_TOOLS_ADDENDUM = `
 ## Mirafold's render tools: where they are, and load them first (important)
 
 The render_* tools and emit_artifact described below live on the
-\`${MIRAFOLD_MCP}\` MCP server. They are ALWAYS available, but Codex may hide
-them from your tool list. Check, in this order:
+\`${MIRAFOLD_MCP}\` MCP server. They are available only after the
+\`${MIRAFOLD_MCP}\` MCP server starts. Mirafold requires that server before
+this thread can run, but Codex may expose its tools through different surfaces.
+Check the surfaces relevant to this session once, in this order:
 1. If they appear in your tool list, call them directly.
 2. If your tool list has \`tool_search\`, they are DEFERRED behind it: call
    tool_search with the tool's name (for example {"query": "render_table"}),
@@ -32,8 +35,10 @@ them from your tool list. Check, in this order:
    call one like
    \`const r = await tools.mcp__${MIRAFOLD_MCP}__render_table({ columns, rows });\`
    and pass the returned \`r.content\` text to \`text(...)\`.
-Never conclude a render tool is unavailable without doing this. Absent from
-your tool list means not loaded yet, never missing.
+Never use \`list_mcp_resources\` or \`list_mcp_resource_templates\` to discover
+tools: those APIs list MCP resources, not callable tools. If the render tools
+are absent from every relevant surface above, stop; do not retry discovery.
+Report that the Mirafold renderer is unavailable for this turn.
 
 Do this in EVERY reply whose content has a structured core — a list, a table,
 a comparison, key→value facts, code, a diff, command output, test results, a

--- a/server/adapters/codex.test.ts
+++ b/server/adapters/codex.test.ts
@@ -410,6 +410,10 @@ test("the render guidance rides thread/start as developerInstructions; turns car
   assert.ok(instructions.includes("tool_search"));
   assert.ok(instructions.includes("tools.mcp__mirafold__render_table("));
   assert.ok(instructions.includes("ALL_TOOLS"));
+  assert.match(instructions, /only after the\s+`mirafold` MCP server starts/);
+  assert.ok(instructions.includes("Never use `list_mcp_resources`"));
+  assert.ok(instructions.includes("do not retry discovery"));
+  assert.doesNotMatch(instructions, /ALWAYS available|never missing/);
   assert.equal(starts[0].params.cwd, tmp);
   // Faithful skin: no sandbox / approval policy of our own.
   assert.equal(starts[0].params.sandbox, undefined);
@@ -982,6 +986,25 @@ test("a retried engine error and a warning are attributed notices; the turn keep
   s.close();
 });
 
+test("a failed Mirafold MCP startup surfaces Codex's exact diagnostic", async () => {
+  const { s, msgs, awaitTurnEnd } = makeSession([
+    ["mcpServer/startupStatus/updated", {
+      name: MIRAFOLD_MCP,
+      status: "failed",
+      error: "handshaking with MCP server failed: connection closed",
+    }],
+    DONE,
+  ]);
+  s.pushPrompt("go");
+  await awaitTurnEnd();
+  const notice = msgs.find((m) => m.type === "notice");
+  assert.equal(notice?.kind, "warning");
+  assert.equal(notice?.source, "codex");
+  assert.match(notice?.text ?? "", /Mirafold render tools failed to start/);
+  assert.match(notice?.text ?? "", /connection closed/);
+  s.close();
+});
+
 test("app-server dies mid-turn: one error, one turn_end, and the next prompt respawns and RESUMES the thread", async () => {
   const { s, msgs, server, turnEnds, awaitTurnEnd } = makeSession(
     async (ctx) => {
@@ -1240,16 +1263,14 @@ function withEnvVar(name: string, value: string | undefined, fn: () => void) {
 const withOpenAiKey = (value: string | undefined, fn: () => void) =>
   withEnvVar("OPENAI_API_KEY", value, fn);
 
-test("F.10: the installed Codex executable runs the app-server", () => {
+test("F.10: the installed Codex executable runs app-server with a required, stable renderer", () => {
   withEnvVar("MIRAFOLD_CODEX_BIN", "/operator/chosen/codex", () => {
     const spec = capturedSpawn({ kind: "subscription" });
     assert.equal(spec.command, "/operator/chosen/codex");
     assert.equal(spec.args[0], "app-server");
-    assert.equal(
-      configOf(spec).features?.apply_patch_streaming_events,
-      true,
-      "the process must enable current Codex's structured live patch snapshots",
-    );
+    const config = configOf(spec);
+    assert.equal(config.features?.apply_patch_streaming_events, undefined);
+    assert.equal(config.mcp_servers?.[MIRAFOLD_MCP]?.required, true);
   });
 });
 
@@ -1568,6 +1589,7 @@ test("a failed engine start does not burn anything: the retry spawns afresh and 
   await waitForTurnEnds(msgs, 1);
   assert.ok(msgs.some((m) => m.type === "error" && m.message.includes("codex binary missing")), "the failure itself surfaced");
   assert.equal(server.prompts().length, 0);
+  assert.equal(server.clients[0]?.exited, true, "the failed app-server is killed before retry");
 
   s.pushPrompt("second ask");
   // This fake fails every start the same way; what must hold is the shape:

--- a/server/adapters/codex.ts
+++ b/server/adapters/codex.ts
@@ -488,8 +488,11 @@ export class CodexSession implements AgentSession {
     })();
     this.threadReady.catch(() => {
       // A failed start is reported by the turn that needed it; the next turn
-      // tries again from a fresh process.
-      if (this.client === client) this.threadReady = undefined;
+      // tries again from a fresh process. Kill this attempt before clearing
+      // the reference: initialize/thread-start rejection does not imply the
+      // app-server process exited, and overwriting a live client would orphan
+      // it for the rest of the Mirafold session.
+      this.abandonAppServer(client);
     });
     return this.threadReady;
   }

--- a/server/adapters/gemini-cli.spike.md
+++ b/server/adapters/gemini-cli.spike.md
@@ -77,12 +77,12 @@ user's own `~/.gemini/settings.json`, faithful):
 // <session cwd>/.gemini/settings.json
 { "mcpServers": { "genui": { "command": "<tsx>", "args": ["<render-mcp.ts>"] } } }
 ```
-Tool approval (headless can't prompt — same wall as Codex exec): allow our server
-specifically via `--allowed-mcp-server-names genui`, and/or a per-server `trust`
-in the settings block, rather than the blunt `--yolo`/`--approval-mode yolo`
-(which would also auto-approve the user's shell — not ours to force). Exact
-knob TBD live (see Open questions), but a scoped allow exists — same posture as
-Codex's per-server `default_tools_approval_mode: "approve"`.
+Tool approval (headless can't prompt — same wall as Codex exec): set per-server
+`trust: true` on our injected entry, rather than the blunt
+`--yolo`/`--approval-mode yolo` (which would also auto-approve the user's shell
+— not ours to force). Post-0.57 correction: `--allowed-mcp-server-names` is a
+server allowlist, not an approval grant; naming only Mirafold blocks every
+user-configured MCP server and must never be used for this purpose.
 
 ## Config we set per session (faithful, agent-scoped)
 
@@ -115,9 +115,9 @@ interactive OAuth (browser), like `codex login`. The CLI is already installed.
 2. **Warm-session mechanics**: confirm `--session-id` + `--resume` continues the
    conversation across separate headless invocations (vs. needing one long-lived
    `--acp`/interactive process).
-3. **Scoped MCP approval** in headless: confirm `--allowed-mcp-server-names genui`
-   (and/or per-server `trust`) makes our render tools run without a prompt, while
-   leaving the user's own tool approvals inherited.
+3. **Scoped MCP approval — resolved:** per-server `trust` runs our render tools
+   without a prompt while the user's MCP set remains inherited. The CLI
+   `--allowed-mcp-server-names` flag filters the server set and is not used.
 4. **OAuth creds path** for the `agentHasCredentials` check.
 
 One short live session answers all four; the adapter is then a mechanical write

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -129,6 +129,28 @@ test("Gemini remains supported without a Mirafold retirement notice", async () =
   s.close();
 });
 
+test("Gemini inherits the user's MCP server set instead of allowlisting only Mirafold", async () => {
+  const argsLog = path.join(tmp, "mcp-inheritance-args.txt");
+  process.env.FAKE_ARGS_LOG = argsLog;
+  fixture("mcp-inheritance.jsonl", [
+    { type: "result", status: "success", stats: { input_tokens: 1, output_tokens: 1 } },
+  ]);
+  const { s, awaitTurnEnd } = makeSession();
+  try {
+    s.pushPrompt("hello");
+    await awaitTurnEnd();
+    const args = spawnArgs(argsLog);
+    assert.equal(
+      args.includes("--allowed-mcp-server-names"),
+      false,
+      "the CLI flag is an allowlist that blocks every user-configured MCP server not named Mirafold",
+    );
+  } finally {
+    delete process.env.FAKE_ARGS_LOG;
+    s.close();
+  }
+});
+
 test("a pre-existing settings.json — broken or valid — is untouched at construction; a turn is what earns consent to merge it", async () => {
   // Unparseable: construction touches NOTHING. Only once a turn actually runs
   // (this workspace is pre-trusted, under `tmp`) does the rewrite+backup happen.
@@ -294,6 +316,7 @@ test("happy stream: full JSONL→WireMsg mapping, exactly one turn_end", async (
 
   assert.equal(msgs.filter((m) => m.type === "render" || m.type === "artifact").length, 2);
   assert.equal(msgs.find((m) => m.type === "error")!.message, "minor complaint");
+  assert.equal(msgs.find((m) => m.type === "error")!.terminal, false);
 
   const usage = msgs.find((m) => m.type === "usage")!;
   assert.equal(usage.model, "gemini-2.5-pro"); // init set the label
@@ -302,6 +325,51 @@ test("happy stream: full JSONL→WireMsg mapping, exactly one turn_end", async (
 
   assert.equal(turnEnds(), 1);
   assert.equal(msgs[msgs.length - 1].type, "turn_end");
+  s.close();
+});
+
+test("Gemini 0.57 warnings stay nonfatal and attributed while the turn continues", async () => {
+  fixture("warning.jsonl", [
+    { type: "init", model: "gemini-2.5-pro" },
+    { type: "error", severity: "warning", message: "Loop detected, stopping execution" },
+    { type: "message", role: "assistant", content: "the reply still arrived" },
+    { type: "result", status: "success", stats: { input_tokens: 2, output_tokens: 3 } },
+  ]);
+  const { s, msgs, awaitTurnEnd } = makeSession();
+  s.pushPrompt("go");
+  await awaitTurnEnd();
+  assert.equal(msgs.some((m) => m.type === "error"), false);
+  const notice = msgs.find((m) => m.type === "notice");
+  assert.deepEqual(
+    notice && { text: notice.text, kind: notice.kind, source: notice.source },
+    {
+      text: "Loop detected, stopping execution",
+      kind: "warning",
+      source: "gemini-cli",
+    },
+  );
+  assert.equal(msgs.filter((m) => m.type === "text_delta").map((m) => m.text).join(""), "the reply still arrived");
+  s.close();
+});
+
+test("Gemini 0.57 fatal result errors surface even after stdout init", async () => {
+  fixture("fatal-result.jsonl", [
+    { type: "init", model: "gemini-2.5-pro" },
+    {
+      type: "result",
+      status: "error",
+      error: { type: "FatalAuthenticationError", message: "Authentication required." },
+      stats: { input_tokens: 0, output_tokens: 0 },
+    },
+  ]);
+  const { s, msgs, awaitTurnEnd } = makeSession();
+  s.pushPrompt("go");
+  await awaitTurnEnd();
+  const errors = msgs.filter((m) => m.type === "error");
+  assert.equal(errors.length, 1);
+  assert.equal(errors[0].message, "Authentication required.");
+  assert.equal(errors[0].terminal, undefined);
+  assert.equal(msgs.filter((m) => m.type === "usage").length, 1);
   s.close();
 });
 

--- a/server/adapters/gemini-cli.ts
+++ b/server/adapters/gemini-cli.ts
@@ -74,6 +74,10 @@ export class GeminiCliSession implements AgentSession {
   private announced = new Set<string>();
   private readonly unknown = new UnknownKindReporter((m) => this.emit(m), "Gemini CLI", (m) => createLogger("gemini-cli").warn(m));
   private pendingRenders = new Map<string, { tool: string; params: Record<string, unknown> }>();
+  // The latest nonfatal stream-json error event in this turn. Gemini 0.57
+  // can repeat it as a terminal result error (or omit result.error entirely),
+  // so retain it long enough to report the outcome once and with real words.
+  private streamErrorMessage?: string;
   // The folder-trust ask, keyed by wire id → resolver. At most one is
   // ever in flight: it gates the first turn in an untrusted workspace, and a
   // yes is remembered on disk, so later turns never reach it.
@@ -443,6 +447,7 @@ export class GeminiCliSession implements AgentSession {
 
   private spawnTurn(text: string): Promise<void> {
     return new Promise((resolve) => {
+      this.streamErrorMessage = undefined;
       // The headless stream-json surface has no system-prompt/instructions
       // hook (unlike Claude's `systemPrompt.append`), so RENDER_GUIDANCE rides
       // ahead of the first turn instead — the only injection point this engine
@@ -455,7 +460,12 @@ export class GeminiCliSession implements AgentSession {
       // the prompt (no stdout event: the exit-42 id-mode collision, a spawn
       // failure, bad auth).
       if (inject) this.guidance.delivered();
-      const args = ["-p", prompt, "-o", "stream-json", "--allowed-mcp-server-names", MIRAFOLD_MCP];
+      // Do not pass --allowed-mcp-server-names here. Despite its approval-
+      // sounding name, Gemini 0.57 uses it as a server allowlist; naming only
+      // Mirafold silently removes every MCP server the user configured. Our
+      // injected entry is already the only one we mark `trust: true`; all
+      // other servers keep the user's own settings and terminal behavior.
+      const args = ["-p", prompt, "-o", "stream-json"];
       if (this.model) args.push("-m", this.model);
       // `resumed` is THIS turn's mode; `started` is optimistic (set before the
       // child confirms anything) and self-corrected on close below.
@@ -662,9 +672,42 @@ export class GeminiCliSession implements AgentSession {
         break;
       }
       case "error":
-        if (typeof ev["message"] === "string") this.emit({ type: "error", message: ev["message"] as string });
+        if (typeof ev["message"] === "string" && ev["message"]) {
+          const message = ev["message"] as string;
+          if (ev["severity"] === "warning") {
+            // Gemini explicitly continues after these (loop detection,
+            // blocked agent work, quota advisories). A terminal error would
+            // close the browser's turn while later output is still arriving.
+            this.emit({
+              type: "notice",
+              text: message,
+              kind: "warning",
+              source: "gemini-cli",
+            });
+          } else {
+            // Severity "error" is still an in-stream diagnostic in Gemini's
+            // contract. The eventual result/child close owns the turn end.
+            this.streamErrorMessage = message;
+            this.emit({ type: "error", message, terminal: false });
+          }
+        }
         break;
       case "result": {
+        if (ev["status"] === "error") {
+          const error = (ev["error"] ?? {}) as Record<string, unknown>;
+          const message =
+            typeof error["message"] === "string" && error["message"]
+              ? (error["message"] as string)
+              : this.streamErrorMessage;
+          // A preceding severity:error already painted the useful text as a
+          // nonterminal error; turn_end will settle it. Fatal 0.57 failures
+          // arrive only here, after init made the old stderr fallback inert.
+          if (message && message !== this.streamErrorMessage) {
+            this.emit({ type: "error", message });
+          } else if (!message) {
+            this.emit({ type: "error", message: "Gemini CLI ended the turn with an error." });
+          }
+        }
         const stats = (ev["stats"] ?? {}) as Record<string, unknown>;
         const model = this.honestModel(stats["models"]);
         // The refinement must land on modelLabel too — modelName is what the

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -246,27 +246,54 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
    *  prompt sent immediately after health races it and the model is offered
    *  ZERO tools — observed live (request 1 carried no tools, so
    *  the scripted render call bounced). The injected render server reporting
-   *  "connected" is the readiness signal start() actually promises. On
-   *  deadline we proceed anyway: the engine still converses, renders just
-   *  arrive with a later turn — degraded, not dead. */
+   *  "connected" is therefore part of start()'s readiness contract. A known
+   *  failure or the shared startup deadline rejects before any model prompt;
+   *  silently conversing without Mirafold's promised renderer is not a valid
+   *  degraded mode. */
   private async waitForInjectedMcp(deadline: number): Promise<void> {
     const injected = Object.keys((this.options.configContent["mcp"] as object | undefined) ?? {});
     if (!injected.length) return;
     while (Date.now() <= deadline && !this.closed) {
+      let statuses: Record<string, { status?: unknown; error?: unknown }> | undefined;
       try {
         const res = await fetch(`${this.base}/mcp`, {
           headers: { authorization: this.auth },
           signal: AbortSignal.timeout(1_000),
         });
         if (res.ok) {
-          const statuses = (await res.json()) as Record<string, { status?: string }>;
-          if (injected.every((name) => statuses[name]?.status === "connected")) return;
+          statuses = (await res.json()) as Record<
+            string,
+            { status?: unknown; error?: unknown }
+          >;
         }
       } catch {
-        // poll again
+        // Transient HTTP/JSON failures poll until the shared startup deadline.
+      }
+      if (statuses && injected.every((name) => statuses[name]?.status === "connected")) return;
+      for (const name of injected) {
+        const state = statuses?.[name];
+        if (
+          state &&
+          (state.status === "failed" ||
+            state.status === "disabled" ||
+            state.status === "needs_auth" ||
+            state.status === "needs_client_registration")
+        ) {
+          const detail =
+            typeof state.error === "string" && state.error.trim()
+              ? `: ${state.error.trim().replace(/[\u0000-\u001f\u007f]/g, " ").slice(0, 500)}`
+              : "";
+          throw new Error(
+            `Mirafold render tools failed to start (${name}: ${String(state.status)}${detail})`,
+          );
+        }
       }
       await delay(250);
     }
+    if (this.closed) throw new Error("session closed while Mirafold render tools were starting");
+    throw new Error(
+      `Mirafold render tools did not connect within ${START_DEADLINE_MS}ms; no model prompt was sent`,
+    );
   }
 
   /** Read the SSE stream for this SPAWN's life, reconnecting on drops. */

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -6,7 +6,8 @@ import { mkdtempSync, writeFileSync } from "node:fs";
 import type { WireMsg } from "../protocol";
 import { MIRAFOLD_CONTEXT, RENDER_GUIDANCE } from "../render-tools";
 import { OpenCodeSession } from "./opencode";
-import type { OpenCodeEvent, OpenCodeTransport } from "./opencode-client";
+import { OpenCodeServerProcess, type OpenCodeEvent, type OpenCodeTransport } from "./opencode-client";
+import { MIRAFOLD_MCP } from "./render-mcp-cmd";
 import { waitFor } from "../testing/wait-for";
 import { OPENCODE_SUBAGENT_EVENTS } from "../testing/opencode-subagent-fixture";
 
@@ -1428,6 +1429,71 @@ test("AUDIT: the minted server password is redacted from a stderr tail (pure)", 
   // Two occurrences both go; an empty secret is a no-op (pre-mint path).
   assert.equal(redactSecret(`${secret} and ${secret}`, secret), "[redacted] and [redacted]");
   assert.equal(redactSecret("nothing to redact", ""), "nothing to redact");
+});
+
+test("an explicit failure of the injected renderer aborts OpenCode startup", async () => {
+  const transport = new OpenCodeServerProcess({
+    bin: "unused",
+    cwd: tmp,
+    configContent: { mcp: { [MIRAFOLD_MCP]: { type: "local", command: ["unused"] } } },
+  });
+  const internals = transport as unknown as {
+    base: string;
+    auth: string;
+    waitForInjectedMcp(deadline: number): Promise<void>;
+  };
+  internals.base = "http://opencode.test";
+  internals.auth = "Basic test";
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(
+      JSON.stringify({
+        [MIRAFOLD_MCP]: {
+          status: "failed",
+          error: "handshaking with MCP server failed: connection closed",
+        },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    )) as typeof fetch;
+  try {
+    await assert.rejects(
+      internals.waitForInjectedMcp(Date.now() + 1_000),
+      /Mirafold render tools failed to start.*connection closed/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+    transport.close();
+  }
+});
+
+test("an injected renderer that never connects fails OpenCode startup at the deadline", async () => {
+  const transport = new OpenCodeServerProcess({
+    bin: "unused",
+    cwd: tmp,
+    configContent: { mcp: { [MIRAFOLD_MCP]: { type: "local", command: ["unused"] } } },
+  });
+  const internals = transport as unknown as {
+    base: string;
+    auth: string;
+    waitForInjectedMcp(deadline: number): Promise<void>;
+  };
+  internals.base = "http://opencode.test";
+  internals.auth = "Basic test";
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response(JSON.stringify({ [MIRAFOLD_MCP]: { status: "connecting" } }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    })) as typeof fetch;
+  try {
+    await assert.rejects(
+      internals.waitForInjectedMcp(Date.now() + 10),
+      /Mirafold render tools did not connect/,
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+    transport.close();
+  }
 });
 
 test("AUDIT: a permission-ask flood auto-denies past the cap — observable at the wire", async () => {


### PR DESCRIPTION
## What ships

- removes Mirafold's forced Codex under-development feature flag and its startup warning
- requires the injected Codex renderer before inference and prevents resource-list retry spirals
- hardens current Gemini CLI and OpenCode startup/error handling across the same renderer boundary
- bumps the npm package to 0.8.1

## Scope

This hotfix branch starts from the v0.8.0 main tip and contains only the reviewed repair from PR #86 plus the version/plan release commit. No unrelated next work is included.

## Verification

- yarn typecheck
- yarn test: 1,113/1,113
- yarn test:server: 161/161
- yarn test:e2e: 130/130
- exact branch npm pack: mirafold@0.8.1
- prior exact-fix packaged smoke: 9/9
- prior real packaged Codex subscription replay of the captured request: four charts; no unstable-feature warning, renderer failure, resource-list retry, unexpected permission, or browser error
- fresh-agent cold review of the fix: no findings

Signed-off commits; release follows docs/RELEASING.md hotfix flow.