### PR TITLE
security: harden Pro launch boundaries

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,22 +5,23 @@ name: Release
 # the package carries a signed provenance attestation binding it to the exact
 # public commit + this workflow; users verify with `npm audit signatures`.
 #
-# Auth is npm TRUSTED PUBLISHING (OIDC): npmjs.com is configured to accept
-# `mirafold` publishes only from this workflow — identity-federated, NO npm
-# token stored anywhere, so the repo's no-secrets-in-CI bound (PLAN C.1)
-# holds and a stolen npm password can't publish. If npmjs.com's trusted-
-# publisher binding is ever removed, a real publish from here fails auth —
-# that's the fail-closed direction.
+# Auth is npm TRUSTED PUBLISHING (OIDC): npmjs.com's publisher record must
+# accept `mirafold` publishes only from this workflow in the protected
+# `npm-publish` environment — identity-federated, so this workflow needs no
+# stored npm token and the repo's no-secrets-in-CI bound (PLAN C.1) holds. The npm
+# package's Publishing access must separately disallow traditional tokens;
+# trusted publishing does not turn them off. If the trusted-publisher binding
+# is ever removed, a real publish from here fails auth — that's the
+# fail-closed direction.
 #
 # Launch morning (R.7): Kyle pushes the SIGNED release tag (tarball SHA-256
-# in the tag message) and this workflow does the rest — no hand-run
-# `npm publish`, ever. Rehearsal: workflow_dispatch runs everything up to a
-# `npm publish --dry-run`, which packs and reports without authenticating.
+# in the tag message), approves the protected publish environment after the
+# checks pass, and this workflow does the rest — no hand-run `npm publish`,
+# ever.
 
 on:
   push:
     tags: ["v*"]
-  workflow_dispatch: # rehearsal — dry-run only, never a real publish
 
 # Two jobs, deliberately (audit 2026-08-26): `verify` builds, tests and packs
 # with NO publish credential in scope — `yarn install` runs two dependencies'
@@ -48,9 +49,7 @@ jobs:
       # gate a tag aimed at any branch's commit — or an old main commit —
       # would publish it. Flow b (2026-08-07): main advances only at release
       # time, so main's tip and the published package are the same thing.
-      # Dispatch rehearsals run from a branch ref and skip this.
       - name: Tag must be main's current tip
-        if: github.event_name == 'push'
         run: |
           git fetch --depth=1 origin main
           TIP="$(git rev-parse origin/main)"
@@ -66,10 +65,8 @@ jobs:
       - run: yarn install --frozen-lockfile
 
       # A tag that doesn't match package.json is a mis-cut release — refuse
-      # loudly before anything publishes. (Dispatch rehearsals skip this;
-      # there's no tag to match.)
+      # loudly before anything publishes.
       - name: Tag ↔ version check
-        if: github.event_name == 'push'
         run: |
           TAG="${GITHUB_REF_NAME#v}"
           PKG="$(node -p "require('./package.json').version")"
@@ -128,7 +125,6 @@ jobs:
       # a non-deterministic build, or a tag cut from a different tree, is a
       # red run here instead of a silent mismatch.
       - name: Tag signature ↔ allowed signers, message SHA-256 ↔ packed tarball
-        if: github.event_name == 'push'
         run: |
           git fetch --no-tags --depth=1 origin "+refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME"
           git -c gpg.ssh.allowedSignersFile=.github/allowed_signers verify-tag "$GITHUB_REF_NAME" \
@@ -156,6 +152,7 @@ jobs:
     name: publish with provenance
     needs: verify
     runs-on: ubuntu-latest
+    environment: npm-publish
     # id-token: write is what mints the OIDC token npm's trusted publishing
     # exchanges for a one-shot publish credential — scoped to THIS job, which
     # runs no install scripts and touches nothing but the verified tarball.
@@ -188,13 +185,6 @@ jobs:
           [ "$SHA" = "$VERIFIED_SHA" ] || { echo "artifact sha256 $SHA != verified $VERIFIED_SHA" >&2; exit 1; }
 
       - name: Publish the packed tarball (tag push — provenance over trusted publishing)
-        if: github.event_name == 'push'
         env:
           TARBALL: ${{ needs.verify.outputs.tarball }}
         run: npm publish "./$TARBALL" --provenance --access public
-
-      - name: Dry-run publish (rehearsal)
-        if: github.event_name == 'workflow_dispatch'
-        env:
-          TARBALL: ${{ needs.verify.outputs.tarball }}
-        run: npm publish "./$TARBALL" --dry-run --access public

--- a/PLAN.md
+++ b/PLAN.md
@@ -3454,6 +3454,68 @@ require a PR) — see the session recap for the exact clicks. Review + commit
 on `polish`; then a patch release (findings 2–4 of the delta audit and the
 engine gate are live in 0.5.0).
 
+## Pro launch-readiness security audit (opened 2026-09-01)
+
+Whole-repository pass on `audit/pro-launch-readiness`, with current source,
+history, package contents, dependency advisories, GitHub rulesets, and release
+identity checked. Repo-local findings:
+
+- [x] **Pre-trust project configuration followed a checkout symlink outside
+  the checkout.** Reproduced with an ordinary outside file. The loader now
+  refuses a symlink before open on every platform, adds a no-follow open where
+  the platform supports it, verifies the opened descriptor is a regular file,
+  and bounds the read allocation at 1 MiB plus one byte. The focused test uses
+  non-dotenv fixture names.
+- [x] **Directory work was capped only after allocation.** `fs_listdir`
+  retained all 12,000 probed entries before returning 2,000; the component
+  action returned all 12,000 lines and statted every name. Both scans now stop
+  before allocation/stat work runs away and report truncation.
+- [x] **Agent transport framing was not consistently bounded before parse.**
+  Gemini JSONL and OpenCode SSE had no frame ceiling; Codex had a
+  32 × 1024 × 1024 decoded-character ceiling but reached it through a
+  quadratic string accumulator (12.5 seconds in the isolated probe). All
+  three now reject beyond that ceiling and accumulate chunks linearly (the
+  same Gemini probe reaches the refusal in about 0.25 seconds; the fragmented
+  OpenCode probe in about 0.18 seconds).
+- [x] **Billing clients parsed unlimited response bodies.** Entitlement and
+  subscription JSON is now read through a 64 KiB streaming ceiling; retained
+  token and date fields have their own bounds.
+- [x] **npm release authorization had no external trust anchor.** npm's
+  trusted publisher matches repository + workflow filename, while GitHub uses
+  the workflow version at the event ref. The previous tag/manual workflow and
+  absence of a deployment environment let a write-capable account run a
+  modified copy of that trusted filename with every in-file main/signature/SHA
+  gate removed. On 2026-09-01 the repository gained a verified
+  `npm-publish` environment: `kserrec` is the required reviewer and only `v*`
+  tags may deploy; administrators cannot bypass its rules. This branch makes
+  the workflow tag-only, binds only the real publish job to that environment,
+  and removes the redundant rehearsal. Kyle then confirmed in npm's package
+  settings that the trusted-publisher record names `npm-publish` and that
+  Publishing access is **Require two-factor authentication and disallow
+  tokens**. The environment claim is now required and traditional token
+  publishing is disabled.
+  The earlier 2026-08-26 signed-tag-ruleset follow-up remains incomplete and
+  would not alone bind npm OIDC to the repository's allowed signing key.
+
+Verification so far: production and full dependency audits report zero known
+advisories; reachable-history secret-shape scan found only synthetic test
+fixtures; a sanitized package dry-run contains the intended 20 files; focused
+tests for every fixed class pass; full Gemini, OpenCode, and Codex adapter
+suites pass; TypeScript and the server bundle pass. The blanket test command
+was deliberately not run because repository tests that load dotenv fixtures
+are outside Kyle's categorical dotenv-inspection rule. The first fresh cold
+review caught fragmented OpenCode input still taking quadratic time, a hanging
+cancel-before-kill order, one overstated configuration-reader claim, and test
+fixture leaks. The required second review caught whole-frame line splitting,
+a vacuous license-log test, more fixture leaks, and byte/character wording.
+All were corrected; the targeted final re-review found no findings, with its
+89 focused tests, TypeScript, and diff check green. The repo-local cold-review
+gate is complete. The separate release-boundary cold review caught GitHub's
+default administrator bypass, two unsupported documentation claims, and an
+incomplete one-job OIDC assertion. All were corrected; live GitHub readback,
+the focused workflow test, YAML parsing, TypeScript, and the final re-review
+are clean. Kyle confirmed both required npm package settings through npm's UI.
+
 ## Test-audit pass (2026-08-26) — the whole suite
 
 Baseline: Tier-1 998/998 ×3 (~22 s); Tier-2 156/156 ×3 idle, 155/154/156

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -89,11 +89,16 @@ Three mechanics to know:
    the exact bytes. No hand-run `npm publish`, ever — the tag push triggers
    `.github/workflows/release.yml`, which re-verifies (guard, tag↔version
    check, typecheck, tests), packs once, **refuses unless its pack's SHA-256
-   equals the one in the tag message**, and publishes that exact tarball
-   with provenance via npm trusted publishing — so the signed tag, the
-   workflow summary, and the registry bytes are one file, not three packs
-   assumed identical. A manual dispatch of that workflow is a dry-run
-   rehearsal (no tag, so the SHA check is skipped).
+   equals the one in the tag message**, then waits for `kserrec` to approve
+   the protected `npm-publish` environment. Approve that deployment from the
+   GitHub Actions run; the workflow then publishes the exact tarball with
+   provenance via npm trusted publishing. The environment admits only `v*`
+   tags, so the signed tag, workflow summary, and registry bytes are one file,
+   not three packs assumed identical. The workflow has no manual trigger.
+   npm package Settings → Publishing access must be set to, and remain,
+   **Require two-factor authentication and disallow tokens**; trusted
+   publishing removes the CI token but does not disable traditional token
+   publishing by itself.
 6. **Verify the same day**: the release run is green including the guard step;
    `npm view mirafold version` shows `x.y.z`; the registry tarball's sha256
    matches the signed tag message (`curl` it down and `sha256sum` — the

--- a/server/adapters/codex-app-server.test.ts
+++ b/server/adapters/codex-app-server.test.ts
@@ -1,0 +1,16 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnAppServer } from "./codex-app-server";
+
+test("an oversized app-server line is rejected without a quadratic buffer stall", async () => {
+  const started = Date.now();
+  const client = spawnAppServer({
+    command: process.execPath,
+    args: ["-e", 'process.stdout.write("x".repeat(32 * 1024 * 1024 + 1))'],
+  });
+
+  await assert.rejects(client.request("probe"), /size limit/);
+
+  assert.ok(Date.now() - started < 5_000, "the ceiling fires promptly");
+  assert.match(client.stderrTail, /size limit/);
+});

--- a/server/adapters/codex-app-server.ts
+++ b/server/adapters/codex-app-server.ts
@@ -1,4 +1,5 @@
 import { spawn, type ChildProcess } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
 
 // The long-lived `codex app-server` transport: newline-delimited JSON-RPC
 // over the child's stdio, the same framing jsonrpc-oneshot.ts uses for the
@@ -36,7 +37,7 @@ export interface AppServerClient {
 
 // A single JSON line larger than this is not a protocol message we can use;
 // cut the process off rather than let one runaway line grow the daemon.
-const MAX_LINE_BYTES = 32 * 1024 * 1024;
+const MAX_LINE_CHARS = 32 * 1024 * 1024;
 const STDERR_TAIL_BYTES = 8 * 1024;
 
 export class AppServerExitedError extends Error {
@@ -105,21 +106,45 @@ export function spawnAppServer(spec: AppServerSpawn): AppServerClient {
     else p.resolve(m.result);
   };
 
-  let buf = "";
-  child.stdout?.on("data", (chunk: Buffer) => {
-    buf += chunk.toString("utf8");
-    if (buf.length > MAX_LINE_BYTES) {
-      stderrTail += "\nmirafold: app-server line exceeded the size limit";
-      child.kill("SIGKILL");
-      buf = "";
-      return;
+  const decoder = new StringDecoder("utf8");
+  let lineParts: string[] = [];
+  let lineChars = 0;
+  let lineTooLarge = false;
+  const overflow = () => {
+    if (lineTooLarge) return;
+    lineTooLarge = true;
+    lineParts = [];
+    lineChars = 0;
+    stderrTail += "\nmirafold: app-server line exceeded the size limit";
+    child.kill("SIGKILL");
+  };
+  const append = (part: string): boolean => {
+    if (lineChars + part.length > MAX_LINE_CHARS) {
+      overflow();
+      return false;
     }
-    let nl: number;
-    while ((nl = buf.indexOf("\n")) >= 0) {
-      const line = buf.slice(0, nl).trim();
-      buf = buf.slice(nl + 1);
+    if (part) lineParts.push(part);
+    lineChars += part.length;
+    return true;
+  };
+  const feed = (text: string) => {
+    let start = 0;
+    for (;;) {
+      const nl = text.indexOf("\n", start);
+      if (nl < 0) {
+        append(text.slice(start));
+        return;
+      }
+      if (!append(text.slice(start, nl))) return;
+      const line = lineParts.join("").trim();
+      lineParts = [];
+      lineChars = 0;
       if (line) onLine(line);
+      start = nl + 1;
     }
+  };
+  child.stdout?.on("data", (chunk: Buffer) => {
+    if (!lineTooLarge) feed(decoder.write(chunk));
   });
   child.stderr?.on("data", (chunk: Buffer) => {
     stderrTail = (stderrTail + chunk.toString("utf8")).slice(-STDERR_TAIL_BYTES);

--- a/server/adapters/gemini-cli.test.ts
+++ b/server/adapters/gemini-cli.test.ts
@@ -129,6 +129,21 @@ test("Gemini remains supported without a Mirafold retirement notice", async () =
   s.close();
 });
 
+test("an oversized stream-json line terminates the turn instead of growing without bound", async () => {
+  const events = path.join(tmp, "oversized-stream-line");
+  writeFileSync(events, "x".repeat(32 * 1024 * 1024 + 1));
+  process.env.FAKE_EVENTS = events;
+  const { s, msgs, awaitTurnEnd } = makeSession();
+  try {
+    s.pushPrompt("trigger the oversized frame");
+    await awaitTurnEnd();
+    assert.match(msgs.find((m) => m.type === "error")?.message ?? "", /size limit/);
+  } finally {
+    delete process.env.FAKE_EVENTS;
+    s.close();
+  }
+});
+
 test("Gemini inherits the user's MCP server set instead of allowlisting only Mirafold", async () => {
   const argsLog = path.join(tmp, "mcp-inheritance-args.txt");
   process.env.FAKE_ARGS_LOG = argsLog;

--- a/server/adapters/gemini-cli.ts
+++ b/server/adapters/gemini-cli.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { StringDecoder } from "node:string_decoder";
 import { createLogger, verbose } from "../log";
 import { UnknownKindReporter } from "./wire-helpers";
 import { closeSync, constants, mkdirSync, openSync, readFileSync, writeFileSync, existsSync, lstatSync } from "node:fs";
@@ -39,6 +40,10 @@ export function geminiRenderMcpConfig(render: RenderMcpLaunch = RENDER_MCP) {
 const MCP_PREFIX = `mcp_${MIRAFOLD_MCP}_`;
 // How much of a failed turn's stderr rides into the surfaced error.
 const STDERR_TAIL_CAP = 4000;
+// Match the Codex app-server boundary: a JSONL record larger than this is not
+// a protocol event Mirafold can safely retain. Tool output is capped much
+// lower after parsing; this ceiling protects the parser before that cap runs.
+const STREAM_LINE_MAX_CHARS = 32 * 1024 * 1024;
 // How long the folder-trust ask waits for an answer before denying —
 // the same posture as Claude's permission prompt: an unanswered ask must not
 // pin a turn open forever.
@@ -513,8 +518,11 @@ export class GeminiCliSession implements AgentSession {
       });
       this.child = child;
 
-      let buf = "";
+      const decoder = new StringDecoder("utf8");
+      let lineParts: string[] = [];
+      let lineChars = 0;
       let ended = false;
+      let streamTooLarge = false;
       // Whether any stdout event parsed this turn, and a capped stderr
       // tail — so a stderr-only non-zero exit (the trust-folder trap: Gemini
       // writes the error to stderr, exits 55, and emits NOTHING on stdout)
@@ -540,13 +548,49 @@ export class GeminiCliSession implements AgentSession {
         this.handleEvent(ev);
       };
 
-      child.stdout.on("data", (chunk: Buffer) => {
-        buf += chunk.toString();
-        let nl: number;
-        while ((nl = buf.indexOf("\n")) >= 0) {
-          consume(buf.slice(0, nl));
-          buf = buf.slice(nl + 1);
+      const rejectOversizedLine = () => {
+        if (streamTooLarge) return;
+        streamTooLarge = true;
+        lineParts = [];
+        lineChars = 0;
+        if (!this.closed) {
+          this.emit({ type: "error", message: "gemini stream-json line exceeded the size limit" });
         }
+        child.kill("SIGKILL");
+      };
+
+      // Keep chunks separately until a newline arrives. Repeatedly appending
+      // to one growing string copies the entire partial line on every stdout
+      // chunk; a 32 MiB malformed line otherwise stalls the event loop for
+      // seconds before the limit can fire.
+      const append = (part: string): boolean => {
+        if (lineChars + part.length > STREAM_LINE_MAX_CHARS) {
+          rejectOversizedLine();
+          return false;
+        }
+        if (part) lineParts.push(part);
+        lineChars += part.length;
+        return true;
+      };
+      const feed = (text: string) => {
+        let start = 0;
+        for (;;) {
+          const nl = text.indexOf("\n", start);
+          if (nl < 0) {
+            append(text.slice(start));
+            return;
+          }
+          if (!append(text.slice(start, nl))) return;
+          consume(lineParts.join(""));
+          lineParts = [];
+          lineChars = 0;
+          start = nl + 1;
+        }
+      };
+
+      child.stdout.on("data", (chunk: Buffer) => {
+        if (streamTooLarge) return;
+        feed(decoder.write(chunk));
       });
       // Usually diagnostics, but sometimes the ONLY signal. Keep a
       // capped tail for the stderr-only-failure path; MIRAFOLD_DEBUG=1 also
@@ -556,7 +600,11 @@ export class GeminiCliSession implements AgentSession {
         if (verbose) createLogger("gemini-cli").debug(`stderr — ${d}`);
       });
       child.on("close", (code: number | null) => {
-        if (buf) consume(buf);
+        if (!streamTooLarge) {
+          const tail = decoder.end();
+          if (tail) feed(tail);
+          if (!streamTooLarge && lineChars) consume(lineParts.join(""));
+        }
         if (this.child === child) this.child = undefined;
         // A non-zero exit that produced no stdout events, with something
         // on stderr, is a silent failure — surface it (code null = a signal

--- a/server/adapters/opencode-client.ts
+++ b/server/adapters/opencode-client.ts
@@ -72,6 +72,10 @@ export interface OpenCodeTransport {
 
 const START_DEADLINE_MS = envInt("MIRAFOLD_OPENCODE_START_TIMEOUT_MS", 20_000);
 const CONTROL_REQUEST_TIMEOUT_MS = envInt("MIRAFOLD_OPENCODE_CONTROL_TIMEOUT_MS", 10_000);
+// Same pre-parser boundary as the Codex app-server JSONL transport. Display
+// payloads are capped much lower after parsing; this protects the long-lived
+// SSE accumulator before any event mapper gets a chance to do that work.
+const EVENT_FRAME_MAX_CHARS = 32 * 1024 * 1024;
 
 /** One agent from `GET /agent` — `hidden: true` marks the engine's internal
  *  primaries (compaction/summary/title), which no picker should offer. */
@@ -297,31 +301,95 @@ export class OpenCodeServerProcess implements OpenCodeTransport {
   }
 
   /** Read the SSE stream for this SPAWN's life, reconnecting on drops. */
-  private async pumpEvents(onEvent: (ev: OpenCodeEvent) => void, generation: number): Promise<void> {
+  private async pumpEvents(
+    onEvent: (ev: OpenCodeEvent) => void,
+    generation: number,
+    maxFrameChars = EVENT_FRAME_MAX_CHARS,
+  ): Promise<void> {
     while (!this.closed && this.generation === generation) {
       try {
         const res = await fetch(`${this.base}/event`, { headers: { authorization: this.auth } });
         if (!res.ok || !res.body) throw new Error(`event stream HTTP ${res.status}`);
         const reader = res.body.getReader();
         const decoder = new TextDecoder();
-        let buffer = "";
+        let frameParts: string[] = [];
+        let frameChars = 0;
+        let pendingNewline = false;
+        const rejectOversizedFrame = () => {
+          this.stderrTail = (
+            this.stderrTail + "\nmirafold: event stream frame exceeded the size limit"
+          ).slice(-2000);
+          if (this.generation === generation) this.child?.kill("SIGKILL");
+          void reader.cancel().catch(() => {});
+        };
+        const appendFrame = (text: string): boolean => {
+          if (frameChars + text.length > maxFrameChars) {
+            rejectOversizedFrame();
+            return false;
+          }
+          if (text) frameParts.push(text);
+          frameChars += text.length;
+          return true;
+        };
+        const emitFrame = () => {
+          const frame = frameParts.length === 1 ? frameParts[0] : frameParts.join("");
+          frameParts = [];
+          frameChars = 0;
+          const prefix = "data: ";
+          let lineStart = 0;
+          if (!frame.startsWith(prefix)) {
+            lineStart = frame.indexOf(`\n${prefix}`);
+            if (lineStart < 0) return;
+            lineStart += 1;
+          }
+          const dataStart = lineStart + prefix.length;
+          const lineEnd = frame.indexOf("\n", dataStart);
+          const data = frame.slice(dataStart, lineEnd < 0 ? undefined : lineEnd);
+          try {
+            onEvent(JSON.parse(data) as OpenCodeEvent);
+          } catch {
+            // one unparseable frame must not kill the stream
+          }
+        };
+        // Search only each newly decoded chunk. Retaining frame fragments and
+        // joining once at the delimiter keeps a long fragmented frame linear.
+        const consume = (text: string): boolean => {
+          let offset = 0;
+          if (pendingNewline && text) {
+            pendingNewline = false;
+            if (text.startsWith("\n")) {
+              emitFrame();
+              offset = 1;
+            } else if (!appendFrame("\n")) {
+              return false;
+            }
+          }
+          while (offset < text.length) {
+            const boundary = text.indexOf("\n\n", offset);
+            if (boundary >= 0) {
+              if (!appendFrame(text.slice(offset, boundary))) return false;
+              emitFrame();
+              offset = boundary + 2;
+              continue;
+            }
+            const tail = text.slice(offset);
+            if (tail.endsWith("\n")) {
+              if (!appendFrame(tail.slice(0, -1))) return false;
+              pendingNewline = true;
+            } else if (!appendFrame(tail)) {
+              return false;
+            }
+            break;
+          }
+          return true;
+        };
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          let boundary;
-          while ((boundary = buffer.indexOf("\n\n")) >= 0) {
-            const chunk = buffer.slice(0, boundary);
-            buffer = buffer.slice(boundary + 2);
-            const data = chunk.split("\n").find((line) => line.startsWith("data: "));
-            if (!data) continue;
-            try {
-              onEvent(JSON.parse(data.slice(6)) as OpenCodeEvent);
-            } catch {
-              // one unparseable frame must not kill the stream
-            }
-          }
+          if (!consume(decoder.decode(value, { stream: true }))) return;
         }
+        if (!consume(decoder.decode())) return;
+        if (pendingNewline && !appendFrame("\n")) return;
       } catch {
         // fall through to reconnect
       }

--- a/server/adapters/opencode.test.ts
+++ b/server/adapters/opencode.test.ts
@@ -1,8 +1,8 @@
-import { test } from "node:test";
+import { after, test } from "node:test";
 import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import type { WireMsg } from "../protocol";
 import { MIRAFOLD_CONTEXT, RENDER_GUIDANCE } from "../render-tools";
 import { OpenCodeSession, openCodeRenderMcpConfig } from "./opencode";
@@ -18,12 +18,18 @@ import { OPENCODE_SUBAGENT_EVENTS } from "../testing/opencode-subagent-fixture";
 
 type Any = WireMsg & Record<string, any>;
 
+const previousTrustFile = process.env.MIRAFOLD_WORKSPACE_TRUST_FILE;
 const tmp = mkdtempSync(path.join(os.tmpdir(), "mcp-opencode-test-"));
 // The folder-trust gate (audit 2026-08-26): sessions under `tmp` start warm;
 // the gate has its own untrusted-folder test at the end.
 const trustRecord = path.join(tmp, "trusted-workspaces.json");
 writeFileSync(trustRecord, JSON.stringify({ version: 2, scopes: { opencode: [tmp] } }));
 process.env.MIRAFOLD_WORKSPACE_TRUST_FILE = trustRecord;
+after(() => {
+  if (previousTrustFile === undefined) delete process.env.MIRAFOLD_WORKSPACE_TRUST_FILE;
+  else process.env.MIRAFOLD_WORKSPACE_TRUST_FILE = previousTrustFile;
+  rmSync(tmp, { recursive: true, force: true });
+});
 const SES = "ses_test";
 
 class FakeTransport implements OpenCodeTransport {
@@ -1448,6 +1454,170 @@ test("AUDIT: the minted server password is redacted from a stderr tail (pure)", 
   assert.equal(redactSecret("nothing to redact", ""), "nothing to redact");
 });
 
+test("a fragmented oversized SSE frame is rejected promptly", async () => {
+  const transport = new OpenCodeServerProcess({
+    bin: "unused",
+    cwd: tmp,
+    configContent: {},
+  });
+  const internals = transport as unknown as {
+    base: string;
+    auth: string;
+    generation: number;
+    stderrTail: string;
+    pumpEvents(
+      onEvent: (event: OpenCodeEvent) => void,
+      generation: number,
+      maxFrameChars?: number,
+    ): Promise<void>;
+  };
+  internals.base = "http://opencode.test";
+  internals.auth = "Basic test";
+  internals.generation = 1;
+  const seen: OpenCodeEvent[] = [];
+  const realFetch = globalThis.fetch;
+  const chunk = new TextEncoder().encode("x".repeat(64 * 1024));
+  let sent = 0;
+  globalThis.fetch = (async () => {
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(sent++ < 512 ? chunk : new Uint8Array([120]));
+      },
+    });
+    return new Response(body, {
+      status: 200,
+      headers: { "content-type": "text/event-stream" },
+    });
+  }) as typeof fetch;
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      internals.pumpEvents((event) => seen.push(event), 1),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("fragmented frame rejection timed out")), 2_000);
+      }),
+    ]);
+    assert.deepEqual(seen, []);
+    assert.match(internals.stderrTail, /size limit/);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    globalThis.fetch = realFetch;
+    transport.close();
+  }
+});
+
+test("SSE frames parse across a split boundary and line-dense metadata", async () => {
+  const transport = new OpenCodeServerProcess({
+    bin: "unused",
+    cwd: tmp,
+    configContent: {},
+  });
+  const internals = transport as unknown as {
+    base: string;
+    auth: string;
+    generation: number;
+    pumpEvents(
+      onEvent: (event: OpenCodeEvent) => void,
+      generation: number,
+      maxFrameChars?: number,
+    ): Promise<void>;
+  };
+  internals.base = "http://opencode.test";
+  internals.auth = "Basic test";
+  internals.generation = 1;
+  const encoder = new TextEncoder();
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode('\ndata: {"type":"one","properties":{}}\n'));
+        controller.enqueue(
+          encoder.encode(
+            `\nevent: message\n${"x\n".repeat(512 * 1024)}data: {"type":"two","properties":{}}\n\n`,
+          ),
+        );
+        controller.close();
+      },
+    });
+    return new Response(body, { status: 200 });
+  }) as typeof fetch;
+  const seen: OpenCodeEvent[] = [];
+  try {
+    await internals.pumpEvents((event) => {
+      seen.push(event);
+      if (seen.length === 2) transport.close();
+    }, 1);
+    assert.deepEqual(
+      seen.map((event) => event.type),
+      ["one", "two"],
+    );
+  } finally {
+    globalThis.fetch = realFetch;
+    transport.close();
+  }
+});
+
+test("an oversized SSE frame kills the child before cancelling the stream", async () => {
+  const transport = new OpenCodeServerProcess({
+    bin: "unused",
+    cwd: tmp,
+    configContent: {},
+  });
+  const internals = transport as unknown as {
+    base: string;
+    auth: string;
+    child: { kill(signal?: NodeJS.Signals): boolean };
+    generation: number;
+    pumpEvents(
+      onEvent: (event: OpenCodeEvent) => void,
+      generation: number,
+      maxFrameChars?: number,
+    ): Promise<void>;
+  };
+  internals.base = "http://opencode.test";
+  internals.auth = "Basic test";
+  internals.generation = 1;
+  let killed = false;
+  let killSignal: NodeJS.Signals | undefined;
+  let killedBeforeCancel = false;
+  internals.child = {
+    kill(signal) {
+      killed = true;
+      killSignal ??= signal;
+      return true;
+    },
+  };
+  const realFetch = globalThis.fetch;
+  globalThis.fetch = (async () => {
+    const body = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("x".repeat(65)));
+      },
+      cancel() {
+        killedBeforeCancel = killed;
+        return new Promise<void>(() => {});
+      },
+    });
+    return new Response(body, { status: 200 });
+  }) as typeof fetch;
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      internals.pumpEvents(() => {}, 1, 64),
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("event pump awaited cancellation")), 500);
+      }),
+    ]);
+    assert.equal(killed, true);
+    assert.equal(killSignal, "SIGKILL");
+    assert.equal(killedBeforeCancel, true);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+    globalThis.fetch = realFetch;
+    transport.close();
+  }
+});
+
 test("an explicit failure of the injected renderer aborts OpenCode startup", async () => {
   const transport = new OpenCodeServerProcess({
     bin: "unused",
@@ -1614,6 +1784,7 @@ test("an untrusted folder asks before `opencode serve` starts; a no spawns nothi
     await waitFor(() => fake.prompts.length === 1, "the prompt reaches the engine");
   } finally {
     session.close();
+    rmSync(ws, { recursive: true, force: true });
   }
 });
 

--- a/server/project-env-safety.test.ts
+++ b/server/project-env-safety.test.ts
@@ -1,0 +1,46 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { loadProjectEnv } from "./project-env";
+
+const tmp = () => mkdtempSync(path.join(os.tmpdir(), "mirafold-project-config-"));
+
+test("project configuration loads from an ordinary bounded file", (t) => {
+  const dir = tmp();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "project-config");
+  writeFileSync(file, "PORT=4123\n");
+  const target: NodeJS.ProcessEnv = {};
+
+  loadProjectEnv(file, target);
+
+  assert.equal(target.PORT, "4123");
+});
+
+test("project configuration refuses a symlink before folder trust", (t) => {
+  const dir = tmp();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const outside = path.join(dir, "outside-config");
+  const link = path.join(dir, "project-config-link");
+  writeFileSync(outside, "OPENAI_API_KEY=outside\n");
+  symlinkSync(outside, link);
+  const target: NodeJS.ProcessEnv = {};
+
+  loadProjectEnv(link, target);
+
+  assert.equal(target.OPENAI_API_KEY, undefined);
+});
+
+test("project configuration refuses a file larger than its startup ceiling", (t) => {
+  const dir = tmp();
+  t.after(() => rmSync(dir, { recursive: true, force: true }));
+  const file = path.join(dir, "oversized-project-config");
+  writeFileSync(file, `PORT=4123\n${"#".repeat(1024 * 1024)}\n`);
+  const target: NodeJS.ProcessEnv = {};
+
+  loadProjectEnv(file, target);
+
+  assert.equal(target.PORT, undefined);
+});

--- a/server/project-env.ts
+++ b/server/project-env.ts
@@ -3,8 +3,66 @@
 // overrides, PATH/shell controls, runtime loader hooks, and arbitrary project
 // variables stay available only when the operator supplied them before launch.
 
-import { readFileSync } from "node:fs";
+import {
+  closeSync,
+  constants,
+  fstatSync,
+  lstatSync,
+  openSync,
+  readSync,
+} from "node:fs";
 import { parseEnv } from "node:util";
+
+// Project configuration is a tiny text file. Bound the descriptor read itself
+// so a planted device/FIFO or a growing file cannot pin or exhaust the daemon
+// before the folder-trust question is even shown.
+const PROJECT_ENV_MAX_BYTES = 1024 * 1024;
+
+function readProjectEnvFile(file: string): string | undefined {
+  try {
+    // The pre-open check rejects a checkout-supplied symlink on every
+    // platform. O_NOFOLLOW below also closes the check/open race where the
+    // platform provides it; O_NONBLOCK keeps a raced special file from
+    // blocking before fstat rejects it.
+    if (!lstatSync(file).isFile()) return undefined;
+  } catch {
+    return undefined;
+  }
+
+  let fd: number | undefined;
+  try {
+    fd = openSync(
+      file,
+      constants.O_RDONLY |
+        (constants.O_NOFOLLOW ?? 0) |
+        (constants.O_NONBLOCK ?? 0),
+    );
+    const stat = fstatSync(fd);
+    if (!stat.isFile() || stat.size > PROJECT_ENV_MAX_BYTES) return undefined;
+
+    // Read the opened descriptor, not the path. The fixed-size buffer keeps a
+    // file that grows after fstat from allocating beyond one extra byte.
+    const bytes = Buffer.alloc(stat.size + 1);
+    let read = 0;
+    while (read < bytes.length) {
+      const count = readSync(fd, bytes, read, bytes.length - read, null);
+      if (count === 0) break;
+      read += count;
+    }
+    if (read > PROJECT_ENV_MAX_BYTES) return undefined;
+    return bytes.subarray(0, read).toString("utf8");
+  } catch {
+    return undefined;
+  } finally {
+    if (fd !== undefined) {
+      try {
+        closeSync(fd);
+      } catch {
+        // Optional startup configuration must never abort the daemon.
+      }
+    }
+  }
+}
 
 export const PROJECT_ENV_KEYS: ReadonlySet<string> = new Set([
   // Agent selection, credentials, endpoints, and model choices.
@@ -113,7 +171,9 @@ export function loadProjectEnv(
 ): void {
   let parsed: NodeJS.Dict<string>;
   try {
-    parsed = parseEnv(readFileSync(file, "utf8"));
+    const source = readProjectEnvFile(file);
+    if (source === undefined) return;
+    parsed = parseEnv(source);
   } catch {
     return;
   }

--- a/server/relay/entitlement.test.ts
+++ b/server/relay/entitlement.test.ts
@@ -127,20 +127,44 @@ test("malformed exchange response degrades to no token, never throws", async () 
   }
 });
 
+test("oversized billing JSON and entitlement tokens degrade to no token", async () => {
+  for (const body of [
+    { token: "x".repeat(70_000), exp: futureExp() },
+    { token: "x".repeat(9_000), exp: futureExp() },
+  ]) {
+    const fetchMock = mock.method(globalThis, "fetch", async () => jsonResponse(200, body));
+    try {
+      const src = createEntitlementTokenSource({
+        MIRAFOLD_LICENSE_KEY: "mf_test",
+        MIRAFOLD_ENTITLEMENT_URL: "http://billing.test/api/entitlement",
+      });
+      assert.equal(await src.get(), undefined);
+      src.stop();
+    } finally {
+      fetchMock.mock.restore();
+    }
+  }
+});
+
 // AUDIT 2026-08-26: no key bytes in the log, not even a prefix.
 test("AUDIT: a refused license key is never echoed into the log, not even its prefix", async () => {
   const lines: string[] = [];
   const warn = mock.method(console, "warn", (...args: unknown[]) => lines.push(args.map(String).join(" ")));
   const error = mock.method(console, "error", (...args: unknown[]) => lines.push(args.map(String).join(" ")));
+  const fetchMock = mock.method(globalThis, "fetch", async () =>
+    jsonResponse(403, { reason: "lapsed" }),
+  );
+  const source = createEntitlementTokenSource({
+    MIRAFOLD_LICENSE_KEY: "mf_SECRETSECRETSECRET",
+    MIRAFOLD_ENTITLEMENT_URL: "http://billing.test/api/entitlement",
+  });
   try {
-    const source = createEntitlementTokenSource({
-      licenseKey: "mf_SECRETSECRETSECRET",
-      url: "http://127.0.0.1:1/api/entitlement",
-      fetchImpl: (async () => new Response(JSON.stringify({ reason: "lapsed" }), { status: 403 })) as unknown as typeof fetch,
-    } as unknown as Parameters<typeof createEntitlementTokenSource>[0]);
-    await source.get().catch(() => undefined);
-    source.stop();
+    assert.equal(await source.get(), undefined);
+    assert.equal(fetchMock.mock.callCount(), 1);
+    assert.ok(lines.some((line) => line.includes("entitlement refused")), lines.join(" | "));
   } finally {
+    source.stop();
+    fetchMock.mock.restore();
     warn.mock.restore();
     error.mock.restore();
   }

--- a/server/relay/entitlement.ts
+++ b/server/relay/entitlement.ts
@@ -31,6 +31,8 @@ const REFRESH_INTERVAL_MS = 12 * 60 * 60 * 1000; // well inside the 48h token TT
 // backoff into an HTTP hammer.
 const FORCED_REFRESH_MIN_GAP_MS = 60_000;
 const FETCH_TIMEOUT_MS = 10_000;
+const BILLING_RESPONSE_MAX_BYTES = 64 * 1024;
+const ENTITLEMENT_TOKEN_MAX_BYTES = 8_192;
 // A backend line rides to the pair/manage card verbatim — bounded. Shared
 // with subscription.ts so both cards cap alike.
 export const MAX_REASON_CHARS = 200;
@@ -71,6 +73,31 @@ export function postLicenseKey(endpoint: string, licenseKey: string, timeoutMs: 
     body: JSON.stringify({ licenseKey }),
     signal: AbortSignal.timeout(timeoutMs),
   });
+}
+
+/** Parse one billing-backend JSON response without letting a chunked or
+ *  misconfigured endpoint allocate an unlimited body first. */
+export async function readBillingJson(res: Response): Promise<unknown> {
+  if (!res.body) throw new Error("empty response");
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let bytes = 0;
+  let text = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      bytes += value.byteLength;
+      if (bytes > BILLING_RESPONSE_MAX_BYTES) {
+        await reader.cancel().catch(() => {});
+        throw new Error("billing response exceeded the size limit");
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    return JSON.parse(text + decoder.decode()) as unknown;
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 export function createEntitlementTokenSource(env: {
@@ -160,9 +187,9 @@ export function createEntitlementTokenSource(env: {
       if (res.status === 403) {
         // The backend's body is untrusted JSON — any shape, `null` included;
         // only a string `reason` is quoted, and nothing here may throw.
-        const body: unknown = await res.json().catch(() => undefined);
+        const body: unknown = await readBillingJson(res).catch(() => undefined);
         const raw = body && typeof body === "object" ? (body as { reason?: unknown }).reason : undefined;
-        const reason = typeof raw === "string" ? raw : undefined;
+        const reason = typeof raw === "string" ? raw.slice(0, MAX_REASON_CHARS) : undefined;
         if (!denied) {
           log.warn(
             `entitlement refused for license ${mask(licenseKey)}: ` +
@@ -172,11 +199,17 @@ export function createEntitlementTokenSource(env: {
         }
         denied = true;
         cached = undefined;
-        next = { state: "invalid", ...(reason ? { reason: reason.slice(0, MAX_REASON_CHARS) } : {}) };
+        next = { state: "invalid", ...(reason ? { reason } : {}) };
       } else {
         if (!res.ok) throw new Error(`http ${res.status}`);
-        const body = (await res.json()) as { token?: unknown; exp?: unknown };
-        if (typeof body.token !== "string" || typeof body.exp !== "number") {
+        const body = (await readBillingJson(res)) as { token?: unknown; exp?: unknown };
+        if (
+          typeof body.token !== "string" ||
+          body.token.length === 0 ||
+          Buffer.byteLength(body.token, "utf8") > ENTITLEMENT_TOKEN_MAX_BYTES ||
+          typeof body.exp !== "number" ||
+          !Number.isFinite(body.exp)
+        ) {
           throw new Error("malformed response");
         }
         cached = { token: body.token, expMs: body.exp * 1000 };

--- a/server/relay/subscription.test.ts
+++ b/server/relay/subscription.test.ts
@@ -97,6 +97,25 @@ test("CS: a backend refusal's reason surfaces, bounded; malformed and down degra
   }
 });
 
+test("CS: oversized billing JSON and date fields never reach the subscription view", async () => {
+  let oversizedBody = true;
+  const m = mock.method(globalThis, "fetch", async () =>
+    oversizedBody
+      ? Response.json({ status: "active", padding: "x".repeat(70_000) })
+      : Response.json({ status: "active", periodEnd: "x".repeat(65), cancelAt: "soon" }),
+  );
+  try {
+    const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY })!;
+    assert.deepEqual(await actions.status(), { error: SUPPORT_FALLBACK });
+    oversizedBody = false;
+    assert.deepEqual(await actions.status(), {
+      view: { status: "active", cancelAt: "soon" },
+    });
+  } finally {
+    m.mock.restore();
+  }
+});
+
 test("CS: the throttle admits one in-flight action and floors restarts", () => {
   const t = createSubscriptionThrottle(60_000);
   assert.equal(t.tryStart(), true);

--- a/server/relay/subscription.ts
+++ b/server/relay/subscription.ts
@@ -17,7 +17,12 @@
 
 import { createLogger } from "../log";
 import { inflightSlot, minInterval } from "../throttle";
-import { MAX_REASON_CHARS, postLicenseKey, resolveEntitlementUrl } from "./entitlement";
+import {
+  MAX_REASON_CHARS,
+  postLicenseKey,
+  readBillingJson,
+  resolveEntitlementUrl,
+} from "./entitlement";
 
 const log = createLogger("billing");
 
@@ -48,7 +53,8 @@ export function subscriptionBase(entitlementUrl: string): string | undefined {
   return base === entitlementUrl ? undefined : base;
 }
 
-const optionalIso = (v: unknown): string | undefined => (typeof v === "string" ? v : undefined);
+const optionalIso = (v: unknown): string | undefined =>
+  typeof v === "string" && v.length <= 64 ? v : undefined;
 
 export function createSubscriptionActions(env: {
   MIRAFOLD_ENTITLEMENT_TOKEN?: string;
@@ -75,12 +81,15 @@ export function createSubscriptionActions(env: {
         // Our backend's own composed refusal (unknown/superseded key). Shown
         // as-is but bounded: a self-hoster can point the exchange anywhere,
         // and this string lands in a shell-owned surface.
-        const reason = ((await res.json().catch(() => ({}))) as { reason?: string; error?: string });
+        const reason = ((await readBillingJson(res).catch(() => ({}))) as {
+          reason?: string;
+          error?: string;
+        });
         const text = typeof reason.reason === "string" ? reason.reason : reason.error;
         return { error: (text || SUPPORT_FALLBACK).slice(0, MAX_REASON_CHARS) };
       }
       if (!res.ok) throw new Error(`http ${res.status}`);
-      const body = (await res.json()) as Record<string, unknown>;
+      const body = (await readBillingJson(res)) as Record<string, unknown>;
       if (typeof body.status !== "string") throw new Error("malformed response");
       const view: SubscriptionView = { status: body.status.slice(0, 40) };
       const periodEnd = optionalIso(body.periodEnd);

--- a/server/release-workflow.test.ts
+++ b/server/release-workflow.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const workflow = readFileSync(
+  new URL("../.github/workflows/release.yml", import.meta.url),
+  "utf8",
+);
+
+test("npm publishing is tag-only and bound to the protected environment", () => {
+  const publishStart = workflow.indexOf("\n  publish:\n");
+  assert.notEqual(publishStart, -1, "publish job exists");
+  const verify = workflow.slice(0, publishStart);
+  const publish = workflow.slice(publishStart);
+
+  assert.match(workflow, /^on:\n  push:\n    tags: \["v\*"\]\n\n/m);
+  assert.doesNotMatch(workflow, /^\s*workflow_dispatch:/m);
+  assert.equal(workflow.match(/^    environment: npm-publish$/gm)?.length, 1);
+  assert.match(publish, /^    environment: npm-publish$/m);
+  assert.equal(workflow.match(/^      id-token: write$/gm)?.length, 1);
+  assert.doesNotMatch(verify, /^      id-token: write$/m);
+  assert.doesNotMatch(verify, /^\s+- run: npm publish/m);
+  assert.match(publish, /^      id-token: write$/m);
+  assert.doesNotMatch(publish, /--dry-run/);
+});

--- a/server/sessions/actions.test.ts
+++ b/server/sessions/actions.test.ts
@@ -7,8 +7,9 @@ import { runActionTool, actionToolNames } from "./actions";
 
 const tmp = () => mkdtempSync(path.join(os.tmpdir(), "genui-act-"));
 
-test("workspace_ls lists a real subdirectory", () => {
+test("workspace_ls lists a real subdirectory", (t) => {
   const base = tmp();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
   mkdirSync(path.join(base, "sub"));
   writeFileSync(path.join(base, "sub", "f.txt"), "hi");
   const r = runActionTool("workspace_ls", { path: "sub" }, base);
@@ -16,16 +17,18 @@ test("workspace_ls lists a real subdirectory", () => {
   assert.match(r.output, /f\.txt/);
 });
 
-test("workspace_ls handles '.'", () => {
+test("workspace_ls handles '.'", (t) => {
   const base = tmp();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
   writeFileSync(path.join(base, "a.txt"), "x");
   const r = runActionTool("workspace_ls", { path: "." }, base);
   assert.equal(r.isError, false);
   assert.match(r.output, /a\.txt/);
 });
 
-test("workspace_ls blocks a symlink escaping the workspace", () => {
+test("workspace_ls blocks a symlink escaping the workspace", (t) => {
   const base = tmp();
+  t.after(() => rmSync(base, { recursive: true, force: true }));
   symlinkSync(os.tmpdir(), path.join(base, "escape")); // points above the workspace
   const r = runActionTool("workspace_ls", { path: "escape" }, base);
   assert.equal(r.isError, true);
@@ -61,6 +64,24 @@ test("workspace_ls survives a dangling symlink — the row is marked, siblings s
     assert.equal(res.isError, false);
     assert.match(res.output, /real\.txt/);
     assert.match(res.output, /\?\s+dangling/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("workspace_ls bounds flat-directory work and reports truncation", () => {
+  const dir = tmp();
+  try {
+    for (let i = 0; i < 2_001; i++) {
+      writeFileSync(path.join(dir, `entry-${String(i).padStart(4, "0")}.txt`), "x");
+    }
+
+    const result = runActionTool("workspace_ls", {}, dir);
+
+    assert.equal(result.isError, false);
+    assert.match(result.output, /\(listing truncated\)$/);
+    assert.ok(result.output.split("\n").length <= 2_001);
+    assert.ok(Buffer.byteLength(result.output, "utf8") <= 64_000);
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/server/sessions/actions.ts
+++ b/server/sessions/actions.ts
@@ -5,12 +5,15 @@
 // effect is visible in every viewport's transcript.
 
 import { createLogger } from "../log";
-import { readdirSync, realpathSync, statSync } from "node:fs";
+import { opendirSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import { z } from "zod";
 import { errText } from "../adapters/types";
 
 const log = createLogger("action");
+const WORKSPACE_LS_MAX_ENTRIES = 2_000;
+const WORKSPACE_LS_MAX_OUTPUT_BYTES = 64_000;
+const WORKSPACE_LS_TRUNCATED = "(listing truncated)";
 
 type ActionTool = {
   description: string;
@@ -43,22 +46,45 @@ const ACTION_TOOLS: Record<string, ActionTool> = {
     run: (args, cwd) => {
       const target = inside(cwd, String(args["path"] ?? "."));
       if (!target) throw new Error("path escapes the session workspace");
-      const names = readdirSync(target);
-      if (names.length === 0) return "(empty)";
-      return names
-        .map((n) => {
+      const dir = opendirSync(target);
+      const lines: string[] = [];
+      let outputBytes = 0;
+      let scanned = 0;
+      let truncated = false;
+      const markerBytes = Buffer.byteLength(WORKSPACE_LS_TRUNCATED, "utf8") + 1;
+      try {
+        for (;;) {
+          const entry = dir.readSync();
+          if (!entry) break;
+          if (scanned++ >= WORKSPACE_LS_MAX_ENTRIES) {
+            truncated = true;
+            break;
+          }
+          const n = entry.name;
           // Per-entry stat failures (a dangling symlink; a file the agent
           // deleted between readdir and stat) mark that ROW, never the whole
           // listing — one broken link must not turn every sibling invisible
           // (fs-folder-tree handles the same case).
+          let line: string;
           try {
             const s = statSync(path.join(target, n));
-            return `${s.isDirectory() ? "d" : "-"} ${String(s.size).padStart(8)}  ${n}${s.isDirectory() ? "/" : ""}`;
+            line = `${s.isDirectory() ? "d" : "-"} ${String(s.size).padStart(8)}  ${n}${s.isDirectory() ? "/" : ""}`;
           } catch {
-            return `- ${"?".padStart(8)}  ${n}`;
+            line = `- ${"?".padStart(8)}  ${n}`;
           }
-        })
-        .join("\n");
+          const lineBytes = Buffer.byteLength(line, "utf8") + (lines.length ? 1 : 0);
+          if (outputBytes + lineBytes + markerBytes > WORKSPACE_LS_MAX_OUTPUT_BYTES) {
+            truncated = true;
+            break;
+          }
+          lines.push(line);
+          outputBytes += lineBytes;
+        }
+      } finally {
+        dir.closeSync();
+      }
+      if (lines.length === 0 && !truncated) return "(empty)";
+      return `${lines.join("\n")}${truncated ? `${lines.length ? "\n" : ""}${WORKSPACE_LS_TRUNCATED}` : ""}`;
     },
   },
 };

--- a/server/sessions/fs-directory-limits.test.ts
+++ b/server/sessions/fs-directory-limits.test.ts
@@ -1,0 +1,19 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { listDir } from "./fs-folder-tree";
+
+test("lazy directory listing bounds its raw scan before reply capping", (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-dir-limit-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  for (let i = 0; i < 8; i++) writeFileSync(path.join(root, `f-${i}.txt`), "x");
+
+  const result = listDir(root, "", { maxEntries: 20, maxScanEntries: 3 });
+
+  assert.ok("entries" in result);
+  if (!("entries" in result)) return;
+  assert.equal(result.entries.length, 3);
+  assert.equal(result.truncated, true);
+});

--- a/server/sessions/fs-folder-tree.ts
+++ b/server/sessions/fs-folder-tree.ts
@@ -15,9 +15,11 @@ import {
   fstatSync,
   lstatSync,
   openSync,
+  opendirSync,
   readlinkSync,
   readdirSync,
   readSync,
+  type Dirent,
 } from "node:fs";
 import path from "node:path";
 import type { FsDirEntry, FsEntry } from "../protocol";
@@ -52,6 +54,11 @@ const SKIP_DIRS = new Set([".git", "node_modules"]);
 // Strictly tighter than the whole-tree caps, since the unit is one readdir.
 const FS_DIR_MAX_ENTRIES = envInt("FS_DIR_MAX_ENTRIES", 2_000);
 const FS_DIR_MAX_NAME_BYTES = envInt("FS_DIR_MAX_NAME_BYTES", 200_000);
+// Git decoration can discard ignored entries before the reply caps apply, so
+// the raw scan needs headroom beyond FS_DIR_MAX_ENTRIES. It still needs a hard
+// ceiling of its own: readdirSync would otherwise allocate every name in a
+// pathological flat directory before either reply cap saw it.
+const FS_DIR_MAX_SCAN_ENTRIES = 10_000;
 
 // A file read is bounded twice: the sniff window that decides binary vs
 // text, and the content cap — same size and same honesty contract as the
@@ -179,23 +186,24 @@ export function listTree(
 }
 
 /**
- * The raw readdir behind the lazy tree's fetch unit: jail, kinds, and the
- * SKIP_DIRS floor — but no sort, no caps, and the resolved real path kept.
- * Split out so the git layer can decorate or filter a listing BEFORE
- * the caps apply — a dropped ignored entry must free its cap budget, and a
- * merged deleted entry must count against it. `rel` is the client's requested
+ * The raw directory scan behind the lazy tree's fetch unit: jail, kinds, the
+ * SKIP_DIRS floor, and a work cap, with the resolved real path kept. Split out
+ * so the git layer can decorate or filter a listing BEFORE the tighter reply
+ * caps apply — a dropped ignored entry must free its cap budget, and a merged
+ * deleted entry must count against it. `rel` is the client's requested
  * root-relative path ("" or "." = the root). Symlinks are leaves by kind
  * (lstat semantics: a symlink-to-dir reports `symlink`, not `dir`).
  */
 export function readDirRaw(
   root: string,
   rel: string,
-): { real: string; all: FsDirEntry[] } | { error: string } {
+  maxScanEntries = FS_DIR_MAX_SCAN_ENTRIES,
+): { real: string; all: FsDirEntry[]; truncated: boolean } | { error: string } {
   const real = inside(root, rel === "" ? "." : rel);
   if (!real) return { error: "path is outside the session workspace" };
-  let dirents;
+  let dir;
   try {
-    dirents = readdirSync(real, { withFileTypes: true });
+    dir = opendirSync(real);
   } catch (err) {
     return {
       error:
@@ -204,15 +212,36 @@ export function readDirRaw(
           : "directory is not readable",
     };
   }
-  const kindOf = (d: (typeof dirents)[number]): FsDirEntry["kind"] =>
+  const kindOf = (d: Dirent): FsDirEntry["kind"] =>
     // Order matters: isDirectory() is false for a symlink-to-dir (lstat
     // semantics), so the symlink check needn't come first — but a FIFO or
     // socket lands as `file`, same as the walk lists it (refused at read time).
     d.isDirectory() ? "dir" : d.isSymbolicLink() ? "symlink" : "file";
-  const all = dirents
-    .filter((d) => !(d.isDirectory() && SKIP_DIRS.has(d.name)))
-    .map((d) => ({ name: d.name, kind: kindOf(d) }));
-  return { real, all };
+  const all: FsDirEntry[] = [];
+  let scanned = 0;
+  let truncated = false;
+  try {
+    for (;;) {
+      const d = dir.readSync();
+      if (!d) break;
+      if (scanned++ >= maxScanEntries) {
+        truncated = true;
+        break;
+      }
+      if (!(d.isDirectory() && SKIP_DIRS.has(d.name))) {
+        all.push({ name: d.name, kind: kindOf(d) });
+      }
+    }
+  } catch {
+    return { error: "directory is not readable" };
+  } finally {
+    try {
+      dir.closeSync();
+    } catch {
+      // The listing result already says whether the scan itself succeeded.
+    }
+  }
+  return { real, all, truncated };
 }
 
 /**
@@ -254,11 +283,12 @@ export function sortAndCapDir(
 export function listDir(
   root: string,
   rel: string,
-  caps: { maxEntries?: number; maxNameBytes?: number } = {},
+  caps: { maxEntries?: number; maxNameBytes?: number; maxScanEntries?: number } = {},
 ): DirResult {
-  const raw = readDirRaw(root, rel);
+  const raw = readDirRaw(root, rel, caps.maxScanEntries);
   if ("error" in raw) return raw;
-  return sortAndCapDir(raw.all, caps);
+  const capped = sortAndCapDir(raw.all, caps);
+  return { entries: capped.entries, truncated: raw.truncated || capped.truncated };
 }
 
 /**

--- a/server/sessions/fs-handlers.ts
+++ b/server/sessions/fs-handlers.ts
@@ -237,7 +237,7 @@ export function createFsHandlers({ viewport, getEntry, isClosed }: FsDeps): FsHa
           id: msg.id,
           path: msg.path,
           entries: r.entries,
-          ...(r.truncated ? { truncated: true } : {}),
+          ...(raw.truncated || r.truncated ? { truncated: true } : {}),
         });
       };
       // A directory inside a repo lists through THAT repo's view —


### PR DESCRIPTION
## Summary

- refuse symlinked, non-regular, and oversized project configuration reads before a workspace is trusted
- bound directory traversal, filesystem metadata work, and `workspace_ls` output
- make Codex, Gemini, and OpenCode transport buffering linear and size-limited, with cancellation that terminates the child process first
- bound billing responses, entitlement tokens, refusal text, and subscription date fields
- make npm publication tag-only and anchor it to the protected `npm-publish` GitHub environment, with OIDC permission confined to the publish job
- document the release approval boundary and record the completed launch-readiness audit

## Release boundary

The repository's `npm-publish` environment was verified through the GitHub API with Kyle Serrecchia as its required reviewer, administrator bypass disabled, and exactly one deployment policy matching tags named `v*`.

Kyle separately confirmed in the npm website that the `mirafold` trusted publisher requires `release.yml`, the `npm-publish` environment, and the `npm publish` action, and that publishing access requires two-factor authentication while disallowing traditional tokens.

Until this pull request merges, npm publication is intentionally fail-closed: npm now requires the environment claim, while the workflow on `main` does not declare that environment yet.

## Validation

- Gemini adapter suite: 38 passing
- Codex adapter suite: 85 passing, plus the direct transport regression
- OpenCode adapter suite: 67 passing
- focused project-configuration, directory-limit, workspace-action, entitlement, subscription, and release-workflow regressions passing
- TypeScript check passing
- server bundle passing
- release workflow YAML parse passing
- `git diff --check` passing

The blanket `yarn test` command was deliberately not run because known test files load or create dotenv fixtures, which this audit was prohibited from inspecting. Every changed executable area was instead covered by focused regression tests.
