### PR TITLE
release: v0.8.5 hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@parcel/watcher": "^2.6.0",
     "express": "^5.2.1",
+    "fast-uri": "^3.1.7",
     "ws": "^8.21.0",
     "zod": "^4.4.3"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.8.4",
+  "version": "0.8.5",
   "description": "A faithful browser re-skin of the coding agents you already use — Claude Agent, Codex, Gemini CLI, or OpenCode — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1649,9 +1649,9 @@ fast-deep-equal@^3.1.3:
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-uri@^3.0.1:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.5.tgz#610f37419a030270430cecd68d74e3d4d96725d0"
-  integrity sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==
+  version "3.1.7"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
+  integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==
 
 fdir@^6.5.0:
   version "6.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1648,7 +1648,7 @@ fast-deep-equal@^3.1.3:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
-fast-uri@^3.0.1:
+fast-uri@^3.0.1, fast-uri@^3.1.7:
   version "3.1.7"
   resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.7.tgz#743157d957f3cbb4c65310e033dc2ad4ad7dc60a"
   integrity sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==


### PR DESCRIPTION
Security
  hotfix: integrates Dependabot PR #101 by updating the indirect runtime dependency fast-uri from 3.1.5 to 3.1.7, then
  bumps Mirafold from 0.8.4 to 0.8.5. Local verification passed: yarn typecheck, yarn test, yarn test:server, yarn
  test:e2e, and yarn test:ui.