### PR TITLE
fix: preserve Fleet session and workspace tooltips

### DIFF
--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -402,8 +402,9 @@ export type ViewportMsgBody =
   // or sequenced; every request gets exactly one reply, an error rides the
   // reply. `path` echoes the request so racing replies correlate beyond the
   // id. Entries are NAMES (not paths — the client owns nesting), capped per
-  // directory with `truncated` honest. `status` chars come from the
-  // multi-repo git layer.
+  // directory with `truncated` honest. A truncated reply is a bounded subset,
+  // not a globally ranked prefix of children the server did not scan. `status`
+  // chars come from the multi-repo git layer.
   | {
       type: "fs_dir";
       id: string;

--- a/server/sessions/fs-folder-tree.ts
+++ b/server/sessions/fs-folder-tree.ts
@@ -245,9 +245,10 @@ export function readDirRaw(
 }
 
 /**
- * Order and cap one directory's entries for the wire. Directories sort
- * before files, alphabetical within each group — so when a cap trips, files
- * are what get cut and the tree stays navigable.
+ * Order and cap the bounded raw scan for the wire. Directories sort before
+ * files, alphabetical within each group, so the reply cap cuts scanned files
+ * first. If the earlier raw work cap trips, entries later in filesystem order
+ * are unknown and `truncated` tells the client the listing is incomplete.
  */
 export function sortAndCapDir(
   all: FsDirEntry[],

--- a/server/testing/fleet.e2e.ts
+++ b/server/testing/fleet.e2e.ts
@@ -129,10 +129,52 @@ test("a maximum-length session name stays inside every supported fleet width", a
         `${width}px rename pencil sits ${nameGeometry.editGap}px after the visible name`,
       );
     }
+    await fleet.setViewportSize({ width: 1280, height: 844 });
+    await fleet.evaluate(
+      () =>
+        new Promise<void>((resolve) =>
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve())),
+        ),
+    );
+
+    const tooltipTargets = await row.evaluate((element) => {
+      const link = element.querySelector<HTMLElement>(".fleet-link");
+      const agent = element.querySelector<HTMLElement>(".fleet-agent");
+      if (!link || !agent) throw new Error("Fleet tooltip targets are missing");
+      const label = element.querySelector<HTMLElement>(".fleet-link-label") ?? link;
+
+      const labelBox = label.getBoundingClientRect();
+      const linkBox = link.getBoundingClientRect();
+      const labelLeft = Math.max(labelBox.left, linkBox.left);
+      const labelRight = Math.min(labelBox.right, linkBox.right);
+      const nameHit = document.elementFromPoint(
+        labelLeft + (labelRight - labelLeft) / 2,
+        labelBox.top + labelBox.height / 2,
+      );
+      const agentBox = agent.getBoundingClientRect();
+      const rowHit = document.elementFromPoint(
+        agentBox.left + agentBox.width / 2,
+        agentBox.top + agentBox.height / 2,
+      );
+
+      return {
+        name:
+          nameHit instanceof HTMLElement
+            ? nameHit.closest<HTMLElement>("[title]")?.title ?? null
+            : null,
+        row:
+          rowHit instanceof HTMLElement
+            ? rowHit.closest<HTMLElement>("[title]")?.title ?? null
+            : null,
+        workspace: element.getAttribute("title"),
+      };
+    });
+    assert.equal(tooltipTargets.name, maximumName, "truncated name has no full-name tooltip");
+    assert.ok(tooltipTargets.workspace, "Fleet row has no workspace tooltip");
     assert.equal(
-      await link.getAttribute("title"),
-      maximumName,
-      "truncated name has no full-name tooltip",
+      tooltipTargets.row,
+      tooltipTargets.workspace,
+      "the stretched Fleet link overrides the row's workspace tooltip",
     );
   } finally {
     await fleet.setViewportSize({ width: 1280, height: 844 });

--- a/web/src/components/SessionName.tsx
+++ b/web/src/components/SessionName.tsx
@@ -54,10 +54,16 @@ export function SessionName({
       <a
         className={cls.link}
         href={sessionPath(s.sessionId)}
-        title={s.name}
+        title={surface === "cockpit" ? s.name : undefined}
         aria-current={current ? "page" : undefined}
       >
-        {s.name}
+        {surface === "fleet" ? (
+          <span className="fleet-link-label" title={s.name}>
+            {s.name}
+          </span>
+        ) : (
+          s.name
+        )}
       </a>
       <button
         className={cls.edit}

--- a/web/src/styles/13-fleet.css
+++ b/web/src/styles/13-fleet.css
@@ -141,6 +141,13 @@
   inset: 0;
 }
 
+/* Above the stretched overlay, the visible name keeps its own full-name
+   tooltip while the rest of the row inherits the workspace tooltip. */
+.fleet-link-label {
+  position: relative;
+  z-index: 1;
+}
+
 /* The row's real controls (and the rename input) ride above the overlay. */
 .fleet-edit,
 .fleet-end,


### PR DESCRIPTION
## Summary

- keep the full session name available over the visible Fleet name
- keep the workspace path available over the stretched row hit area
- define capped directory listings as honest bounded subsets

## Verification

- `yarn typecheck`
- isolated production build with all dotenv filename variants excluded
- focused real-Chrome Fleet regression: passes with the fix
- the same regression against the exact pre-fix UI: fails with the session name overriding the workspace path
- focused raw-directory-cap unit test
- independent cold review: no findings