### PR TITLE
chore: remove proven dead declarations

### DIFF
--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -1174,7 +1174,7 @@ test("BUGFIX: one transport start per engine, even across policy-failure retries
 });
 
 test("BUGFIX: an interrupt during startup cancels the send — no ghost turn", async () => {
-  const { session, fake, msgs, feed, awaitTurnEnd } = makeSession();
+  const { session, fake, feed, awaitTurnEnd } = makeSession();
   let releaseStart: () => void = () => {};
   const origStart = fake.start.bind(fake);
   fake.start = async (cb) => {

--- a/server/sessions/bang-handlers.ts
+++ b/server/sessions/bang-handlers.ts
@@ -9,7 +9,7 @@ import type { ConnectionContext } from "./handler-context";
 import { existsSync, lstatSync, mkdtempSync, readFileSync, realpathSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import type { ClientMsg, WireMsg } from "../protocol";
+import type { ClientMsg } from "../protocol";
 import type { SessionEntry, SessionRegistry } from "./registry";
 import { CLIENT_ID_RE } from "./fs-handlers";
 import { spawnBang } from "../pty/pty";

--- a/server/sessions/fs-handlers.ts
+++ b/server/sessions/fs-handlers.ts
@@ -17,8 +17,7 @@ import path from "node:path";
 import { createLogger } from "../log";
 import type { ConnectionContext } from "./handler-context";
 import { TOO_FAST, inflightSlot, minInterval, tokenBucket } from "../throttle";
-import type { ClientMsg, FsDirEntry, FsEntry, WireMsg } from "../protocol";
-import type { SessionEntry } from "./registry";
+import type { ClientMsg, FsDirEntry, FsEntry } from "../protocol";
 import {
   capBuffer,
   contentRevision,

--- a/server/sessions/git-trust.ts
+++ b/server/sessions/git-trust.ts
@@ -48,11 +48,6 @@ export function gitBin(): string | undefined {
   }
   return gitBinCache;
 }
-/** Test seam: forget the cached lookup (PATH changed). */
-export function resetGitBinCache(): void {
-  gitBinCache = null;
-}
-
 // Shared with every git invocation in git.ts — one timebox for the family.
 export const GIT_TIMEOUT_MS = envInt("FS_GIT_TIMEOUT_MS", 5_000);
 // A config dump is small; this only bounds a pathological repo's memory.

--- a/server/sessions/upload-handlers.ts
+++ b/server/sessions/upload-handlers.ts
@@ -15,7 +15,6 @@ import type { ConnectionContext } from "./handler-context";
 import os from "node:os";
 import path from "node:path";
 import type { ClientMsg, WireMsg } from "../protocol";
-import type { SessionEntry } from "./registry";
 import { relayGateRefusal } from "../provider-policy";
 import { envInt } from "../env";
 import { badClientId } from "./fs-handlers";

--- a/server/testing/app.e2e.ts
+++ b/server/testing/app.e2e.ts
@@ -1,14 +1,13 @@
 import { test, before, after } from "node:test";
 import { MOCK_PROMPTS } from "./mock-prompts";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from "node:fs";
 import { createServer } from "node:http";
 import os from "node:os";
 import path from "node:path";
-import { type Browser, type Locator, type Page } from "playwright-core";
-import { createSession, fixtureGit as git, startDaemon, TestClient, type Daemon } from "./itest-harness";
+import { type Browser, type Page } from "playwright-core";
+import { createSession, fixtureGit as git, startDaemon, type Daemon } from "./itest-harness";
 import { assertAxeClean, launchChrome, noSideScroll, typePrompt, withFreshMockSession, settled } from "./e2e-harness";
-import type { ClientMsg } from "../protocol";
 import { startOllamaFixture } from "./ollama-fixture";
 import { startRelayStub } from "../relay/relay-stub";
 import { THEMES } from "../../web/src/themes/manifest";

--- a/server/testing/diff-panel.e2e.ts
+++ b/server/testing/diff-panel.e2e.ts
@@ -4,7 +4,6 @@ import { mkdirSync, mkdtempSync, rmSync, unlinkSync, writeFileSync } from "node:
 import os from "node:os";
 import path from "node:path";
 import { type Browser, type BrowserContext, type Page } from "playwright-core";
-import type { ClientMsg } from "../protocol";
 import { assertApartOnScreen, assertAxeClean, launchChrome, noSideScroll } from "./e2e-harness";
 import { fixtureGit as git, startDaemon, type Daemon, createSession as seedSession } from "./itest-harness";
 

--- a/server/testing/opencode-subagent-fixture.ts
+++ b/server/testing/opencode-subagent-fixture.ts
@@ -18,12 +18,6 @@
 //  - child session.idle fires BEFORE the parent task part completes and
 //    long before parent session.idle
 
-/** The two session ids the capture uses. */
-export const SUBAGENT_FIXTURE_IDS = {
-  root: "ses_sa0probe00000000000root",
-  child: "ses_sa0probe0000000000child",
-} as const;
-
 /** The captured sequence, in arrival order. */
 export const OPENCODE_SUBAGENT_EVENTS: {
   type: string;

--- a/web/src/changes-requests.ts
+++ b/web/src/changes-requests.ts
@@ -144,5 +144,3 @@ export function createChangesRequests(deps: ChangesRequestsDeps) {
   };
   return requests;
 }
-
-export type ChangesRequests = ReturnType<typeof createChangesRequests>;

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { AgentName, PromptOption } from "@protocol";
-import { ActivityLine, activityLabel, type Activity } from "./ActivityLine";
+import { ActivityLine, activityLabel } from "./ActivityLine";
 import { BangBar } from "./BangBar";
 import { DiffPanelGlyph } from "./DiffPanelGlyph";
 import { FolderTreeGlyph } from "./FolderTreeGlyph";

--- a/web/src/daemon-client.ts
+++ b/web/src/daemon-client.ts
@@ -61,5 +61,3 @@ export function createDaemonClient(socket: SocketClient) {
     },
   };
 }
-
-export type DaemonClient = ReturnType<typeof createDaemonClient>;


### PR DESCRIPTION
## Summary

- remove compiler-proven unused imports and one unused binding
- remove four exported declarations with zero semantic references
- preserve runtime behavior and public interfaces

## Verification

- yarn -s typecheck
- ./node_modules/.bin/tsc --noEmit --noUnusedLocals --noUnusedParameters
- yarn -s test (1,113 passed)
- git diff --check