### PR TITLE
test: make UI readiness checks deterministic

### DIFF
--- a/server/testing/document.e2e.ts
+++ b/server/testing/document.e2e.ts
@@ -373,23 +373,46 @@ test("LD.3: response documents reflow across folder tree, file view, pin dock, a
     await p.locator(".output-zone").evaluate((element) => {
       element.scrollTop = element.scrollHeight;
     });
-    await typePrompt(p, MOCK_PROMPTS["responsive-document"]);
     const stressDocument = p.locator(".response-document", { hasText: "Width stress" });
-    await stressDocument.locator(".rc-diff").waitFor({ timeout: 15_000 });
-    await stressDocument.locator(".rc-chart").waitFor({ timeout: 15_000 });
     const finalStressProse = stressDocument.locator(".turn-assistant", {
       hasText: "without widening the workbench",
     });
+    await p.evaluate(() => {
+      const attribute = "data-e2e-first-stress-paint";
+      document.documentElement.removeAttribute(attribute);
+      const observer = new MutationObserver(() => {
+        const stressDocument = [...document.querySelectorAll(".response-document")].find((element) =>
+          element.textContent?.includes("Width stress"),
+        );
+        if (!stressDocument) return;
+        const artifact = stressDocument.querySelector(".artifact");
+        const prose = [...stressDocument.querySelectorAll(".turn-assistant")].some((element) =>
+          element.textContent?.includes("Every painting"),
+        );
+        if (!artifact && !prose) return;
+        document.documentElement.setAttribute(
+          attribute,
+          artifact && prose ? "simultaneous" : artifact ? "artifact" : "prose",
+        );
+        observer.disconnect();
+      });
+      observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    });
+    await typePrompt(p, MOCK_PROMPTS["responsive-document"]);
+    await stressDocument.locator(".rc-diff").waitFor({ timeout: 15_000 });
+    await stressDocument.locator(".rc-chart").waitFor({ timeout: 15_000 });
     await stressDocument.locator(".artifact").waitFor({ timeout: 15_000 });
     assert.equal(
       await p.locator(".activity-line").count(),
       1,
       "the artifact waited until turn_end",
     );
+    const firstStressPaint = p.locator("html[data-e2e-first-stress-paint]");
+    await firstStressPaint.waitFor({ timeout: 15_000 });
     assert.equal(
-      await finalStressProse.count(),
-      0,
-      "the artifact did not paint before subsequent prose",
+      await firstStressPaint.getAttribute("data-e2e-first-stress-paint"),
+      "artifact",
+      "subsequent prose painted before the artifact",
     );
     const artifactHandle = await stressDocument
       .locator("iframe.artifact-frame")

--- a/server/testing/ui-visual.uitest.ts
+++ b/server/testing/ui-visual.uitest.ts
@@ -93,6 +93,7 @@ async function settleLiveDocument(page: Page): Promise<void> {
   await page.locator(".output-zone").evaluate((element) => {
     element.scrollTop = 0;
   });
+  await page.locator(".jump-to-latest.is-visible").waitFor();
 }
 
 test("visual: agent-picker card", { skip: LINUX_ONLY }, async () => {


### PR DESCRIPTION
## Summary

- Record responsive-document artifact/prose order inside the browser before the stress prompt begins.
- Wait for the jump-to-latest ready state before live-document visual snapshots.

## Why

The former LD.3 assertion queried for later prose only after Playwright had observed the artifact, so driver latency could turn correct ordering into a failure. The live-document visual helper scrolled directly and could capture before the scroll event, follow-tail state update, and React commit made the baselined jump button visible.

## Verification

- yarn typecheck
- yarn test: 1,113 passed
- yarn test:server: 161 passed
- yarn test:e2e: 130 passed
- yarn test:ui: 11 passed
- Mutation proof: scheduling later prose before the artifact fails LD.3 with actual prose versus expected artifact.
- Mutation proof: withholding the jump-button ready class makes the visual helper time out on that exact readiness condition.
- Independent cold review: no findings.

## Scope

Test-only. No application behavior, fixture timing, visual baselines, screenshot tolerances, dependencies, configuration, or documentation changed.