### PR TITLE
feat: secure Desktop relay activation boundary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,12 @@
 node_modules/
 dist/
+# Dotenv files are opaque secrets. Keep every common root and service-name
+# variant out of Git; the intentional public root template stays trackable.
 .env
-# permissions.ts guards .env.local as a secret file — keep git out of it too
-.env.local
+.env.*
+*.env
+*.env.*
+!/.env.example
 *.log
 .claude/
 dist-server/

--- a/PLAN-ARCHIVE.md
+++ b/PLAN-ARCHIVE.md
@@ -11756,3 +11756,561 @@ The mirror contained no real dotenv file and exposed no secret, but the command
 still violated the opacity rule; its 874/874 result is discarded and is not
 audit evidence. The corrected final command explicitly enumerated and validated
 the 87 safe paths before running 817/817.
+
+## Moved 2026-09-05 — Shell DA.1
+
+- [x] **Step DA.1 — add a bounded private credential source without an
+  environment mutation.** Introduce one pure credential-resolution seam used
+  by relay planning, entitlement exchange, and subscription actions. In the
+  Desktop-flagged path, consume a maximum-bounded UTF-8 key from standard input
+  before boot, reject extra bytes/newlines/malformed keys or missing EOF at a
+  short deadline, close the descriptor, remove internal flags from the long-
+  lived argument view, and overlay the valid key only in the in-memory config
+  passed to those three consumers. Preserve terminal env behavior, ops-token
+  precedence, custom
+  entitlement URLs, self-host opt-out/explicit relay behavior, and the rule
+  that any malformed/missing Desktop input disables only remote access—not the
+  local product. Done when unit and spawned-process tests prove pipe/env
+  precedence, EOF/timeout/size/shape/error handling, no pipe-supplied key in
+  `process.env` or argv at any observation point, descriptor closure, and no
+  key-bearing output; Tier 1, typecheck, and server build pass.
+
+**Completed 2026-09-05.** Created `server/desktop-credential.ts`,
+`server/desktop-credential.test.ts`, and `server/desktop-credential.itest.ts`;
+modified `server/index.ts` to await private input before constructing the
+server/session registry and pass `resolveCredentialConfig`'s explicit object
+to relay planning, entitlement exchange, subscription actions, and the existing
+entitlement-presentation selector. The three consumer implementations themselves
+are unchanged. No dependency, wire field, UI change, persistent credential
+store, adapter change, release, or Site implementation was added.
+
+The exact internal flag is `--mirafold-desktop`; all exact occurrences are
+removed from `process.argv` before reading. Unflagged/lookalike-flag launches
+never consume or close stdin. Flagged input has a 43-byte maximum, a fixed
+44-byte OS-read buffer, a two-second absolute deadline unaffected by incoming
+bytes, strict UTF-8 and the existing `mf_` plus 20–40 lowercase base32-character
+shape, and mandatory EOF without a newline or BOM. The stream handle is stopped
+before an explicit fd-0 close: a direct Linux probe showed libuv leaves standard
+descriptors open after stream destruction alone. Temporary byte buffers are
+cleared. Missing, oversized, invalid, timed-out, and failed reads return only a
+fixed problem code; input/error text is never logged.
+
+The pipe key replaces an ambient license key only in the runtime configuration,
+with one credential-free conflict warning. A failed Desktop handoff never falls
+back to an ambient key. The existing hand-issued operations-token override still
+wins, including after a failed handoff; terminal values, custom entitlement/app
+URLs, relay opt-outs, and explicit self-host behavior retain their established
+meaning. Without an override, unusable private input disables hosted admission
+and billing while real local mock sessions remain usable. The key is never
+assigned to `process.env` or argv. Linux spawned-process tests inspect both the
+JavaScript views and `/proc/self/environ` plus `/proc/self/cmdline` before,
+during, and after reads, and observe every environment/argument assignment.
+
+Verification:
+
+- `MIRAFOLD_LOG_FILE= yarn -s node --import tsx --test server/desktop-credential.test.ts`:
+  11/11 focused unit and spawned-process tests passed; the final version,
+  including Linux process-metadata observations, also passed within Tier 1.
+  The tests cover minimum/maximum length, split input, missing EOF, slow input,
+  invalid UTF-8/BOM/newlines/extra frames, oversized input, descriptor/read errors,
+  early stream closure, pipe/env/ops precedence, custom URLs, descriptor closure,
+  unchanged ordinary stdin behavior, and absence of key-bearing output.
+- `MIRAFOLD_LOG_FILE= yarn -s node --import tsx --test server/desktop-credential.itest.ts`:
+  7/7 against the newly built daemon and real WebSockets. Private-key local billing,
+  one ambient-conflict warning, explicit opt-out, ordinary startup, and completed
+  local mock turns after malformed/missing/oversized/unterminated input passed.
+  The first harness run used `PORT=0`, while the existing daemon prints its requested
+  port; that made the harness connect to port 0. Only the new harness was corrected
+  to use the existing harness's randomized-port convention; daemon port behavior
+  was not changed.
+- `yarn typecheck`: passed. The first check identified a `Uint8Array` callback
+  type being treated as `Buffer`; the copy now uses the common typed-array `set`.
+  `yarn build:server`: passed.
+- Permitted Tier 1: 1,145/1,145 across 123 explicitly enumerated test files using
+  the existing Node/tsx runner. Eight tests were excluded, rather than reading
+  dotenv files or running a recursive listing that includes them: all four tests
+  in `server/project-env.test.ts`; the dotenv-inheritance test in
+  `server/pty/pty.test.ts`; the skip-worktree secret test in
+  `server/sessions/workspace/git/git.test.ts` (its Git fixture reads the file);
+  and the secret-file listing plus secret-read/tree-listing tests in
+  `server/sessions/workspace/filesystem/fs-folder-tree.test.ts`. An unrestricted
+  `yarn test` was not run, and those eight cases are not claimed as verified.
+- Builds and broad/focused daemon checks used an isolated copy excluding every
+  dotenv filename, with existing dependencies shared by symlink. All four changed
+  source/test files were SHA-256-equal to the real checkout at verification.
+  `git diff --check` passed. No metered model or production billing call was made.
+
+The prior uncommitted Phase DA plan was preserved. The next authorized chunk
+within this phase is DA.2 (local-only host identity); the deeper real-relay/child
+inheritance proof, correctness hunt, security audit/freeze, and publication remain
+DA.3–DA.6 respectively.
+
+## Moved 2026-09-05 — Shell DA.2
+
+- [x] **Step DA.2 — make only the trusted local shell host-aware.** Add one
+  optional additive Desktop-host marker to the local hello and carry it through
+  the existing hello state. In Desktop mode, the Pro/renew anchor gets a fixed
+  `/activate` marker Electron recognizes and the card says activation finishes
+  in the system browser and returns automatically; the existing-key instruction
+  sends the user through that same protected browser flow. Terminal/browser
+  mode retains the exact `MIRAFOLD_LICENSE_KEY` instruction and plain pay URL.
+  Remote viewports receive no host marker and gain no activation or billing
+  surface. Done when protocol parsers tolerate absence, yesterday-client
+  fixtures still parse, every ConnectDevice arm is pinned in both host modes,
+  agent-rendered content cannot set the marker, and focused plus Tier-1 tests,
+  typecheck, and build pass.
+
+**Completed 2026-09-05.** The local WebSocket connection gets its host identity
+only from DA.1's parsed internal launch flag. Every local `agents` hello,
+including refreshes, carries `host: "desktop"` for that launch; ordinary
+terminal launches and all remote connections omit the property entirely.
+Missing/rejected private credentials still identify a Desktop launch so an
+unactivated local session can offer activation. No credential or identifier
+was added to the wire. The existing entitlement and subscription rules remain
+in place.
+
+The existing hello state admits only the literal Desktop value, clears it on a
+later hello without that value, and preserves it across entitlement updates.
+The session's Shell → StatusBar → ConnectDevice path and FleetView's existing
+ConnectDevice path forward it. A dated boundary amendment added these three
+existing forwarding files before their six forwarding lines were applied; no
+new UI surface, dependency, adapter, relay protocol, or persistent store was
+introduced.
+
+Desktop's Pro and renewal anchors now use the exact non-secret
+`https://mirafold.com/activate` marker, without query parameters or fragments.
+The card says activation finishes in the system browser and returns to
+Mirafold Desktop automatically; its existing-key instruction uses the same
+anchor. Electron's interception, protected browser flow, and restart remain
+future Desktop work. Terminal mode retains `https://mirafold.com/pay` and the
+exact `MIRAFOLD_LICENSE_KEY`/relaunch instruction. Opt-out, malformed relay URL,
+checking, outage, valid/cached QR, self-host, copy feedback, and subscription
+management keep their existing behavior in both host modes. A host/billing hint
+alone never creates a Pair card when the local relay fields are absent.
+
+Source changes: `server/index.ts`, `server/protocol.ts`,
+`server/sessions/connection.ts`, `web/src/transport/daemon-hello.ts`,
+`ConnectDevice.tsx`, and the three forwarding components. Tests: extended the
+existing connection, hello-state, and ConnectDevice unit tests plus DA.1's
+built-daemon test; created `server/testing/e2e/desktop-host.e2e.ts`. Planning:
+updated this archive, Shell's plan, and the cross-repository roadmap. DA.1's
+prior changes and unrelated untracked `decks/` were preserved. No commit,
+push, release, or public Desktop positioning occurred.
+
+Verification:
+
+- Permitted Tier 1: **1,177/1,177**, across 123 explicitly enumerated files,
+  using the existing Node/tsx runner. The same eight dotenv-related tests
+  named in DA.1's evidence were excluded under the global opacity rule; an
+  unrestricted `yarn test` was not run. The ConnectDevice matrix pins all 12
+  pre-DA.2 terminal renders by SHA-256 and checks each arm in Desktop mode.
+  Other new cases exercise refreshed/forged client frames, remote omission,
+  legacy/unknown host values, and entitlement updates that cannot set host.
+- `MIRAFOLD_LOG_FILE= yarn -s node --import tsx --test --test-concurrency=1 server/desktop-credential.itest.ts`:
+  **7/7** against the built daemon. Flagged valid and rejected/absent private
+  input advertise Desktop, ordinary startup omits host, and billing plus local
+  mock sessions retain DA.1's results.
+- `MIRAFOLD_LOG_FILE= yarn -s node --import tsx --test --test-concurrency=1 server/testing/e2e/desktop-host.e2e.ts`:
+  **5/5**. Real session and fleet components render activation/renewal in both
+  modes; a subsequent hello clears host; a remote-shaped hello removes the
+  surface. Agent text and a real sandboxed artifact attempt parent-DOM access,
+  a forged hello, and a nonce-stamped state action; terminal Pair remains on
+  its pay link and existing-key wording. axe and horizontal-overflow checks
+  pass for the cards. Only daemon hello data is varied in this browser fixture;
+  actual startup identity is covered by the built-daemon tests.
+- `yarn -s typecheck` and `yarn -s build`: **passed**. The build emits only the
+  existing large-chunk advisory. `yarn -s test:ui:built`: **11/11**, including
+  managed Chromium, Firefox, WebKit, and every existing visual baseline.
+  An initial visual run differed only because the sanitized copy was named
+  `verify` and the status bar displays that folder name; the committed images
+  show `mirafold`. After inspecting actual/diff/baseline images, renaming only
+  the temporary directory made the focused failure and complete suite pass.
+  No source or snapshot was changed to repair that environment mismatch.
+- The actual `admitWireFrame` function extracted from the released `v0.8.5`
+  source admits both the legacy and Desktop hello fixtures. It is byte-identical
+  to this branch's parser (SHA-256
+  `d407fdc8612ad57ee9df1481dbad0bdce0b0dc46ea600144d76c8a20f15366ec`).
+- Every build and daemon/browser gate ran in a sanitized copy with all dotenv
+  filename variants excluded. Final location: `/tmp/mirafold-da2/mirafold`;
+  existing dependencies and the sibling Relay source were linked for the
+  normal build/type graph. All 13 changed source/test files match the real
+  checkout by SHA-256; `git diff --check` passes. No real-model or production
+  billing call was made. All test-owned browsers and daemons were closed.
+
+Downstream integration constraint recorded in roadmap DPC.3: Desktop Step 13.3
+currently withholds the internal flag until a stored key exists, which would
+leave first-time users on the terminal pay path. Reconcile that no-key launch
+contract before implementing Desktop 13.3; Shell recognizes Desktop from the
+flag even when the pipe is empty. No Desktop executable changed in this step.
+
+The next Shell chunk is **DA.3**, the real-relay and child-inheritance secret
+boundary proof. DA.4 correctness, DA.5 security/freeze, and DA.6 publication
+remain unfinished.
+
+## Moved 2026-09-05 — Shell DA.3
+
+- [x] **Step DA.3 — prove the secret boundary through the real daemon and
+  relay path.** Extend the integration harness to spawn the built daemon with a
+  seeded private-stdin key against fake billing and a gated real relay. Prove
+  entitlement exchange, QR availability, encrypted pairing, and local
+  subscription management; then spawn each reachable engine/PTY/MCP child seam
+  and prove it cannot read the key from environment, argv, inherited file
+  descriptors, transcript, checkpoint, or WireMsg. Seed the key across split
+  output chunks and every error path and search stdout, stderr, flight-recorder
+  logs, crash text, serialized sessions, and browser messages. Include
+  malformed/oversized/early-close input and daemon restart cases; local sessions
+  must remain usable throughout. Done when the focused integration tests and
+  all normally permitted release gates pass, and mutations removing stdin
+  closure, `DAEMON_ONLY_ENV`, log redaction, or remote-viewport omission are
+  caught.
+
+**Completed 2026-09-05.** The new built-daemon harness delivers only a synthetic
+license key over private stdin, split across writes, with isolated working,
+credential-probe, trust, session, and diagnostic directories. A local fake
+billing HTTP server splits responses across transport chunks. The real sibling
+Relay, with its Ed25519 entitlement gate enabled, admits the exchanged signed
+token; a real encrypted remote client pairs using the advertised QR inputs and
+completes a mock turn. All three local subscription actions use the private key.
+The remote hello omits host, relay, relayOff, entitlement, and billing; remote
+subscription requests never reach billing. DA.2's browser suite still proves
+the actual activation cards and QR rendering behavior.
+
+The child probes exercise production launch paths for the real Claude SDK,
+Codex app-server, Gemini CLI, OpenCode serve, and Codex/Gemini model-list
+processes. Engine executables are fixtures with production spawn options;
+the PTY and compiled render-MCP processes are real. Fixture engine executables
+read their own environment/argv and Linux process metadata, reporting hashes
+only. Their actual injected MCP configurations launch the production compiled
+render-MCP child and acknowledge a real render call. Claude's render server is
+in-process. No real model engine or metered model is run. The original stdin
+descriptor identity is absent before server creation and from every observed
+child. Private input is absent from daemon/child OS environment and argv;
+agent children also omit all four daemon-only environment fields, including a
+deliberately supplied stale ambient license. The official-Desktop PTY case has
+no ambient license, as the locked launcher contract requires; this does not
+claim that an ordinary terminal's user-requested shell command loses its own
+environment.
+
+All rejected-input classes preserve local turns: empty and early EOF, newline,
+invalid UTF-8, oversized input, missing EOF, and non-pipe stdin. DA.1's existing
+tests retain the slower-chunk, buffer, and injected read-error cases. Billing
+400/403/503 refusals, malformed/oversized JSON, wrong field types, connection
+closure, and the real ten-second request deadline preserve local turns. A
+three-launch test restores the same saved session with valid, empty, and fresh
+private input: the empty restart cannot reload a license from disk, and a new
+private handoff restores billing. Explicit uncaught-exception and unhandled-
+rejection probes verify the production last-gasp handler and exit code 1.
+Searches cover stdout, stderr, flight-recorder/crash text, local/remote WireMsg,
+and every non-dotenv file in the owned fixture trees, including transcripts and
+checkpoints. The happy-path search also excludes the signed entitlement token.
+
+**Proved defect and executable change.** Before editing, the real daemon with
+a billing 403 that echoed its received key leaked that key into stderr, local
+WireMsg, and the flight-recorder file. The billing consumers bounded strings
+without removing their known credential, and the shared logger did not
+recognize the Mirafold license family. Entitlement/subscription now remove the
+exact key before clipping or returning backend strings, including subscription
+status/date fields; the existing shared scrubber recognizes Mirafold key shapes
+before log clipping. A dated plan-boundary amendment added the logger before
+its edit. Exact-value tests also cover a terminal-supplied key outside the
+Desktop grammar; log tests cover embedded, minimum/maximum, repeated, and
+clipping-edge keys. Adapter, persistence, and relay implementations were not
+modified. The former starting-state claim that entitlement never logged key
+bytes is corrected in PLAN.md: only its fixed prefix had been masked.
+
+**Test-only correction found by the broad gate.** The existing phone QR test
+counted FleetView's Pair button immediately after navigation, before the
+WebSocket hello could render it. The full browser run failed once; five
+unchanged focused runs passed. A separate controlled probe held one real hello
+and observed zero buttons, then released it and observed the button. The test
+now waits for that button's visibility. Its entire ten-test phone fixture
+passes. No application behavior or visual baseline changed for this finding.
+
+Verification, using the isolated dotenv-excluded copy at
+`/tmp/mirafold-da3/mirafold` and existing dependencies:
+
+- Focused billing/log units: **32/32**. New built-daemon boundary/child tests:
+  **27/27** (22 boundary cases and five child-launch cases), also covered by
+  the broad integration run. DA.1's seven built-daemon checks also pass.
+- Permitted Tier 1: **1,180/1,180**, 123 enumerated files. The same eight
+  dotenv-related exclusions named under DA.1 apply.
+- Permitted Tier 2: **182 checks passed** across 28 files. The broad run
+  passed 177 checks; the Electron test file could not load because its binary
+  needed installation in read-only shared node_modules. With the required
+  filesystem access, that unchanged file passed all five checks. No source
+  fix or broad rerun was needed for the installation failure. Additionally
+  excluded under the global rule: all 13 tests in
+  `server/sessions/workspace/filesystem/fs-folder-tree.itest.ts` (shared dotenv
+  fixture/listings), and `E.2: diffs — modified, added, deleted, rename target`
+  in `server/sessions/workspace/git/fs-git.itest.ts` (a dotenv request).
+- Tier 3: **140 checks passed** across 16 files, including DA.2's five browser
+  checks. The initial run passed 139; the diagnosed Pair timing correction
+  passed its complete ten-test phone fixture. The other files already passed.
+- `yarn -s test:ui:built`: **11/11**, managed Chromium/Firefox/WebKit and every
+  committed visual baseline. `yarn -s typecheck`, `yarn -s build`, and
+  `git diff --check` pass. Build output has only the existing large-chunk
+  advisory. Third-party notices regenerate byte-identically, with explicit
+  dotenv exclusions added to the temporary checker; no dependency was added.
+- `node server/testing/desktop-mutations.mjs`: **5/5 faults caught** by their
+  intended regression. Temporary bundles remove stdin closure, remove
+  DAEMON_ONLY_ENV filtering, remove Mirafold log redaction, publish the Desktop
+  marker on an actual remote hello, or remove exact billing-value redaction.
+  Mutations never alter reviewed source and their bundles are removed.
+- `npm pack --ignore-scripts --json --pack-destination /tmp/mirafold-da3`
+  after the final build produced **20 files**, **1,465,617 bytes**,
+  SHA-256 `1be51d08b43e6b472e7e0a22eaf4f6cc005ebfb7e6eb525acfb9d4acfa2812e9`. No test/mutant fixture ships. The tarball was unpacked
+  under an isolated dot-directory global prefix with the existing dependency
+  tree linked; `scripts/packaged-pass.mjs` passed **9/9** against those bytes.
+  This proves the packed runtime with existing dependencies, not a clean
+  dependency installation or a published release. Package version remains
+  0.8.5; DA.5's freeze and DA.6's release versioning are still future work.
+
+The executable changes are limited to `server/log.ts`,
+`server/relay/entitlement.ts`, and `server/relay/subscription.ts`. Tests extend
+their three unit files and the phone browser fixture; seven new integration/
+observation/mutation files live under `server/desktop-*.itest.ts` and
+`server/testing/`. All 14 DA.3 source/test files match the actual checkout by
+SHA-256. This archive, PLAN.md, and the cross-repository roadmap record the
+result. Prior DA.1/DA.2 work, unrelated `decks/`, and sibling working changes
+were preserved. Test-owned processes are closed. No production billing call,
+commit, push, deployment, or publication occurred. The next chunk is **DA.4**,
+the separate feature-delta correctness hunt; DA.5 security/freeze and DA.6
+publication remain unfinished.
+
+## Moved 2026-09-05 — Shell DA.4 and DA.4C correctness hunt
+
+**Scope and method.** DA.4 reviewed the exact 31-file DA.1–DA.3 delta from
+base `8765de5` plus 11 adjacent seams: startup/config resolution, entitlement
+and subscription behavior, relay planning/dial/refusal, the local/remote hello,
+Pair presentation, protocol compatibility, child environments, the launcher,
+and project-config identity rejection. Each confirmed behavior was reproduced
+before editing, repaired serially, and covered by a bounded class regression.
+Six successive fresh read-only reviews followed the first fixes; each proved
+its finding before another edit. The first batch stopped at ten repairs as
+required. Its next cold review proved an eleventh defect, so DA.4C was inserted
+before DA.5 and received two repairs plus its own final fresh review. No dotenv
+file, `decks/`, live model, production billing/relay service, or unrelated
+subsystem was inspected or changed.
+
+**The ten DA.4 findings, all confirmed and repaired:**
+
+1. A successful billing response with an expired or exactly-due expiry could
+   publish `valid` even though `get()` returned no token.
+2. Unsafe seconds-to-milliseconds conversion could turn a finite expiry into an
+   effectively infinite one, and a newly accepted token had no owned deadline
+   watch to withdraw its advertised access.
+3. Header-invalid exchanged or operations tokens reached WebSocket header
+   construction, where Node's synchronous rejection could terminate the daemon
+   and every local session.
+4. If synchronous change-listener work crossed the token deadline, scheduling
+   skipped the already-due cache and left both valid and cached-outage reads
+   advertised.
+5. A forward wall-clock correction or Linux suspend could pass the absolute
+   deadline while the event-loop timer still had monotonic delay remaining.
+6. A backward wall-clock correction could suppress a relay-requested refresh
+   far beyond the promised 60-second request floor.
+7. After expiry had been observed, moving the wall clock backward could revive
+   cached token bytes without restoring a coherent published state.
+8. Reentrant `state()` reconciliation could duplicate a listener delivery and
+   replace the correct expiry-refresh timer.
+9. A failed exchange that observed cache expiry published an uncached outage
+   without retiring the cache object, so listener-time clock correction could
+   revive it.
+10. The listener exception guard called `String()` on the thrown value without
+    its own guard. A value whose conversion threw rejected the exchange, skipped
+    later listeners, and could reach the process last-gasp exit path.
+
+The final entitlement source validates finite, future deadlines before cache
+replacement; owns a one-second wall-time watcher for every advertised cache;
+uses `performance.now()` for the request floor; retires a cache irreversibly
+once expiry is observed; queues reentrant listener delivery without surrendering
+timer ownership; preserves single flight and stop guards; and reports even an
+unprintable listener failure with a fixed fallback before continuing. Node's
+`validateHeaderValue()` is the exact token transport boundary, including valid
+Latin-1 values rather than a narrower invented token grammar.
+
+**DA.4C findings, both confirmed and repaired.** First, a nonempty operations
+override which failed that header rule still counted as configured entitlement
+in relay planning. The gated hosted relay was dialed without a header, the Pair
+surface advertised a link because override mode has no entitlement read, and
+the relay necessarily refused it with 4007 retry churn. Planning and token
+supply now share the exact header predicate. The invalid override continues to
+suppress license-key fallback; default and explicitly spelled canonical hosted
+relays stand down; an explicit relay with an operator entitlement backend also
+stands down; a genuinely ungated explicit self-host still dials tokenless; and
+valid overrides remain unchanged. Boot and Pair messages name only the setting
+and repair, never the credential, QR, payment link, or pairing code.
+
+The first DA.4C cold review then proved that adding this reason to the existing
+`relayOff` enum broke the stated previous-client contract: the `8765de5` bundle
+retained an unknown value in that recognized field and React rendered the raw
+text `invalid-entitlement-token`. A plan correction withdrew that enum change
+before repair. The three old `relayOff` values remain unchanged; the daemon now
+sends one optional local-only
+`relayConfigProblem: "invalid-entitlement-token"` field. The previous bundle
+does not forward that new field and draws no Pair surface. The current reducer
+maps only the exact literal to its actionable state and drops unknown future
+values from both fields. Remote hellos receive neither field. The final fresh
+review executed the actual previous reducer/forwarders and found **no confirmed
+correctness finding**; its focused suite passed 114/114 and its cross-layer
+probe matched Node on 1,025 header inputs, including real loopback WebSocket
+upgrades for accepted Latin-1 and tokenless self-host behavior.
+
+**Final verification on the sanitized mirror.** The candidate passed:
+
+- typecheck and the full production browser/server build (only the established
+  large-bundle advisory);
+- permitted Tier 1: **1,205/1,205** across 123 files. Excluded were the entire
+  `server/project-env.test.ts` file and four named tests whose operation reads or
+  requests dotenv fixtures: inherited checkout environment, skip-worktree
+  secret changes, secret-file listing, and secret-file reading—eight cases in
+  total;
+- permitted Tier 2: **182/182** across 28 files. Excluded were all 13 cases in
+  `server/sessions/workspace/filesystem/fs-folder-tree.itest.ts` and the one
+  dotenv-requesting diff case in `fs-git.itest.ts`—14 cases in total;
+- Tier 3: **140/140** across 16 files; managed Chromium, Firefox, WebKit, and
+  committed visual baselines: **11/11**;
+- all five DA.3 secret-boundary mutations caught by their intended regressions;
+- third-party notices unchanged at 212 packages, SHA-256
+  `74ff44734a59d1fab32e0d3a713ce4752265324ead3f599b8a3d49852b449c3c`;
+  no dependency was added; and
+- a post-build `npm pack --ignore-scripts` artifact with **20 files** and
+  **1,466,534 bytes**, SHA-256
+  `f16eac33288ae3c756979e5a21e48c691103df30bca1d01033bca88177c338ba`.
+  It contains no test or mutation fixture. Extracted under an isolated global
+  prefix with the existing dependency tree linked, those exact bytes passed the
+  packaged-install smoke **9/9**. This proves the package runtime with existing
+  dependencies, not a clean dependency installation or a published release.
+
+The DA.4/DA.4C executable delta is confined to entitlement validation/cache/
+listener behavior, shared relay-header validation and planning, boot handling,
+the additive local hello problem field, current-client normalization, and Pair
+copy. Corresponding unit/integration tests carry every hunter. The ordinary
+three-value `relayOff` wire, explicit ungated self-host path, remote hello,
+Desktop private credential boundary, terminal credential precedence, relay
+cryptography/service, package version `0.8.5`, and dependencies remain
+behaviorally unchanged. No commit, push, deployment, npm publication, Desktop
+executable change, or DA.5 security audit occurred. The next chunk is **DA.5 —
+audit and freeze the Shell security boundary**.
+
+## Moved 2026-09-05 — Shell DA.5 security audit and candidate freeze
+
+Step DA.5 audited the complete uncommitted DA.1–DA.4C Shell candidate based on
+commit `8765de5fe5900b18414c49ff4494b7c6d146d44c`. The review covered the exact
+feature delta and adjacent startup, stdin, descriptor, environment, process,
+child-launch, billing, relay, local/remote hello, log, persistence, browser,
+package, CI, and repository-history boundaries. No dotenv file was opened,
+read, searched, printed, parsed, sourced, diffed, or created; the permitted
+suite and every recursive search excluded all dotenv filename forms
+explicitly. The unrelated untracked `decks/` work stayed outside the audit and
+candidate.
+
+The pre-fix boundary amendment in `PLAN.md` recorded every finding before its
+product edit. Ten confirmed findings were repaired, exactly at the Step's cap:
+
+1. **Configured relay URLs reached persistent logs.** A URL containing
+   userinfo, a private path, or a signed query reached both the startup flight
+   recorder and the successful-pair record. Persistent records now use fixed
+   destination labels and fixed paired text. The deliberately secret-bearing
+   terminal boot block remains terminal-only and retains its warning.
+2. **WebSocket setup rejection escaped its owner.** A relay fragment could
+   make initial or reconnect setup reject inside an unowned asynchronous dial,
+   reaching the daemon's fatal unhandled-rejection path. Planning now refuses
+   every literal fragment delimiter, and the client owns every asynchronous
+   setup failure. Remote access stays off while local sessions stay alive.
+3. **A billing exchange could reflect the permanent key as a relay bearer.**
+   A loopback proof showed the returned value reaching the
+   `mirafold-entitlement` WebSocket header. Exact key reuse is now refused at
+   every length; embedded reuse is refused for key values at least 16
+   characters long. A bad refresh cannot displace an unexpired safe token.
+4. **Billing-controlled status and date text could become Shell-owned claims.**
+   The daemon now admits only the five supported subscription states, maps all
+   others to `unknown`, and forwards only bounded valid timestamps. The
+   browser independently applies the same defensive timestamp rule, handles
+   `paused`, and renders fixed unavailable text for unknown states.
+5. **The production lock selected vulnerable `qs@6.15.3`.** It was covered by
+   GHSA-x5fp-wj9c-mxmx and GHSA-4mjr-xmp4-gh2g. No Mirafold route into the
+   affected parser modes was found: Express retains its simple query parser,
+   Mirafold does not use the Express body parser, and MCP is carried over
+   stdio. The lock and real installed tree now select `qs@6.16.0`. This patch
+   adds no package or transitive dependency; the package itself costs 20 files,
+   about 76.5 kB packed and 374.9 kB unpacked.
+6. **Git permitted common dotenv secret-name variants.** The ignore policy now
+   covers exact, suffixed, service-named, and nested variants while retaining
+   the intentional root `.env.example` template. The regression passes only
+   filenames to `git check-ignore --no-index`; it creates and reads no dotenv
+   file. A filename-only history check found only the public template, and a
+   masked credential-pattern history scan found only explicit test fixtures.
+7. **`Date.parse` alone accepted malformed billing dates.** Inputs such as
+   `"0"`, legacy slash dates, and impossible calendar days could still produce
+   a false cancellation claim. Server and browser now require a bounded RFC
+   3339 shape, valid calendar and clock components, a valid offset, and a
+   finite parse before displaying a date.
+8. **An empty fragment delimiter bypassed the first fragment repair.** The URL
+   API exposes an empty `.hash` for a trailing `#`; Mirafold's appended daemon
+   route then turns it into a nonempty fragment and WebSocket setup rejects.
+   The planner now checks the original value for every literal `#` while
+   retaining encoded `%23` in paths and queries.
+9. **Status validation ran before permanent-key redaction.** A deliberately
+   low-entropy license key equal to a supported state such as `active` could be
+   republished to the viewport as the subscription status. Exact-key redaction
+   now precedes the allowlist.
+10. **The first token-reflection guard overmatched low-entropy custom keys.** A
+    one-character key such as `a` caused an unrelated token such as
+    `safe.token` to be refused. Exact reflection remains forbidden for every
+    key; containment is applied only at the 16-character specificity threshold.
+
+No finding was deferred. Fresh reviewers additionally required a real
+`server/index.ts` persistent-log regression, enumeration of every `qs` lock
+stanza, nested ignore-boundary probes, and corrections to stale comments and
+the malformed-relay Pair-card explanation. The final independent review
+reverse-applied and inspected the exact patch, reran the focused boundary
+tests, exercised adversarial fragment/reflection/status/date variants, and
+found **no confirmed issue remaining**.
+
+The final DA.5 patch relative to the pre-DA.5 working candidate affects 17
+files and is 817 lines, SHA-256
+`9e8045d4ff3862e9c23ee2d283f6736c5967547a30cee2ec78144a42dfff057b`.
+Source changes are confined to `server/index.ts`, the relay URL/client,
+entitlement and subscription modules, the browser subscription presenter, and
+the Pair card's malformed-relay explanation. Repository/dependency changes are
+`.gitignore` and `yarn.lock`. Corresponding tests extend seven existing test
+files and add `server/security/repository-hygiene.test.ts`. Relay cryptography
+and service code, Desktop code, the public wire shape, and package version
+`0.8.5` are unchanged. Terminal process and pairing behavior are unchanged;
+only the malformed-configuration explanation changed. No dependency was added.
+
+Final verification:
+
+- the exact changed security surfaces pass **125/125** against the real
+  installed dependency tree; typecheck and the production browser/server build
+  pass, with only the established large-chunk advisory;
+- permitted Tier 1 passes **1,222/1,222**. Excluded were
+  `server/project-env.test.ts` and five named cases that read, create, request,
+  or bundle a dotenv fixture: inherited checkout environment, a skip-worktree
+  secret, secret-file listing, secret-file reading, and the secret-basename
+  image refusal;
+- permitted Tier 2 passes **183/183** across 28 files. Excluded were all 13
+  cases in `server/sessions/workspace/filesystem/fs-folder-tree.itest.ts` and
+  the one dotenv-requesting diff case in `fs-git.itest.ts`;
+- freshly built Tier 3 passes **140/140** across 16 files; managed Chromium,
+  Firefox, WebKit, and committed visual baselines pass **11/11**;
+- all five Desktop secret-boundary mutations are caught by their intended
+  regressions; third-party notices remain byte-identical for 212 browser
+  packages, SHA-256
+  `74ff44734a59d1fab32e0d3a713ce4752265324ead3f599b8a3d49852b449c3c`;
+- a frozen, script-disabled install in the real repository resolves
+  `qs@6.16.0` both at the root and through Express. A fresh registry audit
+  reports zero vulnerabilities across 131 production dependencies; and
+- the final `npm pack --ignore-scripts` artifact contains exactly 20
+  allowlisted runtime files, is **1,467,431 bytes**, and has SHA-256
+  `43361561d5cc2a8879ce3a8e536fc21735f8cc8c27f63c487bdeca96a15b3ef2`.
+  Extracted under a new isolated global prefix and linked to the real frozen
+  dependency tree, those exact bytes pass the installed-package smoke **9/9**.
+
+No commit, push, deployment, npm publication, Desktop executable change, paid
+billing call, or live Relay change occurred. The frozen candidate remains base
+commit `8765de5fe5900b18414c49ff4494b7c6d146d44c` plus the reviewed working-tree
+delta; the runtime identity is the 20-file tarball hash above. The next chunk
+is DA.6, which alone may version and publish these reviewed bytes through the
+protected release path.

--- a/PLAN.md
+++ b/PLAN.md
@@ -4228,6 +4228,247 @@ named from daily use, each pinned in Tier 3 and falsified both ways:
   modern API work there directly instead of via the fallback. Its own
   repo, its own permission tests.
 
+## Phase DA — secure Mirafold Pro activation for Desktop (opened 2026-09-04; Kyle-directed)
+
+**Outcome and order.** An installed Linux Desktop user can click the existing
+Pair surface, buy Pro or connect an existing Pro key in the system browser,
+return automatically to the app, and use the hosted relay after the daemon
+restarts—without putting the permanent key in a shell profile or personally
+storing it. This Shell phase lands only after the site's private activation
+backend is production-ready and before the Desktop feature release. Do not
+start Step DA.1 until Site Step DA-S.11 is complete. Nothing in this phase
+authorizes public Desktop copy on mirafold.com; that waits for the
+installed Linux end-to-end acceptance gate.
+
+This is an oversized feature phase. Every numbered Step is one independently
+executable `$next` pass, including tests and its dated plan update. Work in
+order and stop after one Step.
+
+**Current `$next`: Step DA.6.** Site Step DA-S.11 and Shell Steps DA.1–DA.5
+are recorded complete. The reviewed candidate remains local on
+`feature/desktop-pro-activation`, based on `origin/next` at `8765de5`; no Shell
+release or Desktop feature has been published by this work.
+
+### Verified starting state — 2026-09-04
+
+- `server/index.ts` passes `process.env` independently to
+  `resolveRelayPlan`, `createEntitlementTokenSource`, and
+  `createSubscriptionActions`. Those functions recognize only
+  `MIRAFOLD_ENTITLEMENT_TOKEN` and `MIRAFOLD_LICENSE_KEY`; there is no
+  in-memory Desktop credential source or Desktop host marker.
+- `server/relay/entitlement.ts` keeps the permanent key server-side, posts it
+  to `https://mirafold.com/api/entitlement`, caches the returned 48-hour signed
+  token, refreshes every 12 hours, bounds responses/time, and masks the key in its fixed log prefix. DA.3
+  later proved and removed a separate leak through reflected billing text. `server/relay/subscription.ts` deliberately uses that same key for the
+  local-only status/cancel/undo surface.
+- `server/adapters/types.ts` already classifies `MIRAFOLD_LICENSE_KEY`, the
+  relay pairing code, daemon auth token, and hand-issued entitlement token as
+  `DAEMON_ONLY_ENV`; `envWithout()` strips them from every agent engine. The
+  project configuration loader also refuses relay/license identity keys. These
+  are existing second walls, not a substitute for keeping a Desktop key out of
+  the daemon's OS environment in the first place.
+- `web/src/components/ConnectDevice.tsx` always links an unentitled user to
+  plain `https://mirafold.com/pay` and tells an existing subscriber to set
+  `MIRAFOLD_LICENSE_KEY` and relaunch. The daemon hello has no host identity,
+  so terminal/browser and Electron render the same wording today.
+- The pair code and Pro credential are separate. The pair code is random per
+  daemon launch, lives in the QR fragment, derives the end-to-end session keys,
+  and never reaches the relay. A Pro entitlement token admits the daemon to the
+  hosted relay but cannot decrypt or join another user's session without that
+  pair code. This phase does not change either relay protocol.
+
+### Approved implementation boundary
+
+Phase DA may create `server/desktop-credential.ts` and its focused test. It may
+modify `server/index.ts`, `server/relay/relay-url.ts`,
+`server/relay/entitlement.ts`, `server/relay/subscription.ts`, `server/log.ts`,
+`server/protocol.ts`, `server/sessions/handler-context.ts`,
+`server/sessions/connection.ts`, `web/src/transport/daemon-hello.ts`, and
+`web/src/components/ConnectDevice.tsx`, `web/src/components/Shell.tsx`,
+`web/src/components/StatusBar.tsx`, and `web/src/components/FleetView.tsx`, plus
+only their directly corresponding tests and integration fixtures. Tests,
+release evidence, and this plan may be updated; no dependency is added.
+
+Boundary amendment — 2026-09-05, DA.2 execution: the existing session and fleet
+Pair cards receive individually forwarded properties. Add the three existing
+forwarding components above for six lines carrying the host property; this is
+necessary to deliver DA.2's specified behavior, adds no product surface, and
+does not change the locked behavior or trust boundary. Amendment recorded
+before editing those components.
+
+Boundary amendment — 2026-09-05, DA.3 execution: a real-daemon probe confirmed
+that a billing response echoing the private key reaches local messages and
+diagnostic sinks. The existing allowed billing consumers will remove their
+known key before returning text. Add `server/log.ts` and its directly
+corresponding test to recognize the Mirafold license-key family at the existing
+shared log scrubber; this closes the proved paste-safe-log gap and permits the
+Step's required redaction mutation check. No new service or credential store.
+
+Boundary amendment — 2026-09-05, DA.4 continuation: after the first ten fixes,
+the required fresh cold review proved that a nonempty operations token which
+cannot be placed in an HTTP header still selects the gated hosted relay while
+the token source silently supplies no credential. Extend the existing optional,
+local-only `relayOff` value set with `invalid-entitlement-token`; validate that
+override at relay-plan time using the same header rule as the dialer, and give
+the existing Pair card and boot output a credential-free explanation. The
+operator override continues to suppress license fallback. An explicit ungated
+self-host remains dialable without a token, while an explicit entitlement
+backend remains a gate. This adds no field, service, dependency, credential
+store, or remote-relay protocol change. Amendment recorded before product code.
+
+Boundary correction — 2026-09-05, DA.4C cold review: the immediately previous
+browser bundle preserves an unknown value in the already-recognized `relayOff`
+field and its exhaustiveness fallback renders that machine value as text. The
+paragraph above therefore does **not** authorize adding a fourth `relayOff`
+value. Keep that field's three-value wire contract unchanged. Add instead one
+optional, local-only `relayConfigProblem: "invalid-entitlement-token"` hello
+field; the previous bundle does not consume it and keeps no Pair button, while
+the current hello reducer validates the exact literal and maps it to the current
+Pair explanation. Remote viewports receive neither field. This is the one new
+wire field allowed by this correction; it carries no credential or identifier
+and adds no service, dependency, store, or remote-relay protocol change.
+Correction recorded before the compatibility repair.
+
+All agent adapters, project configuration formats, the remote pairing secret
+and cryptography, relay protocol and deployment, session/transcript persistence,
+ordinary terminal/npm credential precedence, and unhosted browser behavior stay
+behaviorally unchanged. The new host field is optional and local-only; it is
+not a general platform-identification mechanism. Any need for another product
+surface, executable file, wire field, service, dependency, or persistent store
+stops the Step for an explicit plan-boundary amendment before the change.
+
+### Locked boundary
+
+Desktop supplies the key over a pipe connected to the daemon's standard input
+and adds one fixed, non-secret internal launch flag. Shell reads only when that
+exact flag is present, enforces the existing license-key shape plus a tiny byte
+ceiling and short startup deadline, requires EOF, and closes the descriptor
+before any session or agent can start. The key is held in an explicit in-memory
+runtime configuration object; Shell must never write it to `process.env`,
+mutate argv with it, serialize it, or expose it through the browser wire.
+Terminal/npm launches continue to read the existing environment variable
+exactly as before. The hand-issued
+`MIRAFOLD_ENTITLEMENT_TOKEN` remains the ops override; in a Desktop-hosted
+launch the private pipe key wins over a stale ambient license key, with one
+credential-free warning if both exist. The official Desktop removes that
+ambient license variable before spawn; Shell's precedence rule is a second wall
+for other internal-flag launchers, not permission to rely on an environment
+secret.
+
+The same non-secret launch flag may add an optional `host: "desktop"` field to
+the local daemon hello. That field changes only trusted-shell wording and gives
+the Pro anchor a fixed Desktop marker for Electron main to intercept. It is
+additive wire data, contains no platform path or identifier, and never reaches
+remote viewports. An ordinary terminal/browser hello remains byte-for-behavior
+compatible. No preload, IPC, Node-enabled renderer, custom scheme, account,
+device token, relay endpoint, or secret-bearing WireMsg is introduced.
+
+The permanent key is more powerful than the 48-hour relay token because it can
+also schedule or undo cancellation under the existing accepted license-as-
+identity model. That is why passing only a relay token would be an incomplete
+substitute: it would silently remove the existing local subscription-management
+surface and require a new refresh service. This phase deliberately reuses the
+audited key path instead.
+
+### Steps
+
+- [x] **Step DA.1 — bounded private credential source.** ✅ 2026-09-05 —
+  `--mirafold-desktop` reads at most 43 bytes, requires EOF within two seconds,
+  closes stdin before boot, and resolves one daemon-only configuration for all
+  three consumers. Pipe/ambient and ops precedence, existing relay settings,
+  credential-free failures, and local mock turns are proved. Permitted Tier 1
+  1,145/1,145; focused built-daemon tests 7/7; typecheck and server build pass.
+  Eight dotenv-related tests were excluded under the global opacity rule.
+  Full step and evidence → `PLAN-ARCHIVE.md`, “Moved 2026-09-05 — Shell DA.1.”
+
+- [x] **Step DA.2 — make only the trusted local shell host-aware.** ✅
+  2026-09-05 — optional local-only `host: "desktop"` reaches the session and
+  fleet Pair cards. Desktop activation/renewal and existing-key links use the
+  fixed `/activate` URL and system-browser return wording. All 12 terminal card
+  arms retain their exact rendered markup; remote views gain no surface.
+  Permitted Tier 1 1,177/1,177; built-daemon tests 7/7; focused browser tests 5/5;
+  required browser/visual checks 11/11; typecheck and full build pass. Same eight
+  dotenv-related exclusions as DA.1. Full step and evidence →
+  `PLAN-ARCHIVE.md`, “Moved 2026-09-05 — Shell DA.2.”
+
+- [x] **Step DA.3 — prove the secret boundary through the real daemon and
+  relay path.** ✅ 2026-09-05 — real gated Relay, encrypted pairing, local
+  subscription actions, every engine/catalog/PTY/MCP child seam, rejected input,
+  billing failures, restarts, crash/log/wire/session searches, and five mutation
+  checks pass. Fixed proved billing-reflection/log leaks and one proved browser
+  test timing race. Permitted Tier 1 1,180; Tier 2 182; Tier 3 140; managed
+  browser/visual 11; packaged smoke 9; typecheck, build, notices, and diff check
+  pass. Eight Tier-1 and fourteen Tier-2 dotenv-related cases were excluded.
+  Full step, exact scope, gate recovery, and artifact evidence →
+  `PLAN-ARCHIVE.md`, “Moved 2026-09-05 — Shell DA.3.”
+
+- [x] **Step DA.4 — run the Shell feature-delta correctness hunt.** ✅
+  2026-09-05 — all 31 DA.1–DA.3 delta files and 11 adjacent seams were covered.
+  Ten proved entitlement correctness defects were repaired serially with
+  class-level regressions: expiry validation/watch ownership, invalid-header
+  survival, wall-clock and monotonic-clock behavior, irreversible cache
+  retirement, reentrant dispatch/timer ownership, failed-refresh expiry, and
+  listener-failure isolation. The next cold review proved an eleventh finding,
+  so the required DA.4C continuation was inserted before DA.5. Full coverage,
+  causes, probes, and review chain → `PLAN-ARCHIVE.md`, “Moved 2026-09-05 —
+  Shell DA.4 and DA.4C.”
+
+- [x] **Step DA.4C — close the over-cap invalid-override planning split.** ✅
+  2026-09-05 — the planner and token source now share Node's exact request-
+  header rule. Invalid overrides keep precedence but cannot advertise or dial
+  a gated relay; valid overrides and explicitly ungated tokenless self-hosts
+  remain usable. A cold review then proved and the Step repaired one previous-
+  client compatibility defect by using an exact, optional local-only
+  `relayConfigProblem` field instead of extending the old `relayOff` enum.
+  Final fresh review found no confirmed correctness issue. Permitted Tier 1
+  1,205/1,205; Tier 2 182/182; Tier 3 140/140; browser/visual 11/11; mutations
+  5/5; packaged smoke 9/9; typecheck and build pass. Eight Tier-1 and fourteen
+  Tier-2 dotenv-related cases were excluded under the global opacity rule.
+  No live service, dependency, commit, publication, or security audit.
+
+- [x] **Step DA.5 — audit and freeze the Shell security boundary.** ✅
+  2026-09-05 — ten findings were proved before their edits and repaired at the
+  Step's cap: configured-relay disclosure through two persistent log paths;
+  unowned WebSocket setup rejection; billing reflection of the permanent key;
+  arbitrary subscription claims; vulnerable `qs@6.15.3`; incomplete dotenv
+  ignore coverage; permissive `Date.parse` validation; an empty-fragment
+  bypass; status validation before key redaction; and a low-entropy false
+  positive in the first reflection guard. Each has a class regression. The
+  final independent review found no confirmed issue remaining. Final gates:
+  focused security surfaces 125/125; permitted Tier 1 1,222/1,222; Tier 2
+  183/183; Tier 3 140/140; browser/visual 11/11; mutations 5/5; installed
+  package 9/9; typecheck, build, notices, frozen real install, and production
+  audit pass. The exact 17-file, 817-line DA.5 patch has SHA-256
+  `9e8045d4ff3862e9c23ee2d283f6736c5967547a30cee2ec78144a42dfff057b`.
+  The reviewed 20-file `0.8.5` tarball is 1,467,431 bytes with SHA-256
+  `43361561d5cc2a8879ce3a8e536fc21735f8cc8c27f63c487bdeca96a15b3ef2`.
+  No commit, publication, deployment, Desktop executable change, or live
+  service change occurred. Full findings, exclusions, and evidence →
+  `PLAN-ARCHIVE.md`, “Moved 2026-09-05 — Shell DA.5 security audit and
+  candidate freeze.”
+
+- [ ] **Step DA.6 — publish the reviewed Shell before Desktop consumes it.**
+  Reconfirm Site Step DA-S.11's production activation endpoints are live, then
+  release exactly DA.5's candidate through the protected normal flow without
+  adding a new change. Verify the signed tag, npm provenance, registry tarball
+  hash and contents, a cold terminal install, the ordinary browser key path,
+  and an old Desktop launch with no internal flag. Record the npm version, commits, run
+  IDs, hashes, and automated Desktop intake result. Done when npm serves the
+  reviewed bytes, old clients remain unchanged, and Desktop Phase 13 can pin
+  that exact public version rather than a local tarball or branch.
+
+### Explicitly unchanged and residual
+
+`mirafold-relay` needs no code or deployment for this feature: its offline
+Ed25519 gate, origin policy, pair caps, ciphertext forwarding, and E2E-blind
+logging remain exactly as deployed. The website's existing terminal key flow
+continues. Same-user malware, root/administrator access, a compromised Shell or
+Desktop distribution, and a compromised billing origin can still obtain a key;
+no client-side design can honestly defeat those authorities. The reasonable
+walls here are absence from ambient process metadata, descriptor closure,
+agent-child stripping, renderer isolation, bounded inputs, and no secret on the
+wire.
+
 ## Stretch goals (unscheduled — polish, no milestone gates on these)
 
 Pick one up only when the phases above are quiet.

--- a/server/desktop-boundary.itest.ts
+++ b/server/desktop-boundary.itest.ts
@@ -1,0 +1,188 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { generateKeyPairSync, sign } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { WireMsg } from "./protocol";
+import { waitFor } from "./testing/wait-for";
+import { startRelay } from "../../mirafold-relay/src/relay";
+import { RemoteClient } from "./relay/relay-test-client";
+import { desktopDaemon, fakeDesktopBilling, assertDesktopSecretAbsent, fixtureFiles, type DesktopDaemon, DESKTOP_TEST_KEY as KEY, DESKTOP_TEST_AMBIENT as AMBIENT } from "./testing/desktop-harness";
+
+async function localTurn(run: DesktopDaemon, sessionId?: string) {
+  run.client.send(sessionId ? { type: "attach", sessionId } : { type: "create", agent: "claude-code", cwd: run.cwd });
+  const created = await run.client.type("session_created") as Extract<WireMsg, { type: "session_created" }>;
+  if (sessionId) assert.equal(created.sessionId, sessionId);
+  run.client.send({ type: "prompt", text: "a local turn survives credential failure" });
+  await run.client.type("turn_end");
+  assert.ok(run.client.received.some((message) => message.type === "text_delta"));
+  return created.sessionId;
+}
+
+test("DA.3: the real diagnostic sink redacts a reported Mirafold key", async (t) => {
+  const run = await desktopDaemon(t);
+  run.client.send({ type: "client_error", message: `DA.3 diagnostic ${KEY}` });
+  await run.waitLog(/DA\.3 diagnostic/);
+  assertDesktopSecretAbsent(run);
+  assert.match(run.stderr(), /\[redacted-key\]/);
+});
+
+test("DA.3: a billing refusal cannot reflect the private key into local hello, subscription replies, or logs", async (t) => {
+  const relay = await startRelay({ host: "127.0.0.1" });
+  t.after(() => relay.close());
+  const billing = await fakeDesktopBilling(t, () => ({ status: 403, body: { reason: `Refused ${KEY}: inactive` } }));
+  const run = await desktopDaemon(t, { chunks: [KEY.slice(0, 9), KEY.slice(9)], env: {
+    MIRAFOLD_RELAY_URL: `ws://127.0.0.1:${relay.port}`,
+    MIRAFOLD_ENTITLEMENT_URL: billing.url,
+  } });
+  await run.waitLog(/entitlement refused/);
+  run.client.send({ type: "refresh_agents" });
+  const hello = await run.client.type("agents");
+  assert.equal(hello.type === "agents" && hello.entitlement?.state, "invalid");
+  for (const [i, type] of ["subscription_status", "subscription_cancel", "subscription_uncancel"].entries()) {
+    run.client.send({ type, id: String(i) } as never);
+    const reply = await run.client.type("subscription");
+    assert.ok(reply.type === "subscription" && reply.error);
+  }
+  assertDesktopSecretAbsent(run);
+});
+
+test("DA.3: the private key buys a gated real-relay connection, encrypted pairing, and local subscription actions", async (t) => {
+  const { publicKey, privateKey } = generateKeyPairSync("ed25519");
+  const exp = Math.floor(Date.now() / 1000) + 48 * 60 * 60;
+  const payload = Buffer.from(JSON.stringify({ exp })).toString("base64url");
+  const token = `${payload}.${sign(null, Buffer.from(payload), privateKey).toString("base64url")}`;
+  const relay = await startRelay({ host: "127.0.0.1", entitlementPublicKey: publicKey.export({ format: "der", type: "spki" }).toString("base64") });
+  t.after(() => relay.close());
+  const billing = await fakeDesktopBilling(t, (route) => ({ body: route.endsWith("/entitlement") ? { token, exp } : { status: "active" } }));
+  const run = await desktopDaemon(t, { chunks: [KEY.slice(0, 1), KEY.slice(1, 19), KEY.slice(19)], env: {
+    MIRAFOLD_RELAY_URL: `ws://127.0.0.1:${relay.port}`,
+    MIRAFOLD_ENTITLEMENT_URL: billing.url,
+  } });
+  await run.waitLog(/\[relay\] paired/);
+  run.client.send({ type: "refresh_agents" });
+  const hello = await run.client.type("agents") as Extract<WireMsg, { type: "agents" }>;
+  assert.equal(hello.host, "desktop");
+  assert.equal(hello.billing, "license-key");
+  assert.equal(hello.entitlement?.state, "valid");
+  assert.ok(hello.relay?.code, "the honest QR inputs must be available");
+  const remote = await RemoteClient.connect(relay.port, hello.relay.code);
+  t.after(() => remote.close());
+  const remoteHello = await remote.type("agents");
+  for (const field of ["host", "relay", "relayOff", "relayConfigProblem", "entitlement", "billing"]) assert.equal(Object.hasOwn(remoteHello, field), false, `remote hello carried ${field}`);
+  remote.send({ type: "create", agent: "claude-code", cwd: run.cwd });
+  const created = await remote.type("session_created");
+  assert.equal(created.type === "session_created" && created.demo, true);
+  remote.send({ type: "prompt", text: "hello over the encrypted Desktop relay" });
+  await remote.type("turn_end");
+  assert.ok(remote.received.some((message) => message.type === "text_delta"));
+  for (const [i, type] of ["subscription_status", "subscription_cancel", "subscription_uncancel"].entries()) {
+    run.client.send({ type, id: `local-${i}` } as never);
+    const reply = await run.client.type("subscription");
+    assert.equal(reply.type === "subscription" && reply.status, "active");
+    const before = billing.requests.length;
+    remote.send({ type, id: `remote-${i}` } as never);
+    const refused = await remote.type("subscription");
+    assert.equal(refused.type === "subscription" && refused.error, "no subscription is configured on this daemon");
+    assert.equal(billing.requests.length, before, "a remote billing request reached the service");
+  }
+  assert.ok(billing.requests.length >= 4);
+  assert.ok(billing.requests.every((request) => request.key === KEY));
+  await run.stop();
+  assertDesktopSecretAbsent(run, [KEY, token], remote.received);
+});
+
+test("DA.3: every rejected private-input class leaves local sessions usable and never falls back to an ambient key", async (t) => {
+  const cases = [
+    { name: "empty EOF", chunks: [] },
+    { name: "early EOF", chunks: [KEY.slice(0, 12)] },
+    { name: "newline", chunks: [KEY, "\n"] },
+    { name: "invalid UTF-8", chunks: [Buffer.from([0xff]), KEY] },
+    { name: "oversized", chunks: [KEY, "z".repeat(100_000)] },
+    { name: "missing EOF", chunks: [KEY.slice(0, 8), KEY.slice(8)], eof: false },
+    { name: "non-pipe input", chunks: [], ignoreStdin: true },
+  ];
+  for (const { name, ...options } of cases) await t.test(name, async (t) => {
+    const billing = await fakeDesktopBilling(t, () => ({ body: { status: "active" } }));
+    const run = await desktopDaemon(t, { ...options, env: { MIRAFOLD_LICENSE_KEY: AMBIENT, MIRAFOLD_ENTITLEMENT_URL: billing.url } });
+    assert.equal(run.hello.host, "desktop");
+    assert.equal(run.hello.billing, undefined);
+    assert.equal(run.hello.relayOff, "unentitled");
+    await localTurn(run);
+    await run.stop();
+    assert.deepEqual(billing.requests, []);
+    assert.ok(fixtureFiles(path.join(run.root, "sessions")).length > 0);
+    assertDesktopSecretAbsent(run, [KEY, AMBIENT]);
+  });
+});
+
+test("DA.3: billing transport, parser, and service failures never disclose the key or prevent local turns", async (t) => {
+  const relay = await startRelay({ host: "127.0.0.1" });
+  t.after(() => relay.close());
+  const cases = [
+    { name: "bad request", reply: { status: 400, body: { error: `rejected ${KEY}` } } },
+    { name: "service failure", reply: { status: 503, body: { reason: KEY } } },
+    { name: "malformed JSON", reply: { raw: `{"reason":"${KEY}"` } },
+    { name: "wrong JSON shape", reply: { body: { token: KEY, exp: KEY, status: { key: KEY } } } },
+    { name: "oversized JSON", reply: { body: { padding: KEY.repeat(2_400) } } },
+    { name: "closed connection", reply: { closeEarly: true } },
+    { name: "request deadline", reply: { stall: true } },
+  ];
+  for (const { name, reply } of cases) await t.test(name, async (t) => {
+    const billing = await fakeDesktopBilling(t, () => reply);
+    const run = await desktopDaemon(t, { chunks: [KEY.slice(0, 10), KEY.slice(10)], env: {
+      MIRAFOLD_RELAY_URL: `ws://127.0.0.1:${relay.port}`, MIRAFOLD_ENTITLEMENT_URL: billing.url,
+    } });
+    await waitFor(() => run.client.received.some((message) =>
+      message.type === "entitlement" && message.state === "unreachable" ||
+      message.type === "agents" && message.entitlement?.state === "unreachable"), "failed entitlement read", 15_000);
+    for (const type of ["subscription_status", "subscription_cancel", "subscription_uncancel"] as const) {
+      run.client.send({ type, id: type });
+      const result = await run.client.type("subscription");
+      assert.ok(result.type === "subscription" && result.error);
+    }
+    await localTurn(run);
+    await run.stop();
+    assert.ok(billing.requests.length >= 4);
+    assertDesktopSecretAbsent(run);
+  });
+});
+
+test("DA.3: restarting needs a fresh private pipe while the saved local session stays usable", async (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-desktop-restart-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const billing = await fakeDesktopBilling(t, () => ({ body: { status: "active" } }));
+  const options = { root, env: { MIRAFOLD_RELAY_URL: "off", MIRAFOLD_ENTITLEMENT_URL: billing.url } };
+  const first = await desktopDaemon(t, options);
+  const sessionId = await localTurn(first);
+  await first.stop();
+  assertDesktopSecretAbsent(first);
+  const second = await desktopDaemon(t, { ...options, chunks: [] });
+  assert.equal(second.hello.billing, undefined, "a restart must not reload a saved key");
+  await localTurn(second, sessionId);
+  await second.stop();
+  assertDesktopSecretAbsent(second);
+  const third = await desktopDaemon(t, { ...options, chunks: [KEY.slice(0, 6), KEY.slice(6)] });
+  assert.equal(third.hello.billing, "license-key");
+  third.client.send({ type: "subscription_status", id: "restarted" });
+  const result = await third.client.type("subscription");
+  assert.equal(result.type === "subscription" && result.status, "active");
+  await localTurn(third, sessionId);
+  await third.stop();
+  assertDesktopSecretAbsent(third);
+});
+
+for (const kind of ["uncaughtException", "unhandledRejection"]) {
+  test(`DA.3: ${kind} crash text and the flight recorder remove a reflected key`, async (t) => {
+    const run = await desktopDaemon(t, { imports: [path.resolve(import.meta.dirname, "testing/fixtures/desktop-crash.mjs")] });
+    await localTurn(run);
+    await fetch(`http://127.0.0.1:${run.port}/desktop-test-crash/${kind}`).catch(() => {});
+    await waitFor(() => run.child.exitCode !== null, "expected fixture crash", 5_000);
+    await run.stop();
+    assert.equal(run.child.exitCode, 1);
+    assert.match(run.stderr(), new RegExp(`crashed \\(${kind}\\)`));
+    assert.match(run.stderr(), /\[redacted-key\]/);
+    assertDesktopSecretAbsent(run);
+  });
+}

--- a/server/desktop-children.itest.ts
+++ b/server/desktop-children.itest.ts
@@ -1,0 +1,122 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { waitFor } from "./testing/wait-for";
+import {
+  desktopDaemon, fixtureFiles, assertDesktopSecretAbsent,
+  DESKTOP_TEST_KEY as KEY, DESKTOP_TEST_AMBIENT as AMBIENT,
+} from "./testing/desktop-harness";
+
+const FIXTURES = path.resolve(import.meta.dirname, "testing/fixtures");
+const observer = path.join(FIXTURES, "desktop-observer.mjs");
+const engine = path.join(FIXTURES, "desktop-engine.mjs");
+const hash = (value: string) => createHash("sha256").update(value).digest("hex");
+const shellQuote = (value: string) => "'" + value.replaceAll("'", "'\\''") + "'";
+type Observation = {
+  label: string; pid: number; ppid: number; envKeys: string[]; privatePipeOpen: boolean;
+  envHashes: string[]; argvHashes: string[]; osEnvHashes: string[]; osArgvHashes: string[];
+};
+
+function fixture(t: TestContext) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "mirafold-desktop-children-"));
+  const bin = path.join(root, "bin");
+  const cwd = path.join(root, "workspace");
+  const capture = path.join(root, "capture");
+  mkdirSync(bin); mkdirSync(cwd); mkdirSync(capture);
+  const trust = path.join(root, "trust.json");
+  writeFileSync(trust, JSON.stringify({ version: 2, scopes: Object.fromEntries(["claude-code", "codex", "gemini-cli", "opencode"].map((agent) => [agent, [cwd]])) }));
+  for (const agent of ["codex", "gemini", "opencode"]) {
+    writeFileSync(path.join(bin, agent), `#!/bin/sh\nexec ${shellQuote(process.execPath)} ${shellQuote(engine)} ${agent} "$@"\n`, { mode: 0o755 });
+  }
+  const reports = (): Observation[] => fixtureFiles(capture)
+    .filter((file) => !path.basename(file).startsWith("mcp-ack-"))
+    .map((file) => JSON.parse(readFileSync(file, "utf8")) as Observation);
+  t.after(() => {
+    // Last resort for a failed assertion: only pids this fixture recorded.
+    for (const report of reports()) {
+      try { process.kill(report.pid, "SIGKILL"); } catch { /* already exited */ }
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+  return { root, bin, cwd, capture, reports, env: {
+    MIRAFOLD_TEST_CAPTURE: capture,
+    MIRAFOLD_TEST_DAEMON_OBSERVER: "1",
+    MIRAFOLD_CODEX_BIN: path.join(bin, "codex"),
+    MIRAFOLD_GEMINI_BIN: path.join(bin, "gemini"),
+    OPENCODE_BIN: path.join(bin, "opencode"),
+  } };
+}
+
+const LINUX = process.platform === "linux" ? false : "Linux process metadata and stdin identity proof";
+for (const [agent, mode, credential] of [
+  ["claude-code", "claude", "ANTHROPIC_API_KEY"],
+  ["codex", "codex", "OPENAI_API_KEY"],
+  ["gemini-cli", "gemini", "GEMINI_API_KEY"],
+  ["opencode", "opencode", ""],
+] as const) {
+  test(`DA.3: ${agent} and its reachable MCP children cannot inherit the private input or daemon credentials`, { skip: LINUX }, async (t) => {
+    const f = fixture(t);
+    const run = await desktopDaemon(t, { root: f.root, imports: [observer], env: {
+      ...f.env,
+      ...(credential ? { [credential]: "fixture-provider-credential" } : {}),
+      MIRAFOLD_LICENSE_KEY: AMBIENT,
+      MIRAFOLD_RELAY_URL: "off",
+      MIRAFOLD_TOKEN: "fixture-daemon-authentication",
+      MIRAFOLD_RELAY_CODE: "fixture-pairing-code",
+    } });
+    run.client.send({ type: "create", agent, cwd: f.cwd,
+      ...(agent === "opencode" ? {} : { backend: { kind: "api-key", model: "fixture" } }),
+    });
+    const created = await run.client.waitFor((message) => message.type === "session_created" || message.type === "error", "session creation");
+    assert.equal(created.type, "session_created", JSON.stringify(created).replaceAll(KEY, "[private key]").replaceAll(AMBIENT, "[ambient key]"));
+    run.client.send({ type: "prompt", text: "exercise the child boundary" });
+    await waitFor(() => f.reports().some((report) => report.label === `${mode}-engine`), `${agent} real child observed`, 15_000,
+      () => f.reports().map((report) => report.label).join(","));
+    await run.client.type("error", 15_000);
+    if (agent !== "claude-code") {
+      await waitFor(() => fixtureFiles(f.capture).some((file) => path.basename(file).startsWith(`mcp-ack-${mode}-`)), `${agent} real MCP acknowledgement`, 10_000);
+      assert.ok(f.reports().some((report) => report.label === "mcp"));
+    }
+    if (agent === "codex" || agent === "gemini-cli") {
+      run.client.send({ type: "prompt", text: "/model" });
+      await waitFor(() => f.reports().some((report) => report.label === `${mode}-catalog`), `${agent} catalog child observed`, 10_000);
+    }
+    await run.stop();
+    const reports = f.reports();
+    assert.ok(reports.some((report) => report.label === "daemon-after-private-read"));
+    for (const report of reports) {
+      assert.equal(report.privatePipeOpen, false, `${report.label} kept the private descriptor`);
+      for (const source of [report.envHashes, report.argvHashes, report.osEnvHashes, report.osArgvHashes]) {
+        assert.ok(!source.includes(hash(KEY)), `${report.label} received the private key`);
+        if (report.label !== "daemon-after-private-read") assert.ok(!source.includes(hash(AMBIENT)), `${report.label} inherited the ambient license`);
+      }
+      if (report.label !== "daemon-after-private-read") assert.deepEqual(report.envKeys, [], `${report.label} inherited daemon-only environment fields`);
+    }
+    assertDesktopSecretAbsent(run, [KEY, AMBIENT]);
+  });
+}
+
+test("DA.3: an official Desktop launch keeps the key out of a real PTY, transcript, and checkpoint", { skip: LINUX }, async (t) => {
+  const f = fixture(t);
+  const run = await desktopDaemon(t, { root: f.root, imports: [observer], env: {
+    ...f.env, OPENCODE_BIN: path.join(f.bin, "missing-opencode"), MIRAFOLD_RELAY_URL: "off",
+  } });
+  run.client.send({ type: "create", agent: "claude-code", cwd: f.cwd });
+  await run.client.type("session_created");
+  run.client.send({ type: "bang", id: "desktop-pty", command: `${shellQuote(process.execPath)} ${shellQuote(engine)} pty` });
+  await run.client.type("bang_end");
+  assert.ok(run.client.received.some((message) => message.type === "bang_output" && message.data.includes("Desktop child probe")));
+  const report = f.reports().find((report) => report.label === "pty-engine");
+  assert.ok(report, "the real PTY child must run");
+  assert.equal(report.privatePipeOpen, false);
+  assert.deepEqual(report.envHashes, []);
+  assert.deepEqual(report.osEnvHashes, []);
+  assert.deepEqual(report.argvHashes, []);
+  assert.deepEqual(report.osArgvHashes, []);
+  await run.stop();
+  assert.ok(fixtureFiles(path.join(f.root, "sessions")).length > 0, "the transcript must actually have been persisted");
+  assertDesktopSecretAbsent(run);
+});

--- a/server/desktop-credential.itest.ts
+++ b/server/desktop-credential.itest.ts
@@ -1,0 +1,152 @@
+import { test, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { mkdtempSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { DESKTOP_CREDENTIAL_FLAG } from "./desktop-credential";
+import type { WireMsg } from "./protocol";
+import { SCRUBBED_CREDENTIAL_ENV, TestClient } from "./testing/itest-harness";
+
+const KEY = `mf_${"c".repeat(26)}`;
+const AMBIENT = `mf_${"d".repeat(26)}`;
+
+async function daemon(t: TestContext, options: {
+  input?: string;
+  eof?: boolean;
+  desktop?: boolean;
+  env?: Record<string, string>;
+} = {}) {
+  // A fresh working directory keeps the real daemon away from any checkout
+  // dotenv file, and every persistent test record stays in this fixture.
+  const cwd = mkdtempSync(path.join(os.tmpdir(), "mirafold-desktop-startup-"));
+  const child = spawn(process.execPath, [path.resolve(import.meta.dirname, "../dist-server/index.js"),
+    ...(options.desktop === false ? [] : [DESKTOP_CREDENTIAL_FLAG])], {
+    cwd,
+    env: {
+      PATH: process.env.PATH,
+      ...SCRUBBED_CREDENTIAL_ENV,
+      PORT: String(39_000 + Math.floor(Math.random() * 1_000)),
+      MIRAFOLD_AGENT: "claude-code",
+      MIRAFOLD_SESSION_DIR: path.join(cwd, "sessions"),
+      MIRAFOLD_LICENSE_KEY: "",
+      MIRAFOLD_ENTITLEMENT_TOKEN: "",
+      MIRAFOLD_ENTITLEMENT_URL: "",
+      MIRAFOLD_APP_URL: "",
+      MIRAFOLD_LOCAL_DISCOVERY: "off",
+      MIRAFOLD_LOCAL_ENDPOINTS: "",
+      ...options.env,
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  let logs = "";
+  child.stdout.on("data", (chunk) => { logs += String(chunk); });
+  child.stderr.on("data", (chunk) => { logs += String(chunk); });
+  child.stdin.on("error", () => {});
+  const closed = once(child, "close");
+  t.after(async () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill();
+      const timer = setTimeout(() => child.kill("SIGKILL"), 3_000);
+      await closed;
+      clearTimeout(timer);
+    }
+    rmSync(cwd, { recursive: true, force: true });
+  });
+  if (options.eof === false) child.stdin.write(options.input ?? "");
+  else child.stdin.end(options.input ?? "");
+  const port = await new Promise<number>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      clearInterval(poll);
+      reject(new Error("built daemon did not start in 15 seconds"));
+    }, 15_000);
+    const poll = setInterval(() => {
+      const match = logs.match(/server on http:\/\/127\.0\.0\.1:(\d+)\//);
+      if (match) {
+        clearTimeout(timer);
+        clearInterval(poll);
+        resolve(Number(match[1]));
+      }
+    }, 20);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      clearInterval(poll);
+      reject(new Error("built daemon exited before listening"));
+    });
+  });
+  const client = new TestClient(port);
+  t.after(() => client.close());
+  await client.opened();
+  const hello = await client.type("agents") as Extract<WireMsg, { type: "agents" }>;
+  return { cwd, client, hello, logs: () => logs };
+}
+
+test("built daemon uses the private key for local billing, warns once about an ambient key, and keeps explicit relay opt-out", async (t) => {
+  const keys: string[] = [];
+  const billing = createServer(async (req, res) => {
+    let body = "";
+    for await (const chunk of req) body += String(chunk);
+    keys.push(JSON.parse(body).licenseKey);
+    res.setHeader("content-type", "application/json");
+    res.end(JSON.stringify({ status: "active" }));
+  });
+  billing.listen(0, "127.0.0.1");
+  await once(billing, "listening");
+  t.after(() => new Promise<void>((resolve) => billing.close(() => resolve())));
+  const address = billing.address();
+  assert.ok(address && typeof address === "object");
+  const run = await daemon(t, { input: KEY, env: {
+    MIRAFOLD_LICENSE_KEY: AMBIENT,
+    MIRAFOLD_RELAY_URL: "off",
+    MIRAFOLD_ENTITLEMENT_URL: `http://127.0.0.1:${address.port}/api/entitlement`,
+  } });
+  assert.equal(run.hello.host, "desktop");
+  assert.equal(run.hello.relayOff, "opt-out");
+  assert.equal(run.hello.billing, "license-key");
+  run.client.send({ type: "subscription_status", id: "status" });
+  const response = await run.client.type("subscription");
+  assert.equal(response.type === "subscription" && response.status, "active");
+  assert.deepEqual(keys, [KEY]);
+  assert.equal(run.logs().match(/ambient key is ignored/g)?.length, 1);
+  assert.ok(!run.logs().includes(KEY) && !run.logs().includes(AMBIENT));
+  assert.ok(!JSON.stringify(run.client.received).includes(KEY));
+});
+
+test("malformed, missing, oversized, and unterminated Desktop input preserve real local mock sessions", async (t) => {
+  for (const options of [
+    { input: `${KEY}\n` },
+    { input: "" },
+    { input: "x".repeat(100_000) },
+    { input: KEY, eof: false },
+  ]) {
+    await t.test(options.eof === false ? "missing EOF" : `input length ${options.input.length}`, async (t) => {
+      const run = await daemon(t, { ...options, env: { MIRAFOLD_LICENSE_KEY: AMBIENT } });
+      assert.equal(run.hello.host, "desktop");
+      assert.equal(run.hello.relay, undefined);
+      assert.equal(run.hello.relayOff, "unentitled");
+      assert.equal(run.hello.billing, undefined);
+      run.client.send({ type: "create", agent: "claude-code", cwd: run.cwd });
+      await run.client.type("session_created");
+      run.client.send({ type: "prompt", text: "hello" });
+      await run.client.type("turn_end");
+      assert.ok(run.client.received.some((message) => message.type === "text_delta"));
+      assert.match(run.logs(), /Desktop Pro credential unavailable/);
+      assert.ok(!run.logs().includes(KEY) && !run.logs().includes(AMBIENT));
+      assert.ok(!JSON.stringify(run.client.received).includes(KEY));
+    });
+  }
+});
+
+test("ordinary built-daemon startup never waits for pipe EOF and retains its existing license-key mode", async (t) => {
+  const run = await daemon(t, { desktop: false, input: KEY, eof: false, env: {
+    MIRAFOLD_RELAY_URL: "off",
+    MIRAFOLD_LICENSE_KEY: AMBIENT,
+  } });
+  assert.equal(Object.hasOwn(run.hello, "host"), false);
+  assert.equal(run.hello.billing, "license-key");
+  assert.equal(run.hello.relayOff, "opt-out");
+  assert.ok(!run.logs().includes("Desktop Pro"));
+  assert.ok(!run.logs().includes(KEY) && !run.logs().includes(AMBIENT));
+});

--- a/server/desktop-credential.test.ts
+++ b/server/desktop-credential.test.ts
@@ -1,0 +1,336 @@
+import { test, mock, type TestContext } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { once } from "node:events";
+import {
+  DESKTOP_CREDENTIAL_FLAG,
+  DESKTOP_CREDENTIAL_MAX_BYTES,
+  DESKTOP_CREDENTIAL_TIMEOUT_MS,
+  readDesktopCredential,
+  resolveCredentialConfig,
+  type DesktopCredential,
+} from "./desktop-credential";
+import { createEntitlementTokenSource } from "./relay/entitlement";
+import { createSubscriptionActions } from "./relay/subscription";
+import { DEFAULT_RELAY_URL, presentsOnEntitlement, resolveRelayPlan } from "./relay/relay-url";
+
+const KEY = `mf_${"a".repeat(26)}`;
+const AMBIENT = `mf_${"b".repeat(26)}`;
+const digest = (text: string) => createHash("sha256").update(text).digest("hex");
+const desktop: DesktopCredential = { kind: "desktop", key: KEY };
+
+test("credential resolution copies only relay configuration and never mutates its inputs", () => {
+  const env = Object.freeze({
+    MIRAFOLD_LICENSE_KEY: ` ${AMBIENT} `,
+    MIRAFOLD_ENTITLEMENT_TOKEN: " ops.token ",
+    MIRAFOLD_ENTITLEMENT_URL: " https://billing.example/api/entitlement ",
+    MIRAFOLD_RELAY_URL: " wss://self.example ",
+    MIRAFOLD_APP_URL: " https://app.example/ ",
+    UNRELATED_SECRET: "must-not-be-copied",
+  });
+  const { UNRELATED_SECRET: _, ...expected } = env;
+  const terminal = resolveCredentialConfig(env, { kind: "terminal" });
+  assert.deepEqual(terminal, expected, "even terminal whitespace is preserved for the existing consumers");
+  assert.notEqual(terminal, env);
+  assert.deepEqual(resolveCredentialConfig(env, Object.freeze(desktop)), {
+    ...expected,
+    MIRAFOLD_LICENSE_KEY: KEY,
+  });
+  for (const problem of ["missing-input", "invalid-key", "too-large", "timeout", "input-error"] as const) {
+    assert.deepEqual(resolveCredentialConfig(env, { kind: "desktop", problem }), {
+      ...expected,
+      MIRAFOLD_LICENSE_KEY: undefined,
+    }, "a failed private handoff never falls back to the ambient key");
+  }
+});
+
+test("one resolved configuration selects the pipe key for relay, exchange, and every subscription action", async (t) => {
+  const calls: { url: string; key: string }[] = [];
+  const fetchMock = mock.method(globalThis, "fetch", async (url: unknown, init?: RequestInit) => {
+    calls.push({ url: String(url), key: JSON.parse(String(init?.body)).licenseKey });
+    return String(url).endsWith("/entitlement")
+      ? Response.json({ token: "signed.token", exp: Math.floor(Date.now() / 1000) + 3600 })
+      : Response.json({ status: "active" });
+  });
+  t.after(() => fetchMock.mock.restore());
+  const config = resolveCredentialConfig({
+    MIRAFOLD_LICENSE_KEY: AMBIENT,
+    MIRAFOLD_ENTITLEMENT_URL: " https://custom.example/api/entitlement ",
+  }, desktop);
+  assert.equal(resolveRelayPlan(config).kind, "dial");
+  const source = createEntitlementTokenSource(config);
+  t.after(() => source.stop());
+  assert.equal(source.mode, "license-key");
+  assert.equal(await source.get(), "signed.token");
+  const actions = createSubscriptionActions(config)!;
+  assert.deepEqual(await actions.status(), { view: { status: "active" } });
+  await actions.cancel();
+  await actions.uncancel();
+  assert.deepEqual(calls, ["entitlement", "subscription", "subscription/cancel", "subscription/uncancel"].map(
+    (route) => ({ url: `https://custom.example/api/${route}`, key: KEY }),
+  ));
+});
+
+test("ops override still wins for valid and failed Desktop handoffs, without an exchange or billing actions", async (t) => {
+  const fetchMock = mock.method(globalThis, "fetch", async () => { throw new Error("unexpected exchange"); });
+  const warn = mock.method(console, "warn", () => {});
+  t.after(() => { fetchMock.mock.restore(); warn.mock.restore(); });
+  for (const input of [desktop, { kind: "desktop", problem: "missing-input" }] as const) {
+    const config = resolveCredentialConfig({ MIRAFOLD_ENTITLEMENT_TOKEN: " ops.token ", MIRAFOLD_LICENSE_KEY: AMBIENT }, input);
+    assert.equal(resolveRelayPlan(config).kind, "dial");
+    const source = createEntitlementTokenSource(config);
+    assert.equal(source.mode, "token-override");
+    assert.equal(await source.get(), "ops.token");
+    source.stop();
+    assert.equal(createSubscriptionActions(config), undefined);
+  }
+  assert.equal(fetchMock.mock.callCount(), 0);
+});
+
+test("failed Desktop input disables hosted admission; explicit self-hosts, opt-outs, and custom URLs retain their meaning", () => {
+  const missing: DesktopCredential = { kind: "desktop", problem: "missing-input" };
+  for (const url of [undefined, DEFAULT_RELAY_URL]) {
+    const config = resolveCredentialConfig({ MIRAFOLD_RELAY_URL: url, MIRAFOLD_LICENSE_KEY: AMBIENT }, missing);
+    assert.deepEqual(resolveRelayPlan(config), { kind: "off", reason: "unentitled-default" });
+    assert.equal(createSubscriptionActions(config), undefined);
+  }
+  for (const optOut of ["off", "none", "disabled", "false", "0"]) {
+    assert.deepEqual(resolveRelayPlan(resolveCredentialConfig({ MIRAFOLD_RELAY_URL: optOut }, desktop)), {
+      kind: "off", reason: "opt-out",
+    });
+  }
+  for (const input of [desktop, missing, { kind: "terminal" }] as const) {
+    const env = { MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9876", MIRAFOLD_APP_URL: "https://custom.example/" };
+    const config = resolveCredentialConfig(env, input);
+    const plan = resolveRelayPlan(config);
+    assert.deepEqual(plan, resolveRelayPlan(env));
+    assert.equal(presentsOnEntitlement(plan, config), false);
+    assert.equal(presentsOnEntitlement(plan, { ...config, MIRAFOLD_ENTITLEMENT_URL: "https://custom.example/exchange" }), true);
+  }
+});
+
+test("only an exact internal argument claims stdin; ordinary arguments and argv identity survive", async () => {
+  const argv = ["node", "entry", `${DESKTOP_CREDENTIAL_FLAG}=true`, "--desktop", "--verbose"];
+  const before = [...argv];
+  assert.deepEqual(await readDesktopCredential(argv), { kind: "terminal" });
+  assert.deepEqual(argv, before);
+});
+
+type Observation = {
+  kind: string;
+  problem?: string;
+  keyDigest?: string;
+  configDigest?: string;
+  envDigest?: string;
+  fdClosed: boolean;
+  argv: string[];
+  exposed: boolean;
+};
+
+// The child only reports digests and booleans. The expected key digest is
+// safe in its argv; neither the input nor a key literal is in its script.
+function reader(t: TestContext, options: {
+  key?: string;
+  args?: string[];
+  ambient?: string;
+  mode?: "normal" | "closed-fd" | "read-error" | "early-close";
+  stdin?: "pipe" | "ignore";
+} = {}) {
+  const key = options.key ?? KEY;
+  const script = `
+    import { createHash } from "node:crypto";
+    import { closeSync, fstatSync, readFileSync } from "node:fs";
+    import net from "node:net";
+    import { syncBuiltinESMExports } from "node:module";
+    const hash = (text) => createHash("sha256").update(text).digest("hex");
+    const expected = ${JSON.stringify(digest(key))};
+    let exposed = false;
+    const inspect = (value) => {
+      if (typeof value !== "string") return;
+      if ((value.match(/mf_[a-z2-7]{20,40}/g) ?? []).some(key => hash(key) === expected)) exposed = true;
+    };
+    process.env = new Proxy(process.env, { set(target, key, value) { inspect(value); target[key] = value; return true; } });
+    process.argv = new Proxy(process.argv, { set(target, key, value) { inspect(value); target[key] = value; return true; } });
+    const observe = () => {
+      Object.values(process.env).forEach(inspect);
+      process.argv.forEach(inspect);
+      if (process.platform === "linux") {
+        inspect(readFileSync("/proc/self/environ", "utf8"));
+        inspect(readFileSync("/proc/self/cmdline", "utf8"));
+      }
+    };
+    observe();
+    const OriginalSocket = net.Socket;
+    net.Socket = new Proxy(OriginalSocket, { construct(Target, [options]) {
+      if (options?.fd !== 0) return new Target(options);
+      const originalRead = options.onread.callback;
+      let socket;
+      options.onread.callback = (count, buffer) => {
+        observe();
+        const proceed = originalRead(count, buffer);
+        observe();
+        if (${JSON.stringify(options.mode ?? "normal")} === "read-error") {
+          socket.destroy(new Error(buffer.toString("utf8", 0, count)));
+        } else if (${JSON.stringify(options.mode ?? "normal")} === "early-close") {
+          socket.destroy();
+        }
+        process.stdout.write("chunk\\n");
+        return proceed;
+      };
+      socket = new Target(options);
+      return socket;
+    }});
+    syncBuiltinESMExports();
+    const { readDesktopCredential, resolveCredentialConfig } = await import(${JSON.stringify(new URL("./desktop-credential.ts", import.meta.url).href)});
+    if (${JSON.stringify(options.mode)} === "closed-fd") closeSync(0);
+    const pending = readDesktopCredential();
+    process.stdout.write("reading\\n");
+    const result = await pending;
+    observe();
+    const config = resolveCredentialConfig(process.env, result);
+    observe();
+    let fdClosed = false;
+    try { fstatSync(0); } catch (err) { fdClosed = err.code === "EBADF"; }
+    console.log(JSON.stringify({
+      kind: result.kind, problem: result.problem,
+      keyDigest: result.key ? hash(result.key) : undefined,
+      configDigest: config.MIRAFOLD_LICENSE_KEY ? hash(config.MIRAFOLD_LICENSE_KEY) : undefined,
+      envDigest: process.env.MIRAFOLD_LICENSE_KEY ? hash(process.env.MIRAFOLD_LICENSE_KEY) : undefined,
+      fdClosed, argv: process.argv.slice(2), exposed,
+    }));
+  `;
+  const child = spawn(process.execPath, ["--import", "tsx", "--input-type=module", "--eval", script, "--", "reader",
+    ...(options.args ?? [DESKTOP_CREDENTIAL_FLAG])], {
+    cwd: import.meta.dirname,
+    env: { PATH: process.env.PATH, MIRAFOLD_LOG_FILE: "", ...(options.ambient ? { MIRAFOLD_LICENSE_KEY: options.ambient } : {}) },
+    stdio: [options.stdin ?? "pipe", "pipe", "pipe"],
+  });
+  let output = "";
+  let errors = "";
+  const waiters = new Set<() => void>();
+  child.stdout!.on("data", (data) => { output += String(data); for (const wake of waiters) wake(); });
+  child.stderr!.on("data", (data) => { errors += String(data); });
+  child.stdin?.on("error", () => {}); // rejection can close the pipe during a producer write
+  const closed = once(child, "close");
+  t.after(() => { if (child.exitCode === null) child.kill("SIGKILL"); });
+  const until = (text: string) => new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => { waiters.delete(check); reject(new Error(`reader never reported ${text}`)); }, 10_000);
+    const check = () => { if (output.includes(text)) { clearTimeout(timer); waiters.delete(check); resolve(); } };
+    waiters.add(check);
+    check();
+  });
+  const result = async (): Promise<Observation> => {
+    const timer = setTimeout(() => child.kill("SIGKILL"), 10_000);
+    const [code, signal] = await closed;
+    clearTimeout(timer);
+    assert.equal(code, 0, `reader exit ${signal}: ${errors}`);
+    assert.equal(errors, "", "input and error text never reach stderr");
+    assert.ok(!output.includes(key), "no key-bearing stdout");
+    const observation = JSON.parse(output.trim().split("\n").at(-1)!) as Observation;
+    assert.equal(observation.exposed, false, "no pipe key in environment or argv during any read or assignment");
+    return observation;
+  };
+  return { child, until, result };
+}
+
+test("spawned reader requires EOF, accepts split UTF-8 keys, closes fd 0, and strips every internal flag", async (t) => {
+  const run = reader(t, { args: [DESKTOP_CREDENTIAL_FLAG, "--verbose", DESKTOP_CREDENTIAL_FLAG], ambient: AMBIENT });
+  await run.until("reading\n");
+  run.child.stdin!.write(KEY.slice(0, 8));
+  await run.until("chunk\n");
+  run.child.stdin!.end(KEY.slice(8));
+  const result = await run.result();
+  assert.deepEqual(result, {
+    kind: "desktop", keyDigest: digest(KEY), configDigest: digest(KEY), envDigest: digest(AMBIENT),
+    fdClosed: true, argv: ["--verbose"], exposed: false,
+  });
+});
+
+test("spawned reader accepts both license-shape endpoints with no environment key", async (t) => {
+  for (const size of [20, 40]) {
+    const key = `mf_${"z".repeat(size)}`;
+    const run = reader(t, { key });
+    run.child.stdin!.end(key);
+    const result = await run.result();
+    assert.equal(result.keyDigest, digest(key));
+    assert.equal(result.envDigest, undefined);
+    assert.equal(result.fdClosed, true);
+  }
+});
+
+test("spawned reader rejects missing, malformed, multi-frame, non-UTF-8, BOM, and oversized input without ambient fallback", async (t) => {
+  const invalid: [string | Buffer, string][] = [
+    ["", "missing-input"],
+    ["mf_short", "invalid-key"],
+    [`mf_${"a".repeat(19)}`, "invalid-key"],
+    [`mf_${"A".repeat(26)}`, "invalid-key"],
+    [`mf_${"1".repeat(26)}`, "invalid-key"],
+    [`${KEY}\n`, "invalid-key"],
+    [`${KEY}\r\n`, "invalid-key"],
+    [` ${KEY}`, "invalid-key"],
+    [`${KEY}\0`, "invalid-key"],
+    [Buffer.concat([Buffer.from(KEY), Buffer.from([0xff])]), "invalid-key"],
+    [`\ufeff${KEY}`, "invalid-key"],
+    [`${KEY}${KEY}`, "too-large"],
+    [`mf_${"a".repeat(41)}`, "too-large"],
+    ["x".repeat(1024 * 1024), "too-large"],
+  ];
+  for (const [input, problem] of invalid) {
+    const run = reader(t, { ambient: AMBIENT });
+    run.child.stdin!.end(input);
+    const result = await run.result();
+    assert.equal(result.problem, problem);
+    assert.equal(result.keyDigest, undefined);
+    assert.equal(result.configDigest, undefined);
+    assert.equal(result.envDigest, digest(AMBIENT));
+    assert.equal(result.fdClosed, true);
+  }
+  assert.equal(DESKTOP_CREDENTIAL_MAX_BYTES, 43);
+});
+
+test("the deadline is absolute: missing EOF and a slow producer both fail and close stdin", async (t) => {
+  for (const slow of [false, true]) {
+    const run = reader(t);
+    await run.until("reading\n");
+    const start = performance.now();
+    if (!slow) run.child.stdin!.write(KEY);
+    const drip = slow ? setInterval(() => run.child.stdin!.write("a"), 100) : undefined;
+    try {
+      const result = await run.result();
+      assert.equal(result.problem, "timeout");
+      assert.equal(result.keyDigest, undefined);
+      assert.equal(result.fdClosed, true);
+      assert.ok(performance.now() - start < DESKTOP_CREDENTIAL_TIMEOUT_MS + 3_000, "input never extends the startup deadline");
+    } finally {
+      clearInterval(drip);
+    }
+  }
+});
+
+test("descriptor errors, premature stream closure, and key-bearing stream errors fail without output", async (t) => {
+  for (const mode of ["closed-fd", "read-error", "early-close"] as const) {
+    const run = reader(t, { mode });
+    await run.until("reading\n");
+    if (mode !== "closed-fd") run.child.stdin!.write(KEY);
+    const result = await run.result();
+    assert.equal(result.problem, "input-error");
+    assert.equal(result.keyDigest, undefined);
+    assert.equal(result.fdClosed, true);
+  }
+  const missing = reader(t, { stdin: "ignore" });
+  const result = await missing.result();
+  assert.equal(result.problem, "input-error");
+  assert.equal(result.fdClosed, true);
+});
+
+test("ordinary and lookalike-flag launches never consume or close stdin and retain ambient credentials", async (t) => {
+  for (const args of [[], [`${DESKTOP_CREDENTIAL_FLAG}=true`, "--verbose"]]) {
+    const run = reader(t, { args, ambient: AMBIENT });
+    const result = await run.result(); // producer never sends EOF
+    assert.equal(result.kind, "terminal");
+    assert.equal(result.fdClosed, false);
+    assert.equal(result.configDigest, digest(AMBIENT));
+    assert.deepEqual(result.argv, args);
+  }
+});

--- a/server/desktop-credential.ts
+++ b/server/desktop-credential.ts
@@ -1,0 +1,151 @@
+import { closeSync, fstatSync } from "node:fs";
+import { Socket } from "node:net";
+
+export const DESKTOP_CREDENTIAL_FLAG = "--mirafold-desktop";
+export const DESKTOP_CREDENTIAL_MAX_BYTES = 43; // mf_ + at most 40 base32 characters
+export const DESKTOP_CREDENTIAL_TIMEOUT_MS = 2_000;
+
+export type DesktopCredential =
+  | { kind: "terminal" }
+  | { kind: "desktop"; key: string; problem?: never }
+  | {
+      kind: "desktop";
+      key?: never;
+      problem: "missing-input" | "invalid-key" | "too-large" | "timeout" | "input-error";
+    };
+
+/** An explicit daemon-only configuration, never an environment to inherit. */
+export type RelayRuntimeConfig = {
+  MIRAFOLD_RELAY_URL?: string;
+  MIRAFOLD_APP_URL?: string;
+  MIRAFOLD_ENTITLEMENT_URL?: string;
+  MIRAFOLD_ENTITLEMENT_TOKEN?: string;
+  MIRAFOLD_LICENSE_KEY?: string;
+};
+
+/** All three billing/relay consumers receive this same resolution. Leave
+ * terminal values intact: their established trimming and ops precedence stay
+ * with the consumers. A failed Desktop read must not revive an ambient key. */
+export function resolveCredentialConfig(
+  env: RelayRuntimeConfig,
+  credential: DesktopCredential,
+): RelayRuntimeConfig {
+  return {
+    MIRAFOLD_RELAY_URL: env.MIRAFOLD_RELAY_URL,
+    MIRAFOLD_APP_URL: env.MIRAFOLD_APP_URL,
+    MIRAFOLD_ENTITLEMENT_URL: env.MIRAFOLD_ENTITLEMENT_URL,
+    MIRAFOLD_ENTITLEMENT_TOKEN: env.MIRAFOLD_ENTITLEMENT_TOKEN,
+    MIRAFOLD_LICENSE_KEY: credential.kind === "desktop" ? credential.key : env.MIRAFOLD_LICENSE_KEY,
+  };
+}
+
+function closeStdin(): void {
+  try {
+    closeSync(0);
+  } catch {
+    // A missing/already-closed descriptor is also unavailable to children.
+  }
+}
+
+/** Only the private flag claims stdin. Await this before creating a server,
+ * session registry, or child. No input or error text is ever logged here. */
+export async function readDesktopCredential(argv = process.argv): Promise<DesktopCredential> {
+  if (!argv.slice(2).includes(DESKTOP_CREDENTIAL_FLAG)) return { kind: "terminal" };
+  for (let i = argv.length - 1; i >= 2; i--) {
+    if (argv[i] === DESKTOP_CREDENTIAL_FLAG) argv.splice(i, 1);
+  }
+
+  try {
+    const stat = fstatSync(0);
+    if (!stat.isFIFO() && !stat.isSocket()) {
+      closeStdin();
+      return { kind: "desktop", problem: "input-error" };
+    }
+  } catch {
+    closeStdin();
+    return { kind: "desktop", problem: "input-error" };
+  }
+
+  return new Promise<DesktopCredential>((resolve) => {
+    const bytes = Buffer.alloc(DESKTOP_CREDENTIAL_MAX_BYTES);
+    // Bound the OS read too; a hostile producer never gets a payload-sized
+    // allocation, even for the first chunk or a never-ending stream.
+    const chunk = Buffer.alloc(DESKTOP_CREDENTIAL_MAX_BYTES + 1);
+    const deadlineAt = performance.now() + DESKTOP_CREDENTIAL_TIMEOUT_MS;
+    let length = 0;
+    let result: DesktopCredential | undefined;
+    let input: Socket;
+    const finish = (next: DesktopCredential) => {
+      if (result) return;
+      result = next;
+      input.destroy();
+    };
+    const timer = setTimeout(
+      () => finish({ kind: "desktop", problem: "timeout" }),
+      DESKTOP_CREDENTIAL_TIMEOUT_MS,
+    );
+    const closed = () => {
+      clearTimeout(timer);
+      // libuv deliberately leaves standard descriptors open on Unix. Wait
+      // until its read handle has stopped, then close fd 0 ourselves.
+      closeStdin();
+      bytes.fill(0);
+      chunk.fill(0);
+      resolve(result ?? { kind: "desktop", problem: "input-error" });
+    };
+
+    try {
+      input = new Socket({
+        fd: 0,
+        readable: true,
+        writable: false,
+        onread: {
+          buffer: chunk,
+          callback: (count, buffer) => {
+            if (result) return false;
+            if (performance.now() >= deadlineAt) {
+              finish({ kind: "desktop", problem: "timeout" });
+              return false;
+            }
+            if (length + count > DESKTOP_CREDENTIAL_MAX_BYTES) {
+              finish({ kind: "desktop", problem: "too-large" });
+              return false;
+            }
+            bytes.set(buffer.subarray(0, count), length);
+            length += count;
+            return true;
+          },
+        },
+      });
+      input.once("end", () => {
+        if (performance.now() >= deadlineAt) {
+          finish({ kind: "desktop", problem: "timeout" });
+          return;
+        }
+        if (length === 0) {
+          finish({ kind: "desktop", problem: "missing-input" });
+          return;
+        }
+        try {
+          const key = new TextDecoder("utf-8", { fatal: true, ignoreBOM: true }).decode(bytes.subarray(0, length));
+          // The billing service's existing grammar, with no whitespace/BOM
+          // normalization. EOF is the sole frame terminator, never a newline.
+          finish(/^mf_[a-z2-7]{20,40}(?![\s\S])/.test(key)
+            ? { kind: "desktop", key }
+            : { kind: "desktop", problem: "invalid-key" });
+        } catch {
+          finish({ kind: "desktop", problem: "invalid-key" });
+        }
+      });
+      input.once("error", () => {
+        result = { kind: "desktop", problem: "input-error" };
+        input.destroy();
+      });
+      input.once("close", closed);
+      input.resume();
+    } catch {
+      result = { kind: "desktop", problem: "input-error" };
+      closed();
+    }
+  });
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,4 +1,5 @@
 import "./project-env-loader";
+import { readDesktopCredential, resolveCredentialConfig } from "./desktop-credential";
 import { createServer, type IncomingMessage } from "node:http";
 import { randomUUID } from "node:crypto";
 import path from "node:path";
@@ -15,7 +16,13 @@ import { startRelayClient } from "./relay/relay-client";
 import { createEntitlementTokenSource } from "./relay/entitlement";
 import { createSubscriptionActions } from "./relay/subscription";
 import { MIN_PAIRING_CODE_LENGTH, resolvePairingCode } from "./relay/relay-protocol";
-import { carriesCredentialInClear, presentsOnEntitlement, resolveRelayPlan, type RelayPlan } from "./relay/relay-url";
+import {
+  carriesCredentialInClear,
+  presentsOnEntitlement,
+  relayLogLabel,
+  resolveRelayPlan,
+  type RelayPlan,
+} from "./relay/relay-url";
 import {
   COOKIE_NAME,
   cookieToken,
@@ -47,6 +54,16 @@ const lastGasp = (kind: string, exitCode = 1) => (err: unknown) => {
 process.on("uncaughtException", lastGasp("uncaughtException"));
 process.on("unhandledRejection", lastGasp("unhandledRejection"));
 
+const desktopCredential = await readDesktopCredential();
+const relayConfig = resolveCredentialConfig(process.env, desktopCredential);
+if (desktopCredential.kind === "desktop") {
+  if (desktopCredential.problem) {
+    log.warn(`Desktop Pro credential unavailable (${desktopCredential.problem}); local sessions remain available.`);
+  } else if (process.env.MIRAFOLD_LICENSE_KEY?.trim()) {
+    log.warn("Desktop Pro key from private input takes precedence over MIRAFOLD_LICENSE_KEY; the ambient key is ignored.");
+  }
+}
+
 const app = express();
 
 // Resolved here (not with the relay block below) because the CSP's connect-src
@@ -54,7 +71,7 @@ const app = express();
 // default when an entitlement is configured (relay-url.ts has the full why;
 // MIRAFOLD_RELAY_URL=off is the opt-out). A malformed URL resolves to `off`
 // with its own reason — a bad value must narrow the policy, never widen it.
-const relayPlan = resolveRelayPlan(process.env);
+const relayPlan = resolveRelayPlan(relayConfig);
 const relay = relayPlan.kind === "dial" ? resolveRelayDial(relayPlan) : undefined;
 // Why remote access is off, for the pair button (protocol.ts `agents.relayOff`):
 // the button is always drawn for a local viewport; without a relay it opens
@@ -249,14 +266,14 @@ void probeLocalServers();
 // runs on a license key (subscription.ts decides; token-override and
 // self-host get nothing). Handed to LOCAL viewports only: billing actions
 // stay on the machine that holds the key, so the relay path never sees it.
-const subscriptionActions = createSubscriptionActions(process.env);
+const subscriptionActions = createSubscriptionActions(relayConfig);
 
 // The entitlement token source — a hand-issued token, a license key
 // exchanged at the billing backend, or nothing (a gated relay will refuse
 // the dial with an actionable line; local sessions never depend on this).
 // Created here, before the first viewport, because the pair card presents on
 // its read (protocol.ts `entitlement`); the relay block below dials with it.
-const entitlement = relay ? createEntitlementTokenSource(process.env) : undefined;
+const entitlement = relay ? createEntitlementTokenSource(relayConfig) : undefined;
 
 // Per-socket liveness, read by the heartbeat below to reap half-open
 // leftovers whose `close` never arrived (see ws-liveness.ts).
@@ -279,13 +296,14 @@ wss.on("connection", (ws) => {
   };
   const conn = openConnection(registry, viewport, {
     label: "ws",
+    host: desktopCredential.kind === "desktop" ? "desktop" : undefined,
     relay: relay?.info,
     relayOff,
     subscription: subscriptionActions,
     // The read reaches the pair card only where the exchange IS the relay's
     // gate (relay-url.ts presentsOnEntitlement) — an ungated self-hosted
     // relay carries a refused key just fine, and the card must not hide it.
-    entitlement: presentsOnEntitlement(relayPlan, process.env) ? entitlement : undefined,
+    entitlement: presentsOnEntitlement(relayPlan, relayConfig) ? entitlement : undefined,
   });
   ws.on("message", (data) => conn.handleMessage(String(data)));
   ws.on("close", conn.close);
@@ -380,7 +398,8 @@ if (relay && entitlement) {
       `[relay] KEEP THAT CODE SECRET — it grants remote access to your sessions; ` +
       `never paste this boot output into an issue or chat`,
   );
-  createLogger("relay").file(`dialing ${relay.url} (pairing code elided) — ${modeLine}`);
+  const logDestination = relayPlan.kind === "dial" ? relayLogLabel(relayPlan) : "relay";
+  createLogger("relay").file(`dialing ${logDestination} (pairing code elided) — ${modeLine}`);
 } else {
   switch (relayPlan.kind === "off" ? relayPlan.reason : undefined) {
     case "unentitled-default":
@@ -393,12 +412,19 @@ if (relay && entitlement) {
       );
       break;
     case "malformed-url":
-      // Refused here, named, instead of reaching `new WebSocket()` in the relay
-      // client and dying as an unhandledRejection AFTER the "server on" line.
+      // Refused here before a dial so the operator gets one specific repair
+      // instead of only the client's generic setup-failure containment.
       createLogger("relay").warn(
-        `MIRAFOLD_RELAY_URL is not a valid ws:// or wss:// URL and was REFUSED — ` +
+        `MIRAFOLD_RELAY_URL is not a usable Mirafold relay base and was REFUSED — ` +
           `remote access is OFF for this launch. Local sessions are unaffected. ` +
-          `Expected something like wss://relay.mirafold.sh`,
+          `Expected ws:// or wss:// with no fragment, such as wss://relay.mirafold.sh`,
+      );
+      break;
+    case "invalid-entitlement-token":
+      createLogger("relay").warn(
+        `MIRAFOLD_ENTITLEMENT_TOKEN cannot be used as an HTTP request header and was REFUSED — ` +
+          `remote access is OFF for this launch. Fix or remove that setting and relaunch. ` +
+          `Local sessions are unaffected.`,
       );
       break;
     case "opt-out":

--- a/server/log.test.ts
+++ b/server/log.test.ts
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawn } from "node:child_process";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -47,6 +47,18 @@ test("scrub redacts known provider key shapes anywhere in the line", () => {
   assert.match(scrub("AIzaSyA1B2C3D4E5F6G7H8I9J0K1L2M3N4O5P6Q rejected"), /\[redacted-key\]/);
   assert.match(scrub("using ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ012345"), /\[redacted-key\]/);
   assert.equal(scrub("sk-abcdefghijklmnopqrstuvwx").includes("abcdefghij"), false);
+});
+
+test("DA.3: Mirafold license keys are removed even when adjacent to ordinary text or clipped by the sink", async () => {
+  const { sanitizeLogLine } = await import("./log");
+  for (const size of [20, 26, 40]) {
+    const key = `mf_${"b".repeat(size)}`;
+    assert.equal(scrub(`denied ${key}`), "denied [redacted-key]");
+    assert.equal(scrub(`prefix${key}abc`), "prefix[redacted-key]");
+    const clipped = sanitizeLogLine(`${"x".repeat(3995)}${key}`);
+    assert.ok(!clipped.includes("mf_"));
+  }
+  assert.equal(scrub("mf_not_a_license"), "mf_not_a_license");
 });
 
 test("AUDIT: scrub redacts AWS and Google Vertex credential families", () => {
@@ -99,6 +111,89 @@ test("the scrubber is actually WIRED to both sinks, not just exported", () => {
     assert.equal((onDisk.match(/\[redacted\]/g) ?? []).length, 2); // error() and file()
     assert.match(onDisk, /gemini exited 1/); // still a useful diagnostic
   } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("DA.5: the real startup file sink never records a configured relay URL", { timeout: 20_000 }, async () => {
+  // Exercise server/index.ts itself: a helper-only assertion would survive a
+  // regression that put relay.url back into this one production call site.
+  // The fresh cwd contains no project configuration file, and the child gets
+  // an explicit minimal environment so it cannot inherit credentials or call
+  // a paid backend.
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "mirafold-relay-log-"));
+  const logPath = path.join(dir, "mirafold.log");
+  const relayUrl =
+    "ws://relay-user:relay-password@127.0.0.1:1/private-relay-path-credential?sig=query-secret";
+  const serverDir = path.dirname(fileURLToPath(import.meta.url));
+  const child = spawn(
+    process.execPath,
+    ["--import", fileURLToPath(import.meta.resolve("tsx")), path.join(serverDir, "index.ts")],
+    {
+      cwd: dir,
+      env: {
+        PATH: process.env.PATH ?? "",
+        PORT: "0",
+        MIRAFOLD_AGENT: "claude-code",
+        MIRAFOLD_TOKEN: "",
+        MIRAFOLD_LOG_FILE: logPath,
+        MIRAFOLD_SESSION_DIR: path.join(dir, "sessions"),
+        MIRAFOLD_LOCAL_DISCOVERY: "off",
+        MIRAFOLD_LOCAL_ENDPOINTS: "",
+        MIRAFOLD_RELAY_URL: relayUrl,
+        MIRAFOLD_RELAY_CODE: "da5-production-sink-test-code",
+        MIRAFOLD_APP_URL: "",
+        MIRAFOLD_LICENSE_KEY: "",
+        MIRAFOLD_ENTITLEMENT_TOKEN: "",
+        MIRAFOLD_ENTITLEMENT_URL: "",
+        ANTHROPIC_API_KEY: "",
+        ANTHROPIC_AUTH_TOKEN: "",
+        ANTHROPIC_BASE_URL: "",
+        OPENAI_API_KEY: "",
+        GEMINI_API_KEY: "",
+        GOOGLE_API_KEY: "",
+        CODEX_HOME: path.join(dir, "no-codex-home"),
+        CLAUDE_CONFIG_DIR: path.join(dir, "no-claude-home"),
+        OPENCODE_BIN: path.join(dir, "no-opencode"),
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  let stdout = "";
+  let stderr = "";
+  child.stdout.on("data", (data: Buffer) => (stdout += String(data)));
+  child.stderr.on("data", (data: Buffer) => (stderr += String(data)));
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const deadline = setTimeout(
+        () => reject(new Error(`daemon did not start; stdout:\n${stdout}\nstderr:\n${stderr}`)),
+        15_000,
+      );
+      const poll = setInterval(() => {
+        if (!stdout.includes("server on http://127.0.0.1:0/")) return;
+        clearInterval(poll);
+        clearTimeout(deadline);
+        resolve();
+      }, 20);
+      child.once("exit", (code, signal) => {
+        clearInterval(poll);
+        clearTimeout(deadline);
+        reject(new Error(`daemon exited (${code ?? signal}); stdout:\n${stdout}\nstderr:\n${stderr}`));
+      });
+    });
+
+    const onDisk = fs.readFileSync(logPath, "utf8");
+    assert.ok(stdout.includes(relayUrl), "the explicitly warned terminal boot block lost the configured URL");
+    assert.match(onDisk, /dialing configured relay \(pairing code elided\)/);
+    for (const marker of ["relay-user", "relay-password", "private-relay-path-credential", "query-secret"]) {
+      assert.ok(!onDisk.includes(marker), `${marker} reached the persistent startup log:\n${onDisk}`);
+    }
+  } finally {
+    if (child.exitCode === null && child.signalCode === null) {
+      const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+      child.kill();
+      await exited;
+    }
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });

--- a/server/log.ts
+++ b/server/log.ts
@@ -130,6 +130,9 @@ export function scrub(msg: string): string {
       .replace(/\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/gi, "$1 [redacted]")
       // OpenAI / Anthropic / OpenRouter style: sk-…, sk-ant-…, sk-or-…
       .replace(/\bsk-[A-Za-z0-9_-]{16,}/g, "[redacted-key]")
+      // Mirafold license keys, including a key embedded in a diagnostic's
+      // longer base32 run. The log sink must never retain a key prefix.
+      .replace(/mf_[a-z2-7]{20,}/g, "[redacted-key]")
       // Google API keys
       .replace(/\bAIza[0-9A-Za-z_-]{35}\b/g, "[redacted-key]")
       // GitHub tokens (ghp_/gho_/ghu_/ghs_/ghr_)

--- a/server/protocol.ts
+++ b/server/protocol.ts
@@ -309,6 +309,9 @@ export type ViewportMsgBody =
   // clients strip it and keep the one-row-per-agent picker.
   | {
       type: "agents";
+      // A private Desktop launch changes only local trusted-shell copy.
+      // Absent for terminal launches and every remote viewport.
+      host?: "desktop";
       agents: AgentInfo[];
       default: AgentName;
       cwd?: string;
@@ -323,9 +326,15 @@ export type ViewportMsgBody =
       // `unentitled` = nothing configured (the button offers Mirafold Pro);
       // `opt-out` = MIRAFOLD_RELAY_URL=off; `malformed-url` = the explicit
       // relay URL was refused at boot. LOCAL viewports only — a remote
-      // viewport is proof the relay is on; it gets neither field. Old
-      // clients strip it and keep no button.
+      // viewport is proof the relay is on; it gets neither field.
       relayOff?: "unentitled" | "opt-out" | "malformed-url";
+      // Optional/additive: an operations override cannot ride the gated
+      // relay's HTTP header. This needs its own field because the previous
+      // shell renders unknown values of the already-recognized `relayOff`
+      // field as raw text. Previous clients ignore this field and keep no
+      // Pair button; current clients map only this exact literal to the
+      // actionable off state. LOCAL viewports only.
+      relayConfigProblem?: "invalid-entitlement-token";
       version?: string;
       // Optional/additive: this daemon runs on a license key and can manage
       // the subscription behind it — the "manage subscription" affordance's
@@ -364,7 +373,7 @@ export type ViewportMsgBody =
   // refused (`reason` is the billing backend's line, capped) — no QR, the
   // offer instead; `unreachable` = the backend couldn't be asked — `cached`
   // says whether an unexpired token still carries the relay meanwhile;
-  // `checking` = the first exchange hasn't answered yet. Never a claim of
+  // `checking` = awaiting an exchange at boot or after token expiry. Never a claim of
   // validity the backend didn't make. Old clients strip it.
   | {
       type: "entitlement";
@@ -778,7 +787,9 @@ export type ClientMsg =
   | { type: "client_error"; message: string; clientVersion?: string };
 
 /** Why remote access is off (`agents.relayOff`) — declared once here. */
-export type RelayOffReason = NonNullable<Extract<WireMsg, { type: "agents" }>["relayOff"]>;
+export type RelayOffReason = NonNullable<
+  Extract<WireMsg, { type: "agents" }>["relayOff" | "relayConfigProblem"]
+>;
 
 /** The daemon's license-key read (`entitlement`), minus the tag — declared once here. */
 export type EntitlementView = Omit<Extract<WireMsg, { type: "entitlement" }>, "type">;

--- a/server/relay/entitlement.test.ts
+++ b/server/relay/entitlement.test.ts
@@ -1,6 +1,7 @@
-import { test, mock } from "node:test";
+import { performance } from "node:perf_hooks";
+import { test, mock, type TestContext } from "node:test";
 import assert from "node:assert/strict";
-import { createEntitlementTokenSource } from "./entitlement";
+import { createEntitlementTokenSource, type EntitlementView } from "./entitlement";
 
 // The daemon's token source (R.5). These tests stub global fetch — the failure
 // posture under test is "never throw, never block, degrade to no-token".
@@ -9,6 +10,472 @@ const futureExp = () => Math.floor(Date.now() / 1000) + 48 * 3600;
 
 const jsonResponse = (status: number, body: unknown) =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+// Node's Date mock advances civil time and relative timers, but deliberately
+// leaves the monotonic performance clock alone. Keep elapsed time explicit in
+// tests that exercise the one-minute request floor.
+const elapsedClock = (t: TestContext) => {
+  let now = 0;
+  t.mock.method(performance, "now", () => now);
+  return {
+    advance: (ms: number) => { now += ms; },
+    tick: (ms: number) => {
+      now += ms;
+      t.mock.timers.tick(ms);
+    },
+  };
+};
+
+test("DA.4: unusable expiry metadata cannot advertise access or replace a usable cached token", async (t) => {
+  // Bounded version of the expiry hunter: seconds must map to a finite,
+  // future millisecond deadline, both at boot and while carrying a cache.
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_800_000_000_000 });
+  const clock = elapsedClock(t);
+  for (const carried of [false, true]) {
+    for (const exp of [0, -1, Date.now() / 1000 - 1, Date.now() / 1000, Number.MAX_VALUE, null, "tomorrow"]) {
+      let answer = carried ? { token: "carried.token", exp: futureExp() } : { token: "bad.token", exp };
+      const fetch = t.mock.method(globalThis, "fetch", async () => jsonResponse(200, answer));
+      const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+      try {
+        if (carried) {
+          assert.equal(await source.get(), "carried.token");
+          answer = { token: "bad.token", exp };
+          clock.tick(61_000);
+        }
+        assert.equal(await source.get({ refresh: carried }), carried ? "carried.token" : undefined);
+        assert.deepEqual(source.state(), { state: "unreachable", cached: carried }, `expiry ${String(exp)}`);
+      } finally { source.stop(); fetch.mock.restore(); }
+    }
+  }
+});
+
+test("DA.4: header-invalid exchanged and override tokens degrade without escaping the source", async (t) => {
+  const invalid = ["bad\ntoken", "bad\0token", "bad☃token"];
+  for (const token of invalid) {
+    const fetch = t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse(200, { token, exp: futureExp() }));
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+    try {
+      assert.equal(await source.get(), undefined, JSON.stringify(token));
+      assert.deepEqual(source.state(), { state: "unreachable", cached: false });
+    } finally { source.stop(); fetch.mock.restore(); }
+  }
+
+  const fetch = t.mock.method(globalThis, "fetch", async () => {
+    throw new Error("an invalid override must suppress the key exchange");
+  });
+  try {
+    for (const token of ["bad\ntoken", "bad☃token"]) {
+      const source = createEntitlementTokenSource({
+        MIRAFOLD_ENTITLEMENT_TOKEN: token,
+        MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_run",
+      });
+      assert.equal(source.mode, "token-override");
+      assert.equal(await source.get(), undefined);
+      source.stop();
+    }
+    assert.equal(fetch.mock.callCount(), 0);
+
+    // Node accepts Latin-1 in an HTTP header; do not invent a narrower token
+    // grammar than the transport boundary requires.
+    const valid = createEntitlementTokenSource({ MIRAFOLD_ENTITLEMENT_TOKEN: "custom.é" });
+    assert.equal(await valid.get(), "custom.é");
+    valid.stop();
+  } finally { fetch.mock.restore(); }
+});
+
+test("DA.4: a header-invalid refresh cannot replace a usable cached token", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"] });
+  const clock = elapsedClock(t);
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => jsonResponse(200, ++calls === 1
+    ? { token: "carried.token", exp: futureExp() }
+    : { token: "bad\ntoken", exp: futureExp() }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  assert.equal(await source.get(), "carried.token");
+  clock.tick(61_000);
+  assert.equal(await source.get({ refresh: true }), "carried.token");
+  assert.deepEqual(source.state(), { state: "unreachable", cached: true });
+});
+
+test("DA.5: an exchanged token cannot contain the permanent license key", async (t) => {
+  for (const licenseKey of [`mf_${"b".repeat(26)}`, "custom-license-value"]) {
+    for (const token of [licenseKey, `prefix.${licenseKey}`, `${licenseKey}.suffix`]) {
+      const fetch = t.mock.method(globalThis, "fetch", async () =>
+        jsonResponse(200, { token, exp: futureExp() }));
+      const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: licenseKey });
+      try {
+        assert.equal(await source.get(), undefined);
+        assert.deepEqual(source.state(), { state: "unreachable", cached: false });
+      } finally {
+        source.stop();
+        fetch.mock.restore();
+      }
+    }
+  }
+
+  const licenseKey = `mf_${"b".repeat(26)}`;
+  const safe = "signed.token.with-no-permanent-credential";
+  const fetch = t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, { token: safe, exp: futureExp() }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: licenseKey });
+  try {
+    assert.equal(await source.get(), safe);
+    assert.deepEqual(source.state(), { state: "valid" });
+  } finally {
+    source.stop();
+    fetch.mock.restore();
+  }
+});
+
+test("DA.5 cold review: a short custom key does not reject an incidental token substring", async (t) => {
+  const licenseKey = "a";
+  for (const token of ["safe.token", "relay.token", "signed.payload"]) {
+    const fetch = t.mock.method(globalThis, "fetch", async () =>
+      jsonResponse(200, { token, exp: futureExp() }));
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: licenseKey });
+    try {
+      assert.equal(await source.get(), token);
+      assert.deepEqual(source.state(), { state: "valid" });
+    } finally {
+      source.stop();
+      fetch.mock.restore();
+    }
+  }
+
+  const fetch = t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, { token: licenseKey, exp: futureExp() }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: licenseKey });
+  try {
+    assert.equal(await source.get(), undefined, "exact reflection remains forbidden for every key length");
+  } finally {
+    source.stop();
+    fetch.mock.restore();
+  }
+});
+
+test("DA.5: a reflected refresh cannot displace an unexpired safe token", async (t) => {
+  t.mock.timers.enable({ apis: ["Date"] });
+  const clock = elapsedClock(t);
+  const licenseKey = `mf_${"c".repeat(26)}`;
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => jsonResponse(200, ++calls === 1
+    ? { token: "carried.safe.token", exp: futureExp() }
+    : { token: `wrapped.${licenseKey}.credential`, exp: futureExp() }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: licenseKey });
+  t.after(() => source.stop());
+  assert.equal(await source.get(), "carried.safe.token");
+  clock.tick(61_000);
+  assert.equal(await source.get({ refresh: true }), "carried.safe.token");
+  assert.deepEqual(source.state(), { state: "unreachable", cached: true });
+});
+
+test("DA.4: a fresh token's expiry gates pairing and refreshes without breaking the one-minute request floor", async (t) => {
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_800_000_000_000 });
+  const clock = elapsedClock(t);
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () => jsonResponse(200, {
+    token: ++calls === 1 ? "short.token" : "renewed.token",
+    exp: Date.now() / 1000 + (calls === 1 ? 1 : 3600),
+  }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  const heard: string[] = [];
+  source.onChange((view) => heard.push(view.state));
+  assert.equal(await source.get(), "short.token");
+  clock.tick(1000);
+  assert.deepEqual(source.state(), { state: "checking" });
+  assert.equal(await source.get(), undefined);
+  clock.tick(58_999);
+  assert.equal(calls, 1, "expiry must not create a billing request loop");
+  clock.tick(1);
+  assert.equal(calls, 2, "expiry must arrange a refresh without another caller");
+  assert.equal(await source.get(), "renewed.token");
+  assert.deepEqual(source.state(), { state: "valid" });
+  assert.deepEqual(heard, ["valid", "checking", "valid"]);
+  clock.tick(1000);
+  assert.equal(calls, 2, "the replaced expiry timer must not refresh again");
+});
+
+for (const outcome of ["valid", "unreachable"] as const) {
+  test(`DA.4: expiry during ${outcome} listener dispatch cannot leave access advertised`, async (t) => {
+    t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_800_000_000_000 });
+    const clock = elapsedClock(t);
+    let calls = 0;
+    t.mock.method(globalThis, "fetch", async () => {
+      if (++calls > 1) throw new Error("offline");
+      return jsonResponse(200, { token: "short.token", exp: Date.now() / 1000 + 65 });
+    });
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+    t.after(() => source.stop());
+    let crossed = false;
+    source.onChange((view) => {
+      if (!crossed && view.state === outcome) {
+        crossed = true;
+        // Represents listener work or a scheduling pause crossing the
+        // deadline between the exchange's decision and timer installation.
+        t.mock.timers.setTime(1_800_000_066_000);
+      }
+    });
+    await source.get();
+    if (outcome === "unreachable") {
+      clock.tick(61_000);
+      await source.get({ refresh: true });
+    }
+    assert.equal(crossed, true);
+    clock.tick(0);
+    const state = source.state();
+    assert.ok(state?.state !== "valid" && !(state?.state === "unreachable" && state.cached));
+  });
+}
+
+for (const outcome of ["valid", "unreachable"] as const) {
+  test(`DA.4: a forward wall-clock jump synchronously reconciles an expired ${outcome} read`, async (t) => {
+    const start = 1_800_000_000_000;
+    t.mock.timers.enable({ apis: ["Date"], now: start });
+    const clock = elapsedClock(t);
+    let calls = 0;
+    t.mock.method(globalThis, "fetch", async () => {
+      if (++calls > 1) throw new Error("offline");
+      return jsonResponse(200, { token: "clock.token", exp: start / 1000 + 3600 });
+    });
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+    try {
+      await source.get();
+      if (outcome === "unreachable") {
+        clock.tick(61_000);
+        await source.get({ refresh: true });
+      }
+      t.mock.timers.setTime(start + 3_600_001);
+      assert.deepEqual(
+        source.state(),
+        outcome === "valid" ? { state: "checking" } : { state: "unreachable", cached: false },
+      );
+    } finally { source.stop(); }
+  });
+
+  test(`DA.4: a connected ${outcome} listener hears a wall-clock expiry within one second`, async (t) => {
+    const start = 1_800_000_000_000;
+    const originalNow = Date.now;
+    let now = start;
+    Date.now = () => now;
+    t.after(() => { Date.now = originalNow; });
+    // Keep the relative timer clock independent from wall time, as libuv does.
+    t.mock.timers.enable({ apis: ["setTimeout"] });
+    const clock = elapsedClock(t);
+    let calls = 0;
+    t.mock.method(globalThis, "fetch", async () => {
+      if (++calls > 1) throw new Error("offline");
+      return jsonResponse(200, { token: "clock.token", exp: start / 1000 + 3600 });
+    });
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+    t.after(() => source.stop());
+    let latest: EntitlementView | undefined;
+    source.onChange((view) => { latest = view; });
+    await source.get();
+    if (outcome === "unreachable") {
+      now += 61_000;
+      clock.advance(61_000);
+      await source.get({ refresh: true });
+    }
+    const advertisesAccess = () => latest?.state === "valid" || latest?.state === "unreachable" && latest.cached;
+    assert.equal(advertisesAccess(), true);
+    now = start + 3_600_001;
+    clock.tick(999);
+    assert.equal(advertisesAccess(), true, "the bounded timer fired before its one-second hop");
+    clock.tick(1);
+    assert.equal(advertisesAccess(), false, "the connected viewport kept expired access past one second");
+  });
+}
+
+for (const outcome of ["valid", "unreachable"] as const) {
+  test(`DA.4: a backward wall-clock correction cannot revive an expired ${outcome} token`, async (t) => {
+    const start = 1_800_000_000_000;
+    t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: start });
+    const clock = elapsedClock(t);
+    let calls = 0;
+    t.mock.method(globalThis, "fetch", async () => {
+      if (++calls > 1) throw new Error("offline");
+      return jsonResponse(200, { token: "clock.token", exp: start / 1000 + 3_600 });
+    });
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+    t.after(() => source.stop());
+
+    await source.get();
+    if (outcome === "unreachable") {
+      clock.tick(61_000);
+      await source.get({ refresh: true });
+    }
+
+    t.mock.timers.setTime(start + 3_600_001);
+    assert.deepEqual(
+      source.state(),
+      outcome === "valid" ? { state: "checking" } : { state: "unreachable", cached: false },
+    );
+    t.mock.timers.setTime(start + 120_000);
+    assert.equal(await source.get(), undefined, "an observed expiry must be irreversible for this cache entry");
+    assert.deepEqual(
+      source.state(),
+      outcome === "valid" ? { state: "checking" } : { state: "unreachable", cached: false },
+    );
+  });
+}
+
+test("DA.4: a backward wall-clock correction cannot extend the one-minute forced-refresh floor", async (t) => {
+  const start = 1_800_000_000_000;
+  t.mock.timers.enable({ apis: ["Date"], now: start });
+  const clock = elapsedClock(t);
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, { token: `clock.token.${++calls}`, exp: start / 1000 + 7_200 }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+
+  await source.get();
+  t.mock.timers.setTime(start - 3_600_000);
+  clock.tick(61_000);
+  await source.get({ refresh: true });
+  assert.equal(calls, 2);
+});
+
+test("DA.4: reentrant state reconciliation delivers each new read once", async (t) => {
+  const start = 1_800_000_000_000;
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: start });
+  t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, { token: "short.token", exp: start / 1000 + 1 }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  let reconciled = false;
+  const second: EntitlementView[] = [];
+  source.onChange((next) => {
+    if (!reconciled && next.state === "valid") {
+      reconciled = true;
+      t.mock.timers.setTime(start + 1_001);
+      source.state();
+    }
+  });
+  source.onChange((next) => second.push({ ...next }));
+
+  await source.get();
+  assert.deepEqual(second, [{ state: "checking" }]);
+});
+
+test("DA.4: reentrant state reconciliation preserves its scheduled refresh", async (t) => {
+  const start = 1_800_000_000_000;
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: start });
+  const clock = elapsedClock(t);
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, {
+      token: ++calls === 1 ? "short.token" : "renewed.token",
+      exp: Date.now() / 1000 + (calls === 1 ? 1 : 3_600),
+    }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  let reconciled = false;
+  source.onChange((next) => {
+    if (!reconciled && next.state === "valid") {
+      reconciled = true;
+      t.mock.timers.setTime(start + 1_001);
+      source.state();
+    }
+  });
+
+  await source.get();
+  clock.tick(0);
+  assert.equal(calls, 1, "a wall-clock jump must not bypass the elapsed-time floor");
+  clock.tick(59_999);
+  assert.equal(calls, 1);
+  clock.tick(1);
+  assert.equal(calls, 2, "the expiry-arranged refresh was lost");
+  assert.equal(await source.get(), "renewed.token");
+});
+
+test("DA.4: expiry during an in-flight refresh hides the old token and keeps the refresh single-flight", async (t) => {
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_800_000_000_000 });
+  const clock = elapsedClock(t);
+  let resolve!: (response: Response) => void;
+  let calls = 0;
+  t.mock.method(globalThis, "fetch", () => ++calls === 1
+    ? Promise.resolve(jsonResponse(200, { token: "old.token", exp: Date.now() / 1000 + 65 }))
+    : new Promise<Response>((done) => { resolve = done; }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  await source.get();
+  clock.tick(61_000);
+  const pending = source.get({ refresh: true });
+  clock.tick(4000);
+  assert.deepEqual(source.state(), { state: "checking" });
+  resolve(jsonResponse(200, { token: "new.token", exp: futureExp() }));
+  assert.equal(await pending, "new.token");
+  assert.deepEqual(source.state(), { state: "valid" });
+  clock.tick(60_000);
+  assert.equal(calls, 2, "the old token must not leave a delayed refresh behind");
+});
+
+test("DA.4: a failed refresh that observes expiry retires the old cache before listeners run", async (t) => {
+  const start = 1_800_000_000_000;
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: start });
+  const clock = elapsedClock(t);
+  let calls = 0;
+  let rejectRefresh!: (error: Error) => void;
+  t.mock.method(globalThis, "fetch", () => {
+    if (++calls === 1) {
+      return Promise.resolve(jsonResponse(200, { token: "old.token", exp: start / 1000 + 65 }));
+    }
+    return new Promise<Response>((_resolve, reject) => { rejectRefresh = reject; });
+  });
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  assert.equal(await source.get(), "old.token");
+
+  clock.tick(61_000);
+  const pending = source.get({ refresh: true });
+  t.mock.timers.setTime(start + 66_000);
+  source.onChange((next) => {
+    if (next.state === "unreachable" && !next.cached) {
+      t.mock.timers.setTime(start + 62_000);
+    }
+  });
+  rejectRefresh(new Error("offline"));
+
+  assert.equal(await pending, undefined);
+  assert.equal(calls, 2);
+  assert.deepEqual(source.state(), { state: "unreachable", cached: false });
+});
+
+test("DA.4: stopping before the boot exchange completes cannot leave an automatic expiry refresh", async (t) => {
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"], now: 1_800_000_000_000 });
+  let resolve!: (response: Response) => void;
+  const fetch = t.mock.method(globalThis, "fetch", () => new Promise<Response>((done) => { resolve = done; }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  const pending = source.get();
+  source.stop();
+  resolve(jsonResponse(200, { token: "short.token", exp: Date.now() / 1000 + 1 }));
+  await pending;
+  t.mock.timers.tick(60_001);
+  assert.equal(fetch.mock.callCount(), 1);
+});
+
+test("DA.3: reflected license values are removed before refusal text is clipped or published", async (t) => {
+  // Terminal mode historically accepts an arbitrary supplied key, so the
+  // exact-value guard must work independently of the logger's shaped pattern.
+  const key = "custom-license-value";
+  for (const raw of [`refused ${key}${key}`, `${"x".repeat(195)}${key}`]) {
+    const fetch = t.mock.method(globalThis, "fetch", async () => jsonResponse(403, { reason: raw }));
+    const warn = t.mock.method(console, "warn", () => {});
+    const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: key });
+    try {
+      await source.get();
+      const reason = source.state()?.reason;
+      assert.equal(reason, raw.split(key).join("[license key]").slice(0, 200));
+      assert.ok(!reason?.includes("custom"));
+      assert.ok(warn.mock.calls.every((call) => !String(call.arguments[0]).includes(key)));
+    } finally { source.stop(); fetch.mock.restore(); warn.mock.restore(); }
+  }
+});
 
 test("token override wins outright: no exchange ever runs", async () => {
   const fetchMock = mock.method(globalThis, "fetch", async () => {
@@ -174,12 +641,13 @@ test("AUDIT: a refused license key is never echoed into the log, not even its pr
 // Phase PB.2: the source's READ for the pair card — every exchange outcome
 // sets it, listeners hear only changes, and `unreachable` says whether an
 // unexpired token still carries the relay meanwhile.
-test("license key: the read starts checking, then follows each exchange outcome; listeners hear changes only", async () => {
+test("license key: the read starts checking, then follows each exchange outcome; listeners hear changes only", async (t) => {
   let answer: () => Response = () => jsonResponse(200, { token: "t1", exp: futureExp() });
   const fetchMock = mock.method(globalThis, "fetch", async () => answer());
   // A forced re-exchange is throttled to once a minute (a lapsed key must not
   // turn dial backoff into an HTTP hammer) — the clock has to move for it.
-  mock.timers.enable({ apis: ["Date"] });
+  t.mock.timers.enable({ apis: ["Date"] });
+  const clock = elapsedClock(t);
   try {
     const src = createEntitlementTokenSource({
       MIRAFOLD_LICENSE_KEY: "mf_test",
@@ -193,7 +661,7 @@ test("license key: the read starts checking, then follows each exchange outcome;
 
     // A lapse at the next (forced) exchange: refused, the reason quoted, capped.
     answer = () => jsonResponse(403, { reason: "x".repeat(500) });
-    mock.timers.tick(61_000);
+    clock.tick(61_000);
     await src.get({ refresh: true });
     assert.equal(src.state()?.state, "invalid");
     assert.equal(src.state()?.reason?.length, 200);
@@ -203,7 +671,7 @@ test("license key: the read starts checking, then follows each exchange outcome;
       throw new Error("ECONNREFUSED");
     };
     // The minute gap throttles a stale-cache refetch too — move the clock again.
-    mock.timers.tick(61_000);
+    clock.tick(61_000);
     await src.get();
     assert.deepEqual(src.state(), { state: "unreachable", cached: false });
     await src.get(); // same read again → no second notification
@@ -211,7 +679,7 @@ test("license key: the read starts checking, then follows each exchange outcome;
     off();
     src.stop();
   } finally {
-    mock.timers.reset();
+    t.mock.timers.reset();
     fetchMock.mock.restore();
   }
 });
@@ -260,53 +728,72 @@ test("a throwing listener neither relabels the read nor rejects the refresh", as
   }
 });
 
-test("unreachable with a cached token flips to uncached when that token expires", async () => {
+test("DA.4: an unprintable thrown listener value cannot reject the refresh or skip listeners", async (t) => {
+  t.mock.method(globalThis, "fetch", async () =>
+    jsonResponse(200, { token: "t", exp: futureExp() }));
+  const source = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  t.after(() => source.stop());
+  const heard: string[] = [];
+  source.onChange(() => {
+    throw { toString: () => { throw new Error("unprintable thrown value"); } };
+  });
+  source.onChange((next) => heard.push(next.state));
+
+  const rejected = await source.get().then(() => false, () => true);
+  assert.equal(rejected, false);
+  assert.deepEqual(source.state(), { state: "valid" });
+  assert.deepEqual(heard, ["valid"]);
+});
+
+test("unreachable with a cached token flips to uncached when that token expires", async (t) => {
   let up = true;
   const fetchMock = mock.method(globalThis, "fetch", async () => {
     if (!up) throw new Error("ECONNREFUSED");
     return jsonResponse(200, { token: "t", exp: Math.floor(Date.now() / 1000) + 3600 });
   });
-  mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  const clock = elapsedClock(t);
   try {
     const src = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test", MIRAFOLD_ENTITLEMENT_URL: "http://b.test/api/entitlement" });
     const heard: string[] = [];
     src.onChange((v) => heard.push(`${v.state}${v.cached ? ":cached" : ""}`));
     await src.get();
     up = false;
-    mock.timers.tick(61_000);
+    clock.tick(61_000);
     await src.get({ refresh: true });
     assert.deepEqual(src.state(), { state: "unreachable", cached: true }, "the hour-long token still carries");
-    mock.timers.tick(3600_000);
+    clock.tick(3600_000);
     assert.deepEqual(src.state(), { state: "unreachable", cached: false }, "expiry is a read change");
     assert.deepEqual(heard, ["valid", "unreachable:cached", "unreachable"]);
     src.stop();
   } finally {
-    mock.timers.reset();
+    t.mock.timers.reset();
     fetchMock.mock.restore();
   }
 });
 
-test("a token living longer than a setTimeout can (>24.8 days) is watched in hops, not flipped at once", async () => {
+test("a token living longer than a setTimeout can (>24.8 days) is watched in hops, not flipped at once", async (t) => {
   let up = true;
   const fetchMock = mock.method(globalThis, "fetch", async () => {
     if (!up) throw new Error("ECONNREFUSED");
     return jsonResponse(200, { token: "t", exp: Math.floor(Date.now() / 1000) + 40 * 24 * 3600 });
   });
-  mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  t.mock.timers.enable({ apis: ["Date", "setTimeout"] });
+  const clock = elapsedClock(t);
   try {
     const src = createEntitlementTokenSource({ MIRAFOLD_LICENSE_KEY: "mf_test", MIRAFOLD_ENTITLEMENT_URL: "http://b.test/api/entitlement" });
     await src.get();
     up = false;
-    mock.timers.tick(61_000);
+    clock.tick(61_000);
     await src.get({ refresh: true });
     assert.deepEqual(src.state(), { state: "unreachable", cached: true });
-    mock.timers.tick(2 ** 31); // past one hop: still carrying
+    clock.tick(2 ** 31); // past one hop: still carrying
     assert.deepEqual(src.state(), { state: "unreachable", cached: true });
-    mock.timers.tick(40 * 24 * 3600 * 1000); // past expiry
+    clock.tick(40 * 24 * 3600 * 1000); // past expiry
     assert.deepEqual(src.state(), { state: "unreachable", cached: false });
     src.stop();
   } finally {
-    mock.timers.reset();
+    t.mock.timers.reset();
     fetchMock.mock.restore();
   }
 });

--- a/server/relay/entitlement.ts
+++ b/server/relay/entitlement.ts
@@ -18,9 +18,11 @@
 // the dial-out carries no header — a gated relay refuses it with 4007 and
 // relay-client already prints the actionable line.
 
+import { performance } from "node:perf_hooks";
 import { createLogger } from "../log";
 import type { EntitlementView } from "../protocol";
 import { carriesCredentialInClear } from "./relay-url";
+import { isEntitlementHeaderValue } from "./relay-protocol";
 export type { EntitlementView };
 
 const log = createLogger("relay");
@@ -33,7 +35,18 @@ const FORCED_REFRESH_MIN_GAP_MS = 60_000;
 const FETCH_TIMEOUT_MS = 10_000;
 const BILLING_RESPONSE_MAX_BYTES = 64 * 1024;
 const ENTITLEMENT_TOKEN_MAX_BYTES = 8_192;
-// A backend line rides to the pair/manage card verbatim — bounded. Shared
+// Exact equality is unambiguous for every custom key. Embedded containment is
+// meaningful only once the value is specific enough: otherwise a supported
+// one-character custom key such as `a` would reject ordinary tokens like
+// `safe.token`. Sixteen characters covers every official mf_ key and useful
+// custom credentials without turning incidental short overlaps into outages.
+const EMBEDDED_LICENSE_KEY_MIN_CHARS = 16;
+
+const tokenReflectsLicenseKey = (token: string, licenseKey: string): boolean =>
+  token === licenseKey ||
+  (licenseKey.length >= EMBEDDED_LICENSE_KEY_MIN_CHARS && token.includes(licenseKey));
+// A backend line rides to the pair/manage card with the known key removed
+// and its length bounded. Shared
 // with subscription.ts so both cards cap alike.
 export const MAX_REASON_CHARS = 200;
 
@@ -54,6 +67,11 @@ export type EntitlementMode = "token-override" | "license-key" | "none";
 // Never key bytes in a log line, not even a prefix — the flight recorder
 // is promised paste-safe (audit 2026-08-26).
 const mask = (_s: string) => "[license key]";
+
+/** A billing service already knows this key and can echo it in any string.
+ * Remove the exact value before clipping, logging, or publishing that text. */
+export const redactLicenseKey = (text: string, licenseKey: string): string =>
+  licenseKey ? text.split(licenseKey).join(mask(licenseKey)) : text;
 
 export const DEFAULT_ENTITLEMENT_URL = "https://mirafold.com/api/entitlement";
 
@@ -105,15 +123,24 @@ export function createEntitlementTokenSource(env: {
   MIRAFOLD_LICENSE_KEY?: string;
   MIRAFOLD_ENTITLEMENT_URL?: string;
 }): EntitlementTokenSource & { mode: EntitlementMode } {
-  const override = env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim();
+  const suppliedOverride = env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim();
+  const override = suppliedOverride && isEntitlementHeaderValue(suppliedOverride)
+    ? suppliedOverride
+    : undefined;
   const licenseKey = env.MIRAFOLD_LICENSE_KEY?.trim();
   const url = resolveEntitlementUrl(env);
 
-  if (override) {
+  if (suppliedOverride) {
     if (licenseKey) {
       log.warn(
         `both MIRAFOLD_ENTITLEMENT_TOKEN and MIRAFOLD_LICENSE_KEY are set — ` +
           `the token override wins; the license key is ignored`,
+      );
+    }
+    if (!override) {
+      log.warn(
+        "MIRAFOLD_ENTITLEMENT_TOKEN is not usable as a request header and will be omitted — " +
+          "the selected relay may refuse a tokenless dial; local sessions are unaffected",
       );
     }
     return {
@@ -145,42 +172,91 @@ export function createEntitlementTokenSource(env: {
   // sets it, and only a CHANGED read reaches listeners.
   let view: EntitlementView = { state: "checking" };
   const listeners = new Set<(v: EntitlementView) => void>();
+  let dispatching = false;
+  let pendingDispatch = false;
   // Dispatch runs OUTSIDE the exchange's try/catch (below) and each listener
   // is guarded: a throwing subscriber must not relabel the read or turn the
-  // fire-and-forget refresh into an unhandled rejection.
+  // fire-and-forget refresh into an unhandled rejection. A listener can read
+  // state() reentrantly; finish that newer transition before notifying any
+  // remaining listeners so nobody receives a stale or duplicate read.
   const setView = (next: EntitlementView) => {
     if (next.state === view.state && next.reason === view.reason && next.cached === view.cached) return;
     view = next;
-    for (const cb of listeners) {
-      try {
-        cb(view);
-      } catch (err) {
-        log.warn(`entitlement listener threw: ${String(err)}`);
+    if (dispatching) {
+      pendingDispatch = true;
+      return;
+    }
+    dispatching = true;
+    try {
+      for (;;) {
+        pendingDispatch = false;
+        const delivering = view;
+        for (const cb of [...listeners]) {
+          if (view !== delivering) {
+            pendingDispatch = true;
+            break;
+          }
+          try {
+            cb(delivering);
+          } catch (err) {
+            let detail = "[unprintable thrown value]";
+            try { detail = String(err); } catch {}
+            log.warn(`entitlement listener threw: ${detail}`);
+          }
+          if (view !== delivering) {
+            pendingDispatch = true;
+            break;
+          }
+        }
+        if (!pendingDispatch) break;
       }
+    } finally {
+      dispatching = false;
     }
   };
-  // `unreachable` + a cached token: the QR stays only while that token is
-  // unexpired, so its expiry must flip the read — not wait for the next
-  // 12-hourly exchange.
-  // Node clamps a delay past 2^31-1 ms (~24.8 days) to 1 ms, so a long-lived
-  // token is watched in chained hops and the flip re-checks the clock.
+  // Every cached token has a wall-clock deadline, including one from a
+  // successful exchange. Node timers use a separate monotonic clock, so a
+  // long sleep or forward clock correction can cross that deadline without
+  // completing one long relative timeout. Recheck wall time in one-second
+  // hops, and also reconcile synchronously whenever state() is read.
+  // A previously valid read checks again, observing the same request floor
+  // as on-demand refresh; an outage read loses its cached-token allowance.
   const MAX_DELAY_MS = 2 ** 31 - 1;
+  const EXPIRY_WALL_CHECK_MS = 1_000;
   let expiry: ReturnType<typeof setTimeout> | undefined;
-  const watchExpiry = (expMs: number) => {
+  let stopped = false;
+  let lastFetchAt = -Infinity;
+  const armTimer = (delayMs: number, callback: () => void) => {
     clearTimeout(expiry);
-    expiry = setTimeout(() => {
-      if (view.state !== "unreachable" || !view.cached) return;
-      if (expMs > Date.now()) watchExpiry(expMs);
-      else setView({ state: "unreachable", cached: false });
-    }, Math.min(MAX_DELAY_MS, Math.max(0, expMs - Date.now())));
+    if (stopped) return;
+    expiry = setTimeout(callback, Math.min(MAX_DELAY_MS, Math.max(0, delayMs)));
     expiry.unref();
   };
+  const reconcileExpiry = () => {
+    if (stopped || !cached || cached.expMs > Date.now()) return;
+    const expiredView = view;
+    cached = undefined;
+    clearTimeout(expiry);
+    expiry = undefined;
+    if (expiredView.state === "valid") {
+      setView({ state: "checking" });
+      armTimer(lastFetchAt + FORCED_REFRESH_MIN_GAP_MS - performance.now(), () => void refresh());
+    } else if (expiredView.state === "unreachable" && expiredView.cached) {
+      setView({ state: "unreachable", cached: false });
+    }
+  };
+  const watchExpiry = (expMs: number) => {
+    armTimer(Math.min(EXPIRY_WALL_CHECK_MS, expMs - Date.now()), () => {
+      if (!cached || cached.expMs !== expMs) return;
+      if (expMs > Date.now()) watchExpiry(expMs);
+      else reconcileExpiry();
+    });
+  };
   let denied = false; // a 403 already warned — suppresses repeat WARNINGS only (the request throttle is FORCED_REFRESH_MIN_GAP_MS)
-  let lastFetchMs = 0;
   let inflight: Promise<void> | undefined;
 
   const exchange = async (): Promise<void> => {
-    lastFetchMs = Date.now();
+    lastFetchAt = performance.now();
     let next: EntitlementView;
     try {
       const res = await postLicenseKey(url, licenseKey, FETCH_TIMEOUT_MS);
@@ -189,7 +265,7 @@ export function createEntitlementTokenSource(env: {
         // only a string `reason` is quoted, and nothing here may throw.
         const body: unknown = await readBillingJson(res).catch(() => undefined);
         const raw = body && typeof body === "object" ? (body as { reason?: unknown }).reason : undefined;
-        const reason = typeof raw === "string" ? raw.slice(0, MAX_REASON_CHARS) : undefined;
+        const reason = typeof raw === "string" ? redactLicenseKey(raw, licenseKey).slice(0, MAX_REASON_CHARS) : undefined;
         if (!denied) {
           log.warn(
             `entitlement refused for license ${mask(licenseKey)}: ` +
@@ -207,8 +283,13 @@ export function createEntitlementTokenSource(env: {
           typeof body.token !== "string" ||
           body.token.length === 0 ||
           Buffer.byteLength(body.token, "utf8") > ENTITLEMENT_TOKEN_MAX_BYTES ||
+          !isEntitlementHeaderValue(body.token) ||
+          // Reject exact credential reuse at every length and embedded reuse
+          // once the key is specific enough (see the threshold above).
+          tokenReflectsLicenseKey(body.token, licenseKey) ||
           typeof body.exp !== "number" ||
-          !Number.isFinite(body.exp)
+          !Number.isFinite(body.exp * 1000) ||
+          body.exp * 1000 <= Date.now()
         ) {
           throw new Error("malformed response");
         }
@@ -222,8 +303,16 @@ export function createEntitlementTokenSource(env: {
       // refusal line at dial time is the terminal's signal; the pair card
       // gets the honest read (and whether the cached token still carries it).
       const carried = !!cached && cached.expMs > Date.now();
-      if (carried) watchExpiry(cached!.expMs);
+      if (!carried) cached = undefined;
       next = { state: "unreachable", cached: carried };
+    }
+    // Install the cache's watch before publishing the read. A listener may
+    // reconcile expiry reentrantly and replace it with a floor-delayed refresh;
+    // the completing exchange must not overwrite that newer scheduling choice.
+    if (cached) watchExpiry(cached.expMs);
+    else {
+      clearTimeout(expiry);
+      expiry = undefined;
     }
     setView(next);
   };
@@ -241,17 +330,23 @@ export function createEntitlementTokenSource(env: {
   return {
     mode: "license-key",
     get: async ({ refresh: forced = false } = {}) => {
-      const stale = !cached || cached.expMs <= Date.now();
-      const throttled = Date.now() - lastFetchMs < FORCED_REFRESH_MIN_GAP_MS;
+      reconcileExpiry();
+      const stale = !cached;
+      const throttled = performance.now() - lastFetchAt < FORCED_REFRESH_MIN_GAP_MS;
       if ((forced || stale) && !throttled) await refresh();
       else if (inflight) await inflight;
-      return cached && cached.expMs > Date.now() ? cached.token : undefined;
+      reconcileExpiry();
+      return cached?.token;
     },
     stop: () => {
+      stopped = true;
       clearInterval(timer);
       clearTimeout(expiry);
     },
-    state: () => view,
+    state: () => {
+      reconcileExpiry();
+      return view;
+    },
     onChange: (cb) => {
       listeners.add(cb);
       return () => listeners.delete(cb);

--- a/server/relay/relay-client.test.ts
+++ b/server/relay/relay-client.test.ts
@@ -144,3 +144,56 @@ test("dial-out with no token source sends no entitlement header", async () => {
     });
   }
 });
+
+test("DA.5: a successful pairing log never repeats the configured relay URL", async (t) => {
+  const lines: string[] = [];
+  t.mock.method(console, "log", (line: unknown) => lines.push(String(line)));
+  let opened!: () => void;
+  const connected = new Promise<void>((resolve) => (opened = resolve));
+  const server = createServer();
+  const wss = new WebSocketServer({ noServer: true });
+  server.on("upgrade", (req, socket, head) => {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      opened();
+      ws.on("error", () => {});
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  const marker = "private-relay-path-credential";
+  const url = `ws://127.0.0.1:${port}/${marker}`;
+  const client = startRelayClient({
+    url,
+    code: "a-strong-pairing-code-for-tests",
+    registry: {} as SessionRegistry,
+  });
+  try {
+    await connected;
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    assert.ok(lines.some((line) => line.includes("paired with relay")), lines.join("\n"));
+    assert.ok(lines.every((line) => !line.includes(marker)));
+  } finally {
+    client.stop();
+    wss.close();
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      server.closeAllConnections?.();
+    });
+  }
+});
+
+test("DA.5: a rejected WebSocket setup is owned instead of becoming an unhandled rejection", async (t) => {
+  const lines: string[] = [];
+  t.mock.method(console, "log", (line: unknown) => lines.push(String(line)));
+  const client = startRelayClient({
+    url: "ws://127.0.0.1:1/path#fragment-that-ws-rejects",
+    code: "a-strong-pairing-code-for-tests",
+    registry: {} as SessionRegistry,
+  });
+  try {
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    assert.ok(lines.some((line) => line.includes("relay setup failed")), lines.join("\n"));
+  } finally {
+    client.stop();
+  }
+});

--- a/server/relay/relay-client.ts
+++ b/server/relay/relay-client.ts
@@ -172,7 +172,11 @@ export function startRelayClient(opts: {
       // proxy: ~5 s) must not have already reset it.
       confirmTimer = setTimeout(() => {
         confirmed = true;
-        log.info(`paired with ${opts.url}`);
+        // The configured URL may contain userinfo or a secret-bearing path or
+        // query. The terminal already printed it in the explicitly
+        // non-paste-safe boot block; the persistent flight recorder gets only
+        // this fixed connection-state label.
+        log.info("paired with relay");
       }, PAIR_CONFIRM_MS);
     });
     ws.on("message", (data) => {
@@ -269,13 +273,23 @@ export function startRelayClient(opts: {
       // long the close took to arrive (a wall it can't beat, e.g. a lapsed
       // license, keeps widening toward RECONNECT_MAX_MS instead of churning).
       if (confirmed && !refusal) backoff = RECONNECT_MIN_MS;
-      const t = setTimeout(() => void dial(pair), backoff);
+      const t = setTimeout(() => ownDial(pair), backoff);
       t.unref();
       backoff = Math.min(backoff * 2, RECONNECT_MAX_MS);
     });
   };
 
-  void derivePair(opts.code).then((pair) => void dial(pair));
+  // `new WebSocket()` can reject a URL synchronously, while token and crypto
+  // setup are asynchronous. Own every dial promise so no malformed edge (or
+  // unexpected setup failure) can reach the process-wide unhandled-rejection
+  // exit path and take local sessions down with remote access.
+  const setupFailed = () => {
+    if (!stopped) log.info("relay setup failed — remote access is off for this launch; local sessions are unaffected");
+  };
+  const ownDial = (pair: PairSecret) => {
+    void dial(pair).catch(setupFailed);
+  };
+  void derivePair(opts.code).then(ownDial, setupFailed);
   return {
     stop: () => {
       stopped = true;

--- a/server/relay/relay-protocol.ts
+++ b/server/relay/relay-protocol.ts
@@ -5,6 +5,7 @@
 // `p`, and the wire protocol itself is untouched by this layer.
 
 import { randomBytes } from "node:crypto";
+import { validateHeaderValue } from "node:http";
 
 /** Relay → daemon, over the daemon's dial-out socket. */
 export type RelayToDaemon =
@@ -61,6 +62,18 @@ export const CLOSE_UNENTITLED = 4007; // dial-in without a valid entitlement tok
 // (the paid-tier gate). Shared contract with the relay's contract.ts —
 // the sibling itest's parity guard pins them equal.
 export const ENTITLEMENT_HEADER = "mirafold-entitlement";
+
+/** The entitlement token is carried only as an HTTP upgrade header. Keep the
+ * planning decision and the eventual dial on Node's exact transport rule so
+ * neither layer can promise a credential the other layer must omit. */
+export function isEntitlementHeaderValue(token: string): boolean {
+  try {
+    validateHeaderValue(ENTITLEMENT_HEADER, token);
+    return true;
+  } catch {
+    return false;
+  }
+}
 
 // A pair id shorter than this is refused outright — a guessable dev value
 // must never silently work against a relay. (Real ids are 22 chars.)

--- a/server/relay/relay-url.test.ts
+++ b/server/relay/relay-url.test.ts
@@ -50,24 +50,21 @@ test("DA.4C: every header-invalid override keeps a gated relay off without licen
   assert.equal(resolveRelayPlan({ MIRAFOLD_ENTITLEMENT_TOKEN: "custom.é" }).kind, "dial");
 });
 
-test("DA.4C: an invalid override is tolerated only by an explicitly ungated self-host", () => {
-  const ungated = resolveRelayPlan({
-    MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9100",
-    MIRAFOLD_ENTITLEMENT_TOKEN: "bad\ntoken",
-    MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win",
-  });
-  assert.equal(ungated.kind, "dial", "a tokenless self-host may be ungated");
-
-  assert.deepEqual(
-    resolveRelayPlan({
-      MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9100",
-      MIRAFOLD_ENTITLEMENT_URL: "http://127.0.0.1:9200/api/entitlement",
-      MIRAFOLD_ENTITLEMENT_TOKEN: "bad\ntoken",
-      MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win",
-    }),
-    { kind: "off", reason: "invalid-entitlement-token" },
-    "an operator-configured entitlement backend makes the self-host gated",
-  );
+test("DA.6 review: an invalid override blocks every explicit relay", () => {
+  for (const withEntitlementUrl of [false, true]) {
+    assert.deepEqual(
+      resolveRelayPlan({
+        MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9100",
+        MIRAFOLD_ENTITLEMENT_TOKEN: "bad\ntoken",
+        MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win",
+        ...(withEntitlementUrl
+          ? { MIRAFOLD_ENTITLEMENT_URL: "http://127.0.0.1:9200/api/entitlement" }
+          : {}),
+      }),
+      { kind: "off", reason: "invalid-entitlement-token" },
+      `entitlement URL configured=${withEntitlementUrl}`,
+    );
+  }
 });
 
 test("whitespace-only entitlement is NOT entitled", () => {

--- a/server/relay/relay-url.test.ts
+++ b/server/relay/relay-url.test.ts
@@ -4,6 +4,7 @@ import {
   carriesCredentialInClear,
   DEFAULT_APP_URL,
   DEFAULT_RELAY_URL,
+  relayLogLabel,
   resolveRelayPlan,
 } from "./relay-url";
 
@@ -31,11 +32,49 @@ test("a hand-issued token counts as entitled too", () => {
   assert.equal(plan.kind === "dial" && plan.url, DEFAULT_RELAY_URL);
 });
 
+test("DA.4C: every header-invalid override keeps a gated relay off without license fallback", () => {
+  for (const token of ["bad\ntoken", "bad\rtoken", "bad\u000btoken", "bad☃token"]) {
+    for (const withFallbackKey of [false, true]) {
+      assert.deepEqual(
+        resolveRelayPlan({
+          MIRAFOLD_ENTITLEMENT_TOKEN: token,
+          ...(withFallbackKey ? { MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win" } : {}),
+        }),
+        { kind: "off", reason: "invalid-entitlement-token" },
+        `${JSON.stringify(token)}, fallback=${withFallbackKey}`,
+      );
+    }
+  }
+
+  // Match Node's actual header boundary: Latin-1 remains valid.
+  assert.equal(resolveRelayPlan({ MIRAFOLD_ENTITLEMENT_TOKEN: "custom.é" }).kind, "dial");
+});
+
+test("DA.4C: an invalid override is tolerated only by an explicitly ungated self-host", () => {
+  const ungated = resolveRelayPlan({
+    MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9100",
+    MIRAFOLD_ENTITLEMENT_TOKEN: "bad\ntoken",
+    MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win",
+  });
+  assert.equal(ungated.kind, "dial", "a tokenless self-host may be ungated");
+
+  assert.deepEqual(
+    resolveRelayPlan({
+      MIRAFOLD_RELAY_URL: "ws://127.0.0.1:9100",
+      MIRAFOLD_ENTITLEMENT_URL: "http://127.0.0.1:9200/api/entitlement",
+      MIRAFOLD_ENTITLEMENT_TOKEN: "bad\ntoken",
+      MIRAFOLD_LICENSE_KEY: "mf_fallback_must_not_win",
+    }),
+    { kind: "off", reason: "invalid-entitlement-token" },
+    "an operator-configured entitlement backend makes the self-host gated",
+  );
+});
+
 test("whitespace-only entitlement is NOT entitled", () => {
   assert.equal(resolveRelayPlan({ MIRAFOLD_LICENSE_KEY: "   " }).kind, "off");
 });
 
-// The self-host / dev-stub path: an explicit URL keeps pre-bake behavior
+// The self-host / dev-stub path: a valid explicit URL keeps pre-bake behavior
 // verbatim — dialed entitled or not (an ungated relay accepts tokenless
 // dials), and NO app-origin default (the HTTP-twin fallback serves dev).
 test("explicit URL dials with no entitlement and no default app origin", () => {
@@ -59,6 +98,42 @@ test("explicit MIRAFOLD_APP_URL rides any dial, trailing slash trimmed", () => {
     MIRAFOLD_APP_URL: "https://app.example",
   });
   assert.equal(defaulted.kind === "dial" && defaulted.appUrl, "https://app.example");
+});
+
+test("DA.5: persistent relay labels never repeat a configured URL", () => {
+  const secretBearing = resolveRelayPlan({
+    MIRAFOLD_RELAY_URL:
+      "wss://alice:password@relay.example/private-route-credential?sig=query-secret",
+  });
+  assert.equal(secretBearing.kind, "dial");
+  if (secretBearing.kind !== "dial") return;
+  const label = relayLogLabel(secretBearing);
+  assert.equal(label, "configured relay");
+  for (const secret of ["alice", "password", "private-route-credential", "query-secret"]) {
+    assert.ok(!label.includes(secret), secret);
+  }
+
+  const hosted = resolveRelayPlan({ MIRAFOLD_LICENSE_KEY: "mf_test" });
+  assert.equal(hosted.kind === "dial" && relayLogLabel(hosted), "hosted relay");
+});
+
+test("DA.5: every relay URL fragment delimiter is refused during planning", () => {
+  for (const raw of [
+    "wss://relay.example/private#fragment-secret",
+    "ws://127.0.0.1:1#",
+    "ws://127.0.0.1:1/#",
+    "ws://127.0.0.1:1/path?#",
+  ]) {
+    assert.deepEqual(resolveRelayPlan({ MIRAFOLD_RELAY_URL: raw }), {
+      kind: "off",
+      reason: "malformed-url",
+      raw,
+    });
+  }
+
+  const encoded = "ws://127.0.0.1:1/path%23segment";
+  const plan = resolveRelayPlan({ MIRAFOLD_RELAY_URL: encoded });
+  assert.equal(plan.kind === "dial" && plan.url, encoded, "an encoded path octet is not a fragment");
 });
 
 test("the documented opt-outs turn remote access off quietly", () => {
@@ -130,9 +205,10 @@ test("presentsOnEntitlement: the hosted default, or an operator's own backend �
 
 test("review 2026-08-29: the hosted relay spelled out by hand keeps the hosted semantics", async () => {
   const { presentsOnEntitlement } = await import("./relay-url");
-  // A user who copies the default into .env must get exactly what leaving it
-  // unset gets: the hosted app origin (the relay host serves no app) and the
-  // license gate — never an "explicit" self-host plan with a twin-fallback QR.
+  // A user who sets the default explicitly in the parent shell environment
+  // must get exactly what leaving it unset gets: the hosted app origin (the
+  // relay host serves no app) and the license gate — never an "explicit"
+  // self-host plan with a twin-fallback QR.
   const byHand = resolveRelayPlan({ MIRAFOLD_RELAY_URL: DEFAULT_RELAY_URL, MIRAFOLD_LICENSE_KEY: "mf_x" });
   assert.deepEqual(byHand, resolveRelayPlan({ MIRAFOLD_LICENSE_KEY: "mf_x" }));
   assert.equal(byHand.kind === "dial" && byHand.appUrl, DEFAULT_APP_URL);

--- a/server/relay/relay-url.ts
+++ b/server/relay/relay-url.ts
@@ -33,8 +33,8 @@ export type RelayPlan =
   | { kind: "dial"; url: string; origin: string; source: "explicit" | "default"; appUrl?: string }
   /** Remote access off. `opt-out` = user said so (quiet); `unentitled-default`
    *  = nothing configured, so the bake stood down (one actionable boot line);
-   *  `invalid-entitlement-token` = an override cannot ride the required HTTP
-   *  header, so a gated dial was refused before it could enter retry churn;
+   *  `invalid-entitlement-token` = an override cannot ride the HTTP header,
+   *  so its dial was refused before an unknown gate could enter retry churn;
    *  `malformed-url` = the explicit URL is not usable as Mirafold's relay
    *  base (wrong scheme, invalid syntax, or a fragment delimiter) and was REFUSED —
    *  refusing beats honoring, and local sessions never depend on the relay. */
@@ -114,7 +114,12 @@ export function resolveRelayPlan(env: {
     const origin = relayOriginOf(raw);
     if (!origin) return { kind: "off", reason: "malformed-url", raw };
     if (origin !== hostedOrigin) {
-      if (invalidOverride && env.MIRAFOLD_ENTITLEMENT_URL?.trim()) {
+      // An explicit relay can be gated by a hand-issued token without running
+      // an entitlement-exchange endpoint. No local setting proves that an
+      // arbitrary relay is ungated, so never dial it after omitting a supplied
+      // but header-invalid override. Removing the override still preserves the
+      // ordinary tokenless self-host/dev-stub path below.
+      if (invalidOverride) {
         return { kind: "off", reason: "invalid-entitlement-token" };
       }
       return { kind: "dial", url: raw, origin, source: "explicit", appUrl };

--- a/server/relay/relay-url.ts
+++ b/server/relay/relay-url.ts
@@ -7,7 +7,7 @@
 // the relay. So the baked default engages exactly when a dial could succeed;
 // otherwise remote access stays off with a single actionable boot line.
 //
-// An EXPLICIT url is dialed verbatim, entitled or not — that is
+// A valid EXPLICIT URL is dialed verbatim, entitled or not — that is
 // the self-host path (an ungated relay accepts tokenless dials) and the dev
 // stub path. The app-origin default travels WITH the relay default: a phone
 // pairing through the hosted relay loads the viewport from the hosted static
@@ -19,6 +19,7 @@
 // twin-fallback QR there is a dead link) and the entitlement gate (review
 // 2026-08-29).
 import { envOff } from "../env";
+import { isEntitlementHeaderValue } from "./relay-protocol";
 
 export const DEFAULT_RELAY_URL = "wss://relay.mirafold.sh";
 export const DEFAULT_APP_URL = "https://app.mirafold.com";
@@ -32,15 +33,34 @@ export type RelayPlan =
   | { kind: "dial"; url: string; origin: string; source: "explicit" | "default"; appUrl?: string }
   /** Remote access off. `opt-out` = user said so (quiet); `unentitled-default`
    *  = nothing configured, so the bake stood down (one actionable boot line);
-   *  `malformed-url` = the explicit URL is not ws:/wss: and was REFUSED —
+   *  `invalid-entitlement-token` = an override cannot ride the required HTTP
+   *  header, so a gated dial was refused before it could enter retry churn;
+   *  `malformed-url` = the explicit URL is not usable as Mirafold's relay
+   *  base (wrong scheme, invalid syntax, or a fragment delimiter) and was REFUSED —
    *  refusing beats honoring, and local sessions never depend on the relay. */
-  | { kind: "off"; reason: "opt-out" | "unentitled-default" }
+  | { kind: "off"; reason: "opt-out" | "unentitled-default" | "invalid-entitlement-token" }
   | { kind: "off"; reason: "malformed-url"; raw: string };
 
-/** A relay URL's bare origin, or undefined when it is not a ws:/wss: URL. */
+/** A persistent-log label for a relay plan. The configured URL itself can
+ * carry userinfo, a private path, or a query (and malformed input may attempt
+ * a fragment), so it belongs only in the explicitly secret-bearing stdout
+ * boot line — never the paste-safe log. */
+export function relayLogLabel(plan: Extract<RelayPlan, { kind: "dial" }>): string {
+  return plan.source === "default" ? "hosted relay" : "configured relay";
+}
+
+/** A relay URL's bare origin, or undefined when it is not a usable Mirafold ws:/wss: relay base. */
 export function relayOriginOf(url: string): string | undefined {
+  // URL.hash cannot distinguish no fragment from an empty `#` delimiter. A
+  // nonempty fragment is rejected by `ws` directly; an empty one becomes
+  // nonempty when the client appends /daemon?... to this raw base. A literal
+  // `#` is therefore unusable here; an intended path/query octet is `%23`.
+  if (url.includes("#")) return undefined;
   try {
     const u = new URL(url);
+    // Refuse every such base while planning so an operator gets the specific
+    // one-time configuration warning before any dial; the client's rejection
+    // owner remains a last-resort containment for direct callers.
     return u.protocol === "ws:" || u.protocol === "wss:" ? u.origin : undefined;
   } catch {
     return undefined;
@@ -82,17 +102,26 @@ export function resolveRelayPlan(env: {
   MIRAFOLD_APP_URL?: string;
   MIRAFOLD_ENTITLEMENT_TOKEN?: string;
   MIRAFOLD_LICENSE_KEY?: string;
+  MIRAFOLD_ENTITLEMENT_URL?: string;
 }): RelayPlan {
   const raw = env.MIRAFOLD_RELAY_URL?.trim();
   const appUrl = env.MIRAFOLD_APP_URL?.trim().replace(/\/+$/, "") || undefined;
+  const suppliedOverride = env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim();
+  const invalidOverride = !!suppliedOverride && !isEntitlementHeaderValue(suppliedOverride);
   if (raw && envOff(raw)) return { kind: "off", reason: "opt-out" };
   const hostedOrigin = relayOriginOf(DEFAULT_RELAY_URL) as string;
   if (raw) {
     const origin = relayOriginOf(raw);
     if (!origin) return { kind: "off", reason: "malformed-url", raw };
-    if (origin !== hostedOrigin) return { kind: "dial", url: raw, origin, source: "explicit", appUrl };
+    if (origin !== hostedOrigin) {
+      if (invalidOverride && env.MIRAFOLD_ENTITLEMENT_URL?.trim()) {
+        return { kind: "off", reason: "invalid-entitlement-token" };
+      }
+      return { kind: "dial", url: raw, origin, source: "explicit", appUrl };
+    }
   }
-  const entitled = !!(env.MIRAFOLD_ENTITLEMENT_TOKEN?.trim() || env.MIRAFOLD_LICENSE_KEY?.trim());
+  if (invalidOverride) return { kind: "off", reason: "invalid-entitlement-token" };
+  const entitled = !!(suppliedOverride || env.MIRAFOLD_LICENSE_KEY?.trim());
   if (!entitled) return { kind: "off", reason: "unentitled-default" };
   return {
     kind: "dial",
@@ -109,8 +138,8 @@ export function resolveRelayPlan(env: {
 /**
  * Whether the pair card should present on the entitlement EXCHANGE (the
  * `entitlement` read). The exchange is what the HOSTED relay gates on, so a
- * refused key there truly means "no QR". An explicit self-hosted relay is
- * dialed verbatim and may be ungated — then the exchange says nothing about
+ * refused key there truly means "no QR". A valid explicit self-hosted relay
+ * is dialed verbatim and may be ungated — then the exchange says nothing about
  * whether the relay carries, and presenting on it would hide a working QR
  * (review 2026-08-26). An explicit entitlement URL means the operator runs
  * their own gate against their own backend: present again.

--- a/server/relay/subscription.test.ts
+++ b/server/relay/subscription.test.ts
@@ -109,10 +109,34 @@ test("CS: oversized billing JSON and date fields never reach the subscription vi
     assert.deepEqual(await actions.status(), { error: SUPPORT_FALLBACK });
     oversizedBody = false;
     assert.deepEqual(await actions.status(), {
-      view: { status: "active", cancelAt: "soon" },
+      view: { status: "active" },
     });
   } finally {
     m.mock.restore();
+  }
+});
+
+test("DA.5: only known subscription states and strict ISO instants reach the shell", async (t) => {
+  let body: Record<string, unknown> = { status: "active" };
+  const fetch = t.mock.method(globalThis, "fetch", async () => Response.json(body));
+  const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY })!;
+  try {
+    for (const status of ["\u202eactive — renewed", "active\nsubscription ended", "future_status", "x".repeat(100)]) {
+      body = { status, periodEnd: "not-a-date", cancelAt: "soon" };
+      assert.deepEqual(await actions.status(), { view: { status: "unknown" } });
+    }
+    for (const status of ["trialing", "active", "past_due", "paused", "canceled"]) {
+      body = { status, periodEnd: "2026-09-01T00:00:00Z", cancelAt: null };
+      assert.deepEqual(await actions.status(), {
+        view: { status, periodEnd: "2026-09-01T00:00:00Z" },
+      });
+    }
+    for (const malformed of ["soon", "0", "1", "999", "09/01/2026", "2026-09-01", "2026-02-30T00:00:00Z"]) {
+      body = { status: "active", periodEnd: malformed, cancelAt: malformed };
+      assert.deepEqual(await actions.status(), { view: { status: "active" } }, malformed);
+    }
+  } finally {
+    fetch.mock.restore();
   }
 });
 
@@ -122,4 +146,39 @@ test("CS: the throttle admits one in-flight action and floors restarts", () => {
   assert.equal(t.tryStart(), false, "second start while in flight is refused");
   t.done();
   assert.equal(t.tryStart(), false, "the min gap holds even after completion");
+});
+
+test("DA.3: every billing string removes the exact license key before any truncation", async (t) => {
+  const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: KEY })!;
+  for (const [status, body] of [
+    [403, { reason: `prefix${KEY}${KEY}: refused` }],
+    [400, { error: `bad ${KEY}` }],
+    [403, { reason: `${"x".repeat(195)}${KEY}` }],
+    [200, { status: `${"x".repeat(35)}${KEY}`, periodEnd: KEY, cancelAt: `date ${KEY}` }],
+  ] as const) {
+    const fetch = t.mock.method(globalThis, "fetch", async () => Response.json(body, { status }));
+    try {
+      for (const act of [actions.status, actions.cancel, actions.uncancel]) {
+        const result = JSON.stringify(await act());
+        assert.ok(!result.includes(KEY));
+        assert.ok(!result.includes("mf_"), "clipping retained the beginning of the credential");
+        if (status !== 200) {
+          assert.ok(result.includes("[lice"), "a displayed refusal must retain the replacement marker");
+        }
+      }
+    } finally { fetch.mock.restore(); }
+  }
+});
+
+test("DA.5 cold review: status redaction precedes the known-state allowlist", async (t) => {
+  const licenseKey = "active";
+  const fetch = t.mock.method(globalThis, "fetch", async () => Response.json({ status: licenseKey }));
+  try {
+    const actions = createSubscriptionActions({ MIRAFOLD_LICENSE_KEY: licenseKey })!;
+    const result = await actions.status();
+    assert.deepEqual(result, { view: { status: "unknown" } });
+    assert.ok(!JSON.stringify(result).includes(licenseKey), "the configured key reached the viewport result");
+  } finally {
+    fetch.mock.restore();
+  }
 });

--- a/server/relay/subscription.ts
+++ b/server/relay/subscription.ts
@@ -21,6 +21,7 @@ import {
   MAX_REASON_CHARS,
   postLicenseKey,
   readBillingJson,
+  redactLicenseKey,
   resolveEntitlementUrl,
 } from "./entitlement";
 
@@ -32,7 +33,14 @@ const FETCH_TIMEOUT_MS = 10_000;
 const MIN_GAP_MS = 2_000;
 
 /** What the manage-subscription card renders — nothing more rides back. */
-export type SubscriptionView = { status: string; periodEnd?: string; cancelAt?: string };
+export const KNOWN_SUBSCRIPTION_STATUSES = ["trialing", "active", "past_due", "paused", "canceled"] as const;
+type KnownSubscriptionStatus = (typeof KNOWN_SUBSCRIPTION_STATUSES)[number];
+const knownSubscriptionStatuses = new Set<string>(KNOWN_SUBSCRIPTION_STATUSES);
+export type SubscriptionView = {
+  status: KnownSubscriptionStatus | "unknown";
+  periodEnd?: string;
+  cancelAt?: string;
+};
 export type SubscriptionResult = { view: SubscriptionView } | { error: string };
 
 export type SubscriptionActions = {
@@ -53,8 +61,20 @@ export function subscriptionBase(entitlementUrl: string): string | undefined {
   return base === entitlementUrl ? undefined : base;
 }
 
-const optionalIso = (v: unknown): string | undefined =>
-  typeof v === "string" && v.length <= 64 ? v : undefined;
+const ISO_INSTANT =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/;
+
+const optionalIso = (v: unknown, licenseKey: string): string | undefined => {
+  if (typeof v !== "string" || v.length > 64) return undefined;
+  const safe = redactLicenseKey(v, licenseKey);
+  const match = ISO_INSTANT.exec(safe);
+  if (!match) return undefined;
+  const [year, month, day, hour, minute, second] = match.slice(1, 7).map(Number);
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1] ?? 0;
+  if (day < 1 || day > daysInMonth || hour > 23 || minute > 59 || second > 59) return undefined;
+  return Number.isFinite(Date.parse(safe)) ? safe : undefined;
+};
 
 export function createSubscriptionActions(env: {
   MIRAFOLD_ENTITLEMENT_TOKEN?: string;
@@ -79,21 +99,30 @@ export function createSubscriptionActions(env: {
       const res = await postLicenseKey(endpoint, licenseKey, FETCH_TIMEOUT_MS);
       if (res.status === 403 || res.status === 400) {
         // Our backend's own composed refusal (unknown/superseded key). Shown
-        // as-is but bounded: a self-hoster can point the exchange anywhere,
+        // with the known key removed and length bounded: a self-hoster can point the exchange anywhere,
         // and this string lands in a shell-owned surface.
         const reason = ((await readBillingJson(res).catch(() => ({}))) as {
           reason?: string;
           error?: string;
         });
         const text = typeof reason.reason === "string" ? reason.reason : reason.error;
-        return { error: (text || SUPPORT_FALLBACK).slice(0, MAX_REASON_CHARS) };
+        return { error: redactLicenseKey(text || SUPPORT_FALLBACK, licenseKey).slice(0, MAX_REASON_CHARS) };
       }
       if (!res.ok) throw new Error(`http ${res.status}`);
       const body = (await readBillingJson(res)) as Record<string, unknown>;
       if (typeof body.status !== "string") throw new Error("malformed response");
-      const view: SubscriptionView = { status: body.status.slice(0, 40) };
-      const periodEnd = optionalIso(body.periodEnd);
-      const cancelAt = optionalIso(body.cancelAt);
+      // These values become shell-owned copy. Forward only Paddle's five
+      // subscription states; a future or hostile string gets a fixed unknown
+      // state rather than arbitrary text in the trusted UI. Redact first: the
+      // terminal deliberately accepts arbitrary keys, including a low-entropy
+      // value that could otherwise collide with one of the known states.
+      const safeStatus = redactLicenseKey(body.status, licenseKey);
+      const status: SubscriptionView["status"] = knownSubscriptionStatuses.has(safeStatus)
+        ? (safeStatus as KnownSubscriptionStatus)
+        : "unknown";
+      const view: SubscriptionView = { status };
+      const periodEnd = optionalIso(body.periodEnd, licenseKey);
+      const cancelAt = optionalIso(body.cancelAt, licenseKey);
       if (periodEnd) view.periodEnd = periodEnd;
       if (cancelAt) view.cancelAt = cancelAt;
       return { view };

--- a/server/release-workflow.test.ts
+++ b/server/release-workflow.test.ts
@@ -1,6 +1,11 @@
+import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
+import path from "node:path";
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import ts from "typescript";
+
+const root = path.resolve(import.meta.dirname, "..");
 
 const workflow = readFileSync(
   new URL("../.github/workflows/release.yml", import.meta.url),
@@ -22,4 +27,46 @@ test("npm publishing is tag-only and bound to the protected environment", () => 
   assert.doesNotMatch(verify, /^\s+- run: npm publish/m);
   assert.match(publish, /^      id-token: write$/m);
   assert.doesNotMatch(publish, /--dry-run/);
+});
+
+test("the single-repository release typecheck excludes every sibling-dependent test", () => {
+  const configPath = path.join(root, "tsconfig.ci.json");
+  const loaded = ts.readConfigFile(configPath, ts.sys.readFile);
+  assert.equal(loaded.error, undefined, "tsconfig.ci.json parses");
+  const excluded = new Set<string>(loaded.config.exclude ?? []);
+
+  // Tracked TypeScript paths only; every dotenv filename form is excluded
+  // explicitly even though none can match the positive extensions.
+  const files = execFileSync(
+    "git",
+    [
+      "ls-files",
+      "-z",
+      "--",
+      ":(glob)**/*.ts",
+      ":(glob)**/*.tsx",
+      ":(exclude,glob)**/.env",
+      ":(exclude,glob)**/.env.*",
+      ":(exclude,glob)**/*.env",
+      ":(exclude,glob)**/*.env.*",
+    ],
+    { cwd: root, encoding: "utf8" },
+  ).split("\0").filter(Boolean);
+
+  const outsideImporters = new Set<string>();
+  for (const relativeFile of files) {
+    const absoluteFile = path.join(root, relativeFile);
+    const source = readFileSync(absoluteFile, "utf8");
+    for (const match of source.matchAll(/\b(?:from\s*|import\s*\()\s*["'](\.\.[^"']+)["']/g)) {
+      const resolved = path.resolve(path.dirname(absoluteFile), match[1]);
+      if (path.relative(root, resolved).startsWith(`..${path.sep}`)) {
+        outsideImporters.add(relativeFile);
+      }
+    }
+  }
+
+  assert.ok(outsideImporters.size > 0, "the sibling-import guard exercises a real importer");
+  for (const relativeFile of outsideImporters) {
+    assert.ok(excluded.has(relativeFile), `${relativeFile} must be excluded from tsconfig.ci.json`);
+  }
 });

--- a/server/security/repository-hygiene.test.ts
+++ b/server/security/repository-hygiene.test.ts
@@ -1,0 +1,61 @@
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import os from "node:os";
+import path from "node:path";
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+const ROOT = path.resolve(import.meta.dirname, "../..");
+const require = createRequire(import.meta.url);
+
+const qsAtSecurityFloor = (version: string): boolean => {
+  const [major = 0, minor = 0, patch = 0] = version.split(".").map(Number);
+  return major > 6 || (major === 6 && (minor > 16 || (minor === 16 && patch >= 0)));
+};
+
+test("DA.5: Git ignores dotenv secret-name variants while retaining the public root template", () => {
+  const dir = mkdtempSync(path.join(os.tmpdir(), "mirafold-ignore-"));
+  try {
+    execFileSync("git", ["init", "--quiet"], { cwd: dir });
+    writeFileSync(path.join(dir, ".gitignore"), readFileSync(path.join(ROOT, ".gitignore"), "utf8"));
+    const ignored = (candidate: string) =>
+      spawnSync(
+        "git",
+        ["-c", "core.excludesFile=/dev/null", "check-ignore", "--no-index", "--quiet", candidate],
+        { cwd: dir },
+      ).status === 0;
+
+    // Path-only probes: no dotenv file is created or read by this test.
+    for (const candidate of [
+      ".env",
+      ".env.local",
+      ".env.production",
+      "service.env",
+      "service.env.local",
+      "nested/.env",
+      "nested/.env.local",
+      "nested/.env.example",
+      "nested/service.env.production",
+    ]) {
+      assert.equal(ignored(candidate), true, candidate);
+    }
+    assert.equal(ignored(".env.example"), false);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("DA.5: the production lock keeps qs on the advisory-patched line", () => {
+  const lock = readFileSync(path.join(ROOT, "yarn.lock"), "utf8");
+  const locked = [...lock.matchAll(/^(?:qs@|"qs@)[^\n]*:\n  version "([^"]+)"/gm)].map(
+    (match) => match[1],
+  );
+  assert.ok(locked.length > 0, "a production qs lock entry exists");
+  for (const version of locked) {
+    assert.ok(qsAtSecurityFloor(version), `locked qs ${version} is below the 6.16.0 security floor`);
+  }
+
+  const installed = (require("qs/package.json") as { version: string }).version;
+  assert.ok(qsAtSecurityFloor(installed), `installed qs ${installed} is below the 6.16.0 security floor`);
+});

--- a/server/sessions/connection.test.ts
+++ b/server/sessions/connection.test.ts
@@ -1,6 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { describeBackendForLog, escapeTranscriptFence } from "./connection";
+import { describeBackendForLog, escapeTranscriptFence, openConnection, type ConnectionOptions } from "./connection";
+import { SessionRegistry } from "./registry";
+import type { WireMsg } from "../protocol";
 import { escapeTranscriptAttr } from "./bang-handlers";
 
 // 2026-07-17 audit, finding 4: a `!` command's output rides to the agent
@@ -48,4 +50,83 @@ test("UX.8: backend logs never contain configured URL authentication or query da
   });
   assert.equal(summary, "local via configured endpoint (model forged-log-line)");
   assert.doesNotMatch(summary, /alice|password|example\.test|topsecret|\n/);
+});
+
+
+test("DA.2: only a Desktop startup option marks local hellos, including refreshes and forged client input", async (t) => {
+  // This test triggers a real refresh, but no network discovery. Restore the
+  // process settings after the connection closes.
+  const names = ["MIRAFOLD_LOCAL_DISCOVERY", "MIRAFOLD_LOCAL_ENDPOINTS"] as const;
+  const saved = names.map((name) => process.env[name]);
+  process.env.MIRAFOLD_LOCAL_DISCOVERY = "off";
+  process.env.MIRAFOLD_LOCAL_ENDPOINTS = "";
+  t.after(() => names.forEach((name, i) => {
+    if (saved[i] === undefined) delete process.env[name];
+    else process.env[name] = saved[i];
+  }));
+
+  for (const options of [
+    {},
+    { host: "desktop" },
+    { host: "desktop", remote: true },
+  ] satisfies ConnectionOptions[]) {
+    await t.test(JSON.stringify(options), async (t) => {
+      const reg = new SessionRegistry({ backend: { agent: "claude-code", kind: "none", live: false } });
+      const seen: WireMsg[] = [];
+      const actions = { status: async () => ({ view: { status: "active" as const } }) };
+      const conn = openConnection(reg, (m) => seen.push(m), {
+        ...options,
+        relayOff: "unentitled",
+        subscription: { ...actions, cancel: actions.status, uncancel: actions.status },
+        entitlement: { state: () => ({ state: "invalid" }), onChange: () => () => {} },
+      });
+      t.after(() => conn.close());
+      const hellos = () => seen.filter((m) => m.type === "agents");
+      assert.equal(hellos().length, 1);
+      // Neither a client-forged server frame nor extra refresh properties
+      // can override the startup option in either direction.
+      conn.handleMessage(JSON.stringify({ type: "agents", host: "desktop", agents: [] }));
+      conn.handleMessage(JSON.stringify({ type: "refresh_agents", host: "terminal" }));
+      conn.handleMessage(JSON.stringify({ type: "refresh_agents", host: "desktop" }));
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.ok(hellos().length >= 2, "the refresh must actually produce another hello");
+      for (const hello of hellos()) {
+        const desktop = "host" in options && options.host === "desktop" && !("remote" in options && options.remote);
+        assert.equal(Object.hasOwn(hello, "host"), desktop);
+        assert.equal(hello.host, desktop ? "desktop" : undefined);
+        if ("remote" in options && options.remote) {
+          for (const field of ["host", "relayOff", "relayConfigProblem", "billing", "entitlement"]) {
+            assert.equal(Object.hasOwn(hello, field), false, `remote hello carried ${field}`);
+          }
+        }
+      }
+    });
+  }
+});
+
+test("DA.4C: the invalid-token state uses a new local field that the previous client ignores", () => {
+  const reg = new SessionRegistry({ backend: { agent: "claude-code", kind: "none", live: false } });
+  const local: WireMsg[] = [];
+  const localConnection = openConnection(reg, (message) => local.push(message), {
+    relayOff: "invalid-entitlement-token",
+  });
+  localConnection.close();
+  const localHello = local.find((message) => message.type === "agents");
+  assert.ok(localHello?.type === "agents");
+  assert.equal(localHello.relayOff, undefined, "the previous client must not receive an unknown old-field value");
+  assert.equal(localHello.relayConfigProblem, "invalid-entitlement-token");
+  // The previous client knows only `relayOff`; absence means it keeps no Pair
+  // card instead of rendering a future machine value as text.
+  assert.equal((localHello as { relayOff?: string }).relayOff ?? "", "");
+
+  const remote: WireMsg[] = [];
+  const remoteConnection = openConnection(reg, (message) => remote.push(message), {
+    relayOff: "invalid-entitlement-token",
+    remote: true,
+  });
+  remoteConnection.close();
+  const remoteHello = remote.find((message) => message.type === "agents");
+  assert.ok(remoteHello?.type === "agents");
+  assert.equal(Object.hasOwn(remoteHello, "relayOff"), false);
+  assert.equal(Object.hasOwn(remoteHello, "relayConfigProblem"), false);
 });

--- a/server/sessions/connection.ts
+++ b/server/sessions/connection.ts
@@ -84,13 +84,16 @@ export type Connection = {
  */
 export type ConnectionOptions = {
   label?: string;
+  /** Supplied by daemon startup only, never by a client or agent message. */
+  host?: Extract<WireMsg, { type: "agents" }>["host"];
   /** Pairing info for the "connect a device" QR. The local WS path passes
    *  it; the relay path never does — the code must not cross the relay.
    *  Same shape the hello carries (protocol.ts `agents.relay`). */
   relay?: { url: string; code: string; ws?: string };
-  /** Why remote access is off, when it is (protocol.ts `agents.relayOff`).
-   *  The local WS path passes it so the pair button can say so; a remote
-   *  viewport is proof the relay is on and never receives it. */
+  /** Why remote access is off, when it is (protocol.ts `agents.relayOff` /
+   *  `relayConfigProblem`). The local WS path passes it so the pair button
+   *  can say so; a remote viewport is proof the relay is on and never
+   *  receives it. */
   relayOff?: RelayOffReason;
   /** True for a viewport arriving over the paid relay. The relay gate
    *  refuses to attach such a viewport to a subscription-backed session;
@@ -113,7 +116,7 @@ export function openConnection(
   viewport: (msg: WireMsg) => void,
   options: ConnectionOptions = {},
 ): Connection {
-  const { label = "ws", relay, relayOff, remote = false, subscription, entitlement } = options;
+  const { label = "ws", host, relay, relayOff, remote = false, subscription, entitlement } = options;
   const log = createLogger(label);
   // A connection is a viewport onto one registry session — or a fleet
   // watcher observing the registry itself.
@@ -301,6 +304,7 @@ export function openConnection(
     const read = remote ? undefined : entitlement?.state();
     viewport({
       type: "agents",
+      ...(host === "desktop" && !remote ? { host } : {}),
       agents: availableAgents(),
       default: defaultAgent(),
       cwd: process.cwd(),
@@ -308,7 +312,11 @@ export function openConnection(
       folderPicker: !remote && folderPickerAvailable(),
       version: VERSION,
       ...(relay ? { relay } : {}),
-      ...(relayOff && !remote ? { relayOff } : {}),
+      ...(relayOff && !remote
+        ? relayOff === "invalid-entitlement-token"
+          ? { relayConfigProblem: relayOff }
+          : { relayOff }
+        : {}),
       ...(subscription && !remote ? { billing: "license-key" as const } : {}),
       ...(read ? { entitlement: read } : {}),
     });

--- a/server/testing/desktop-harness.ts
+++ b/server/testing/desktop-harness.ts
@@ -1,0 +1,156 @@
+import assert from "node:assert/strict";
+import type { TestContext } from "node:test";
+import { spawn } from "node:child_process";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync } from "node:fs";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { setTimeout as delay } from "node:timers/promises";
+import os from "node:os";
+import path from "node:path";
+import type { WireMsg } from "../protocol";
+import { DESKTOP_CREDENTIAL_FLAG } from "../desktop-credential";
+import { SCRUBBED_CREDENTIAL_ENV, TestClient } from "./itest-harness";
+import { waitFor } from "./wait-for";
+
+export const DESKTOP_TEST_KEY = `mf_${"e".repeat(26)}`;
+export const DESKTOP_TEST_AMBIENT = `mf_${"f".repeat(26)}`;
+export const DAEMON_ENTRY = process.env.MIRAFOLD_TEST_DAEMON_ENTRY ?? path.resolve(import.meta.dirname, "../../dist-server/index.js");
+
+export async function desktopDaemon(t: TestContext, options: {
+  root?: string;
+  chunks?: (string | Buffer)[];
+  eof?: boolean;
+  desktop?: boolean;
+  ignoreStdin?: boolean;
+  env?: Record<string, string>;
+  imports?: string[];
+} = {}) {
+  const root = options.root ?? mkdtempSync(path.join(os.tmpdir(), "mirafold-desktop-boundary-"));
+  const cwd = path.join(root, "workspace");
+  mkdirSync(cwd, { recursive: true });
+  const env = {
+    PATH: process.env.PATH,
+    ...SCRUBBED_CREDENTIAL_ENV,
+    SHELL: "/bin/sh",
+    CODEX_HOME: path.join(root, "codex"),
+    CLAUDE_CONFIG_DIR: path.join(root, "claude"),
+    PORT: String(39_000 + Math.floor(Math.random() * 1_000)),
+    MIRAFOLD_DEBUG: "1",
+    MIRAFOLD_LOG_FILE: path.join(root, "logs", "daemon.log"),
+    MIRAFOLD_SESSION_DIR: path.join(root, "sessions"),
+    MIRAFOLD_WORKSPACE_TRUST_FILE: path.join(root, "trust.json"),
+    MIRAFOLD_AGENT: "claude-code",
+    MIRAFOLD_LICENSE_KEY: "",
+    MIRAFOLD_ENTITLEMENT_TOKEN: "",
+    MIRAFOLD_ENTITLEMENT_URL: "",
+    MIRAFOLD_APP_URL: "",
+    MIRAFOLD_LOCAL_DISCOVERY: "off",
+    MIRAFOLD_LOCAL_ENDPOINTS: "",
+    SUBSCRIPTION_MIN_GAP_MS: "0",
+    ...options.env,
+  };
+  const child = spawn(process.execPath, [
+    ...(options.imports ?? []).flatMap((file) => ["--import", file]),
+    DAEMON_ENTRY,
+    ...(options.desktop === false ? [] : [DESKTOP_CREDENTIAL_FLAG]),
+  ], { cwd, env, stdio: [options.ignoreStdin ? "ignore" : "pipe", "pipe", "pipe"] });
+  let stdout = "";
+  let stderr = "";
+  child.stdout!.on("data", (chunk) => { stdout += String(chunk); });
+  child.stderr!.on("data", (chunk) => { stderr += String(chunk); });
+  child.stdin?.on("error", () => {});
+  const closed = new Promise<void>((resolve) => child.once("close", () => resolve()));
+  let stopped: Promise<void> | undefined;
+  const stop = () => stopped ??= (async () => {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill();
+      const hard = setTimeout(() => child.kill("SIGKILL"), 3_000);
+      await closed;
+      clearTimeout(hard);
+    } else await closed;
+  })();
+  t.after(async () => {
+    await stop();
+    if (!options.root) rmSync(root, { recursive: true, force: true });
+  });
+  for (const chunk of options.chunks ?? [DESKTOP_TEST_KEY]) {
+    child.stdin?.write(chunk);
+    await delay(5);
+  }
+  if (options.eof !== false) child.stdin?.end();
+  const logs = () => stdout + stderr;
+  await waitFor(() => /server on http:\/\/127\.0\.0\.1:(\d+)\//.test(logs()), "Desktop daemon listening", 15_000,
+    () => `exit ${child.exitCode}; signal ${child.signalCode}`);
+  const port = Number(logs().match(/server on http:\/\/127\.0\.0\.1:(\d+)\//)![1]);
+  const client = new TestClient(port, env.MIRAFOLD_TOKEN ? { token: env.MIRAFOLD_TOKEN } : {});
+  t.after(() => client.close());
+  await client.opened();
+  const hello = await client.type("agents") as Extract<WireMsg, { type: "agents" }>;
+  return { root, cwd, env, child, client, hello, port, stop, logs, stdout: () => stdout, stderr: () => stderr,
+    waitLog: (pattern: RegExp) => waitFor(() => pattern.test(logs()), String(pattern), 15_000),
+  };
+}
+
+export type DesktopDaemon = Awaited<ReturnType<typeof desktopDaemon>>;
+
+export async function fakeDesktopBilling(t: TestContext, answer: (route: string, key: unknown) => {
+  status?: number;
+  body?: unknown;
+  raw?: string;
+  closeEarly?: boolean;
+  stall?: boolean;
+}) {
+  const requests: { route: string; key: unknown }[] = [];
+  const server = createServer(async (req, res) => {
+    let input = "";
+    for await (const chunk of req) input += String(chunk);
+    const key: unknown = JSON.parse(input).licenseKey;
+    const route = req.url ?? "";
+    requests.push({ route, key });
+    const reply = answer(route, key);
+    if (reply.closeEarly) { res.destroy(); return; }
+    if (reply.stall) return;
+    res.writeHead(reply.status ?? 200, { "content-type": "application/json" });
+    // Deliberately split every response, including a reflected credential,
+    // across transport chunks before the production bounded reader sees it.
+    const body = reply.raw ?? JSON.stringify(reply.body);
+    const chunkSize = body.length > 65_536 ? 4_093 : 7;
+    for (let offset = 0; offset < body.length; offset += chunkSize) {
+      if (res.destroyed) return;
+      res.write(body.slice(offset, offset + chunkSize));
+      await delay(1);
+    }
+    res.end();
+  });
+  server.listen(0, "127.0.0.1");
+  await once(server, "listening");
+  t.after(() => new Promise<void>((resolve) => {
+    server.close(() => resolve());
+    server.closeAllConnections();
+  }));
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  return { server, requests, url: `http://127.0.0.1:${address.port}/api/entitlement` };
+}
+
+// Even test-owned trees obey the account's dotenv opacity rule. Do not
+// traverse symlinks or ever inspect an opaque filename's contents.
+const opaque = (name: string) => name === ".env" || name.endsWith(".env") || name.startsWith(".env.") || name.includes(".env.");
+export function fixtureFiles(root: string): string[] {
+  let entries;
+  try { entries = readdirSync(root, { withFileTypes: true }); } catch { return []; }
+  return entries.filter((entry) => !opaque(entry.name)).flatMap((entry) => {
+    const file = path.join(root, entry.name);
+    return entry.isDirectory() ? fixtureFiles(file) : entry.isFile() ? [file] : [];
+  });
+}
+
+export function assertDesktopSecretAbsent(run: DesktopDaemon, secrets = [DESKTOP_TEST_KEY], messages: WireMsg[] = []) {
+  const surfaces: [string, string][] = [
+    ["stdout", run.stdout()], ["stderr", run.stderr()],
+    ["local WireMsg", JSON.stringify(run.client.received)], ["remote WireMsg", JSON.stringify(messages)],
+    ...fixtureFiles(run.root).map((file): [string, string] => [path.relative(run.root, file), readFileSync(file, "utf8")]),
+  ];
+  const leaks = surfaces.filter(([, text]) => secrets.some((secret) => text.includes(secret))).map(([name]) => name);
+  assert.deepEqual(leaks, [], "credential reached these surfaces");
+}

--- a/server/testing/desktop-mutations.mjs
+++ b/server/testing/desktop-mutations.mjs
@@ -1,0 +1,83 @@
+// Run after build: node server/testing/desktop-mutations.mjs
+// Faults affect temporary built entries only; reviewed source stays untouched.
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
+
+const root = fileURLToPath(new URL("../../", import.meta.url));
+const mutations = [
+  {
+    name: "stdin-closure", source: "server/desktop-credential.ts",
+    before: "closeSync(0);", after: "void 0;",
+    file: "server/desktop-children.itest.ts", test: "DA.3: gemini-cli",
+    proof: "daemon-after-private-read kept the private descriptor",
+  },
+  {
+    name: "daemon-only-environment", source: "server/adapters/types.ts",
+    before: "!DAEMON_ONLY_ENV.has(e[0])", after: "true",
+    file: "server/desktop-children.itest.ts", test: "DA.3: gemini-cli",
+    proof: "inherited the ambient license",
+  },
+  {
+    name: "log-redaction", source: "server/log.ts",
+    before: '      .replace(/mf_[a-z2-7]{20,}/g, "[redacted-key]")', after: "",
+    file: "server/desktop-boundary.itest.ts", test: "DA.3: the real diagnostic sink",
+    proof: "credential reached these surfaces",
+  },
+  {
+    // Remove the complete omission by publishing the marker on a real
+    // remote hello, including connections whose options omit local identity.
+    name: "remote-host-omission", source: "server/sessions/connection.ts",
+    before: '...(host === "desktop" && !remote ? { host } : {}),',
+    after: '...(host === "desktop" || remote ? { host: "desktop" as const } : {}),',
+    file: "server/desktop-boundary.itest.ts", test: "DA.3: the private key buys",
+    proof: "remote hello carried host",
+  },
+  {
+    name: "billing-reflection", source: "server/relay/entitlement.ts",
+    before: 'licenseKey ? text.split(licenseKey).join(mask(licenseKey)) : text;', after: "text;",
+    file: "server/desktop-boundary.itest.ts", test: "DA.3: a billing refusal",
+    proof: "credential reached these surfaces",
+  },
+];
+
+for (const mutation of mutations) {
+  const entry = path.join(root, "dist-server", `desktop-mutant-${process.pid}-${mutation.name}.mjs`);
+  try {
+    let changed = false;
+    await build({
+      absWorkingDir: root, entryPoints: ["server/index.ts"], outfile: entry,
+      bundle: true, platform: "node", format: "esm", packages: "external", logLevel: "silent",
+      plugins: [{ name: mutation.name, setup(build) {
+        build.onLoad({ filter: /\.ts$/ }, (args) => {
+          if (args.path !== path.join(root, mutation.source)) return;
+          const original = fs.readFileSync(args.path, "utf8");
+          assert.equal(original.split(mutation.before).length, 2, `${mutation.name}: mutation target must occur once`);
+          changed = true;
+          return { contents: original.replace(mutation.before, mutation.after), loader: "ts" };
+        });
+      } }],
+    });
+    assert.ok(changed, `${mutation.name}: source was not loaded`);
+    const child = spawn(process.execPath, ["--import", "tsx", "--test", "--test-concurrency=1", `--test-name-pattern=${mutation.test}`, mutation.file], {
+      cwd: root,
+      env: { ...process.env, MIRAFOLD_LOG_FILE: "", MIRAFOLD_TEST_DAEMON_ENTRY: entry },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let output = "";
+    child.stdout.on("data", (chunk) => { output += String(chunk); });
+    child.stderr.on("data", (chunk) => { output += String(chunk); });
+    const status = await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("close", resolve);
+    });
+    assert.notEqual(status, 0, `${mutation.name}: regression survived`);
+    assert.ok(output.includes(mutation.proof), `${mutation.name}: failed for an unintended reason:\n${output}`);
+    process.stdout.write(`${mutation.name}: caught by the intended regression\n`);
+  } finally {
+    fs.rmSync(entry, { force: true });
+  }
+}

--- a/server/testing/e2e/desktop-host.e2e.ts
+++ b/server/testing/e2e/desktop-host.e2e.ts
@@ -1,0 +1,133 @@
+// DA.2: exercise the real Shell/StatusBar and Fleet prop paths. Only the
+// daemon hello is varied; browser routing and both Pair cards are production.
+import { test, before, after } from "node:test";
+import assert from "node:assert/strict";
+import type { Browser, Page, WebSocketRoute } from "playwright-core";
+import type { WireMsg } from "../../protocol";
+import { launchChrome, withFreshMockSession, assertAxeClean, noSideScroll } from "./e2e-harness";
+
+let browser: Browser;
+before(async () => { browser = await launchChrome(); });
+after(async () => { await browser?.close(); });
+
+function helloFixture(host?: "desktop", invalid = false) {
+  const routes = new Map<WebSocketRoute, Extract<WireMsg, { type: "agents" }>>();
+  let currentHost = host;
+  let remote = false;
+  const rewrite = (hello: Extract<WireMsg, { type: "agents" }>) => {
+    const result = { ...hello };
+    delete result.host;
+    if (currentHost) result.host = currentHost;
+    if (invalid) {
+      delete result.relayOff;
+      result.relay = { url: "http://phone.example", code: "abcdefghijklmnop" };
+      result.billing = "license-key";
+      result.entitlement = { state: "invalid", reason: "subscription lapsed" };
+    }
+    if (remote) {
+      delete result.host;
+      delete result.relay;
+      delete result.relayOff;
+      delete result.billing;
+      delete result.entitlement;
+    }
+    return result;
+  };
+  const refresh = () => {
+    for (const [route, hello] of routes) route.send(JSON.stringify(rewrite(hello)));
+  };
+  return {
+    prepare: (page: Page) => page.routeWebSocket("**/ws*", (route) => {
+      const server = route.connectToServer();
+      server.onMessage((message) => {
+        const parsed = JSON.parse(String(message)) as WireMsg;
+        if (parsed.type === "agents") {
+          routes.set(route, parsed);
+          route.send(JSON.stringify(rewrite(parsed)));
+        } else route.send(message);
+      });
+      server.onClose(() => { routes.delete(route); route.close(); });
+      route.onClose(() => { routes.delete(route); server.close(); });
+    }),
+    clearHost: () => { currentHost = undefined; refresh(); },
+    makeRemote: () => { remote = true; refresh(); },
+    deliver: (message: WireMsg) => {
+      assert.ok(routes.size > 0, "the browser must have received a real daemon hello");
+      for (const route of routes.keys()) route.send(JSON.stringify(message));
+    },
+  };
+}
+
+async function checkCard(page: Page, host: "desktop" | undefined, invalid: boolean) {
+  await page.locator(".sb-pair").click();
+  const card = page.locator(".pair-card");
+  await card.waitFor();
+  const url = host ? "https://mirafold.com/activate" : "https://mirafold.com/pay";
+  assert.equal(await card.locator(".pair-cta").getAttribute("href"), url);
+  if (host) {
+    assert.match(await card.innerText(), /Activation finishes in your system browser and returns to Mirafold Desktop automatically\./);
+    assert.doesNotMatch(await card.innerText(), /MIRAFOLD_LICENSE_KEY/);
+    if (!invalid) {
+      assert.equal(await card.locator("a").count(), 2);
+      assert.equal(await card.locator("a").last().getAttribute("href"), url);
+    }
+  } else if (!invalid) {
+    assert.match(await card.innerText(), /Already have a license key\? Set MIRAFOLD_LICENSE_KEY and relaunch\./);
+  }
+  assert.equal(await card.locator(".pair-cta").getAttribute("target"), "_blank");
+  assert.equal(await card.locator(".pair-cta").getAttribute("rel"), "noopener noreferrer");
+  await noSideScroll(page);
+  await assertAxeClean(page, `${host ?? "terminal"} ${invalid ? "renewal" : "activation"} card`);
+}
+
+for (const host of [undefined, "desktop"] as const) {
+  for (const invalid of [false, true]) {
+    test(`DA.2: ${host ?? "terminal"} ${invalid ? "renewal" : "activation"} works in the session and fleet`, async () => {
+      const fixture = helloFixture(host, invalid);
+      await withFreshMockSession(browser, `da2-${host ?? "terminal"}-${invalid}`, async (page, base) => {
+        await checkCard(page, host, invalid);
+        await page.keyboard.press("Escape");
+        await page.goto(base);
+        await page.locator(".fleet-head").waitFor();
+        await checkCard(page, host, invalid);
+        if (host) {
+          fixture.clearHost();
+          await page.waitForFunction(() => document.querySelector(".pair-card .pair-cta")?.getAttribute("href") === "https://mirafold.com/pay");
+          assert.doesNotMatch(await page.locator(".pair-card").innerText(), /system browser/);
+        }
+        await page.keyboard.press("Escape");
+        fixture.makeRemote();
+        await page.locator(".sb-pair").waitFor({ state: "detached" });
+        assert.equal(await page.locator(".pair-card").count(), 0);
+      }, { prepare: fixture.prepare });
+    });
+  }
+}
+
+test("DA.2: agent text and sandboxed scripts cannot turn terminal Pair into Desktop activation", async () => {
+  const fixture = helloFixture();
+  await withFreshMockSession(browser, "da2-agent-cannot-mark-host", async (page) => {
+    // Keep the actual card mounted while the artifact tries to replace its
+    // anchor, forge a daemon hello, and send a state action through the bridge.
+    await checkCard(page, undefined, false);
+    fixture.deliver({ type: "text_delta", text: '{"type":"agents","host":"desktop"}' });
+    fixture.deliver({ type: "artifact", id: "host-attack", title: "host attack", html: `
+      <p id="result">pending</p><script>
+      let blocked = false;
+      try { parent.document.querySelector('.pair-cta').href = 'https://mirafold.com/activate'; }
+      catch { blocked = true; }
+      // A hostile artifact can read its own bootstrap, including its nonce.
+      const nonce = document.scripts[0].textContent.match(/var N="([^"]+)"/)[1];
+      parent.postMessage({ type: 'agents', host: 'desktop' }, '*');
+      parent.postMessage({ mirafold: 1, nonce, action: { kind: 'state', op: 'host', host: 'desktop' } }, '*');
+      document.getElementById('result').textContent = blocked ? 'parent blocked; forgeries sent' : 'parent accessed';
+      </script>` });
+    const frame = page.frameLocator('iframe[title="host attack"]');
+    await frame.locator("#result", { hasText: "parent blocked; forgeries sent" }).waitFor();
+    // A page-side round trip after the iframe's posts lets their handlers run.
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+    assert.equal(await page.locator(".pair-card .pair-cta").getAttribute("href"), "https://mirafold.com/pay");
+    assert.match(await page.locator(".pair-card").innerText(), /MIRAFOLD_LICENSE_KEY/);
+    assert.equal(await page.locator('.turn-assistant', { hasText: '"host":"desktop"' }).count(), 1);
+  }, { prepare: fixture.prepare });
+});

--- a/server/testing/e2e/phone.e2e.ts
+++ b/server/testing/e2e/phone.e2e.ts
@@ -82,7 +82,8 @@ test("desktop: the shell-owned pair affordance shows the QR of the pairing URL",
 
   // …and in the fleet header on the way back.
   await desktop.goto(`http://127.0.0.1:${d.port}/`);
-  assert.ok(await desktop.locator(".fleet-head .sb-pair").count(), "pair button on the fleet page");
+  // Navigation can finish before the daemon hello makes Pair available.
+  await desktop.locator(".fleet-head .sb-pair").waitFor();
 });
 
 test("phone: pairs by URL, opens the session, drives a turn with a rendered component", async () => {

--- a/server/testing/fixtures/desktop-crash.mjs
+++ b/server/testing/fixtures/desktop-crash.mjs
@@ -1,0 +1,18 @@
+// Test-only failure injection after the unmodified built daemon has booted.
+// The key is a synthetic fixture value; it never enters child environment/argv.
+import http from "node:http";
+import { syncBuiltinESMExports } from "node:module";
+const createServer = http.createServer;
+http.createServer = function (...args) {
+  const server = Reflect.apply(createServer, this, args);
+  server.on("request", (req) => {
+    if (!req.url?.startsWith("/desktop-test-crash/")) return;
+    const failure = new Error(`Desktop diagnostic fixture ${["mf_", "e".repeat(26)].join("")}`);
+    setImmediate(() => {
+      if (req.url.endsWith("/uncaughtException")) throw failure;
+      else void Promise.reject(failure);
+    });
+  });
+  return server;
+};
+syncBuiltinESMExports();

--- a/server/testing/fixtures/desktop-engine.mjs
+++ b/server/testing/fixtures/desktop-engine.mjs
@@ -1,0 +1,73 @@
+// A real spawned child at each production engine seam. It reads only its
+// own launch metadata and its fresh fixture configuration, drives the actual
+// bundled render-MCP child, then exercises the engine-failure path.
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { observe } from "./desktop-observer.mjs";
+
+const mode = process.argv[2];
+const args = process.argv.slice(3);
+const isCatalog = mode === "gemini" && args.includes("--acp") || mode === "codex" && !args.some((arg) => arg.startsWith("mcp_servers."));
+observe(`${mode}${isCatalog ? "-catalog" : "-engine"}`);
+
+if (mode === "pty") {
+  process.stdout.write("Desktop child probe ");
+  setTimeout(() => { process.stdout.write("completed\n"); process.exit(0); }, 5);
+} else if (isCatalog) {
+  let buffer = "";
+  process.stdin.on("data", (chunk) => {
+    buffer += String(chunk);
+    let nl;
+    while ((nl = buffer.indexOf("\n")) >= 0) {
+      const msg = JSON.parse(buffer.slice(0, nl)); buffer = buffer.slice(nl + 1);
+      if (msg.id === undefined) continue;
+      const result = msg.method === "session/new"
+        ? { models: { availableModels: [{ modelId: "fixture", name: "fixture" }], currentModelId: "fixture" }
+        } : msg.method === "model/list"
+          ? { data: [{ id: "fixture", displayName: "fixture", isDefault: true }] } : {};
+      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\n");
+    }
+  });
+} else {
+  let launch;
+  if (mode === "codex") {
+    const config = {};
+    for (let i = 0; i < args.length - 1; i++) {
+      if (args[i] !== "-c") continue;
+      const split = args[++i].indexOf("=");
+      if (split < 0) continue;
+      config[args[i].slice(0, split)] = JSON.parse(args[i].slice(split + 1));
+    }
+    const key = Object.keys(config).find((key) => /^mcp_servers\..*\.command$/.test(key));
+    if (key) launch = { command: config[key], args: config[key.replace(/command$/, "args")] };
+  } else if (mode === "gemini") {
+    const settings = JSON.parse(fs.readFileSync(path.join(process.cwd(), ".gemini/settings.json"), "utf8"));
+    launch = Object.values(settings.mcpServers)[0];
+  } else if (mode === "opencode") {
+    const settings = JSON.parse(process.env.OPENCODE_CONFIG_CONTENT);
+    const mcp = Object.values(settings.mcp)[0];
+    launch = { command: mcp.command[0], args: mcp.command.slice(1), env: mcp.environment };
+  }
+  if (launch) {
+    const client = new Client({ name: "desktop-child-probe", version: "0.0.0" });
+    const transport = new StdioClientTransport({
+      command: launch.command,
+      args: ["--import", fileURLToPath(new URL("./desktop-observer.mjs", import.meta.url)), ...launch.args],
+      cwd: process.cwd(),
+      env: { ...process.env, ...launch.env, MIRAFOLD_TEST_MCP_OBSERVER: "1" },
+      stderr: "pipe",
+    });
+    await client.connect(transport);
+    const reply = await client.callTool({ name: "render_card", arguments: { title: "child probe", body: "boundary checked" } });
+    if (reply.isError) throw new Error("real render-MCP rejected the probe");
+    fs.writeFileSync(path.join(process.env.MIRAFOLD_TEST_CAPTURE, `mcp-ack-${mode}-${process.pid}.json`), JSON.stringify({ mode, acknowledged: true }));
+    await client.close();
+  }
+  // The production adapters assemble this split stderr into their own error
+  // report, then broadcast and checkpoint it. No provider is ever contacted.
+  process.stderr.write("Desktop child ");
+  setTimeout(() => { process.stderr.write("probe failure\n"); process.exit(17); }, 5);
+}

--- a/server/testing/fixtures/desktop-observer.mjs
+++ b/server/testing/fixtures/desktop-observer.mjs
@@ -1,0 +1,65 @@
+// Test-only observation around the unchanged built daemon / real MCP entry.
+// Report hashes and descriptor identity, never credential bytes.
+import fs from "node:fs";
+import path from "node:path";
+import http from "node:http";
+import childProcess from "node:child_process";
+import { createHash } from "node:crypto";
+import { syncBuiltinESMExports } from "node:module";
+import { fileURLToPath } from "node:url";
+
+const capture = process.env.MIRAFOLD_TEST_CAPTURE;
+const read = (file) => { try { return fs.readFileSync(file, "utf8"); } catch { return ""; } };
+const link = (file) => { try { return fs.readlinkSync(file); } catch { return ""; } };
+const hashes = (text) => [...text.matchAll(/mf_[a-z2-7]{20,40}/g)].map(([value]) => createHash("sha256").update(value).digest("hex"));
+const daemonNames = ["MIRAFOLD_TOKEN", "MIRAFOLD_LICENSE_KEY", "MIRAFOLD_RELAY_CODE", "MIRAFOLD_ENTITLEMENT_TOKEN"];
+
+export function observe(label) {
+  if (!capture) throw new Error("Desktop probe has no capture directory");
+  const links = process.platform === "linux"
+    ? fs.readdirSync("/proc/self/fd").filter((name) => /^\d+$/.test(name)).map((name) => link(`/proc/self/fd/${name}`))
+    : [];
+  const report = {
+    label, pid: process.pid, ppid: process.ppid,
+    envKeys: daemonNames.filter((name) => Object.hasOwn(process.env, name)),
+    envHashes: hashes(JSON.stringify(process.env)),
+    argvHashes: hashes(JSON.stringify(process.argv)),
+    osEnvHashes: hashes(read("/proc/self/environ")),
+    osArgvHashes: hashes(read("/proc/self/cmdline")),
+    privatePipeOpen: links.some((target) => target && target === process.env.MIRAFOLD_TEST_PIPE_TARGET),
+  };
+  fs.mkdirSync(capture, { recursive: true });
+  fs.writeFileSync(path.join(capture, `${label}-${process.pid}.json`), JSON.stringify(report));
+  return report;
+}
+
+if (process.env.MIRAFOLD_TEST_DAEMON_OBSERVER === "1") {
+  // The preload runs before any daemon module. The first HTTP server creation
+  // is after the private reader; identity must be gone even if fd 0 is reused.
+  process.env.MIRAFOLD_TEST_PIPE_TARGET = link("/proc/self/fd/0");
+  delete process.env.MIRAFOLD_TEST_DAEMON_OBSERVER;
+  const createServer = http.createServer;
+  http.createServer = function (...args) {
+    observe("daemon-after-private-read");
+    return Reflect.apply(createServer, this, args);
+  };
+  // Keep the real Claude SDK and its actual spawn options, replacing only
+  // the model engine executable with a fixture. No model can be reached.
+  const spawn = childProcess.spawn;
+  childProcess.spawn = function (command, args, options) {
+    const index = Array.isArray(args) ? args.findIndex((arg) => typeof arg === "string" && /@anthropic-ai\/claude-agent-sdk\/cli\.js$/.test(arg)) : -1;
+    const nativeClaude = typeof command === "string" && path.basename(command) === "claude" && args?.includes("--input-format") && args.includes("--output-format");
+    if (index >= 0 || nativeClaude) {
+      const fixture = fileURLToPath(new URL("./desktop-engine.mjs", import.meta.url));
+      return spawn(process.execPath, [fixture, "claude", ...args.slice(nativeClaude ? 0 : index + 1)], options);
+    }
+    if (typeof command === "string" && command.startsWith(path.join(path.dirname(capture), "bin") + path.sep)) {
+      return spawn(command, args, options);
+    }
+    throw new Error(`Desktop test refused child executable ${path.basename(String(command))}; argument files ${Array.isArray(args) ? args.filter((arg) => typeof arg === "string" && /\.(m?js)$/.test(arg)).map((arg) => path.basename(arg)).join(",") : "none"}`);
+  };
+  syncBuiltinESMExports();
+} else if (process.env.MIRAFOLD_TEST_MCP_OBSERVER === "1") {
+  delete process.env.MIRAFOLD_TEST_MCP_OBSERVER;
+  observe("mcp");
+}

--- a/tsconfig.ci.json
+++ b/tsconfig.ci.json
@@ -1,9 +1,9 @@
 {
   // Single-repo typecheck config. Identical to tsconfig.json except it excludes
-  // the one cross-repo file: server/relay/relay-service.itest.ts imports the
-  // relay under test from the SIBLING ../mirafold-relay checkout (see
-  // docs/ARCHITECTURE.md's relay overview), which a lone checkout of this repo
-  // doesn't have.
+  // cross-repo integration tests. server/relay/relay-service.itest.ts and
+  // server/desktop-boundary.itest.ts import the relay under test from the
+  // SIBLING ../mirafold-relay checkout (see docs/ARCHITECTURE.md's relay
+  // overview), which a lone checkout of this repo doesn't have.
   //
   // Used by .github/workflows/release.yml ONLY, and now for a different reason
   // than it was written for (2026-08-02). The original reason — the relay repo
@@ -13,10 +13,14 @@
   //
   // The publish path deliberately did NOT follow. Keeping release.yml a
   // single-repo checkout means no push to another repo's default branch can
-  // block a release, and the file this excludes is a test that never ships in
+  // block a release, and the files excluded here are tests that never ship in
   // the package. Contract drift is still caught — loudly — by ci.yml on every
   // PR. Delete this file only if the release workflow is ever given the sibling
   // checkout too, which would trade that isolation away.
   "extends": "./tsconfig.json",
-  "exclude": ["node_modules", "server/relay/relay-service.itest.ts"]
+  "exclude": [
+    "node_modules",
+    "server/desktop-boundary.itest.ts",
+    "server/relay/relay-service.itest.ts"
+  ]
 }

--- a/web/src/components/ConnectDevice.test.ts
+++ b/web/src/components/ConnectDevice.test.ts
@@ -1,9 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createElement } from "react";
+import { createHash } from "node:crypto";
+import { createElement, type ComponentProps } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import {
   ConnectDevice,
+  DESKTOP_ACTIVATION_URL,
   LicenseGate,
   PAY_URL,
   PairCardBody,
@@ -45,8 +47,17 @@ test("relay off by the user's own setting: the card says which setting, and sell
   assert.match(optOut, /MIRAFOLD_RELAY_URL=off/);
   assert.doesNotMatch(optOut, /pair-cta|mirafold\.com\/pay/);
   const malformed = renderToStaticMarkup(createElement(RemoteAccessOff, { reason: "malformed-url" }));
-  assert.match(malformed, /not a valid/);
+  assert.match(malformed, /not a usable Mirafold relay address/);
+  assert.match(malformed, /no fragment/);
   assert.doesNotMatch(malformed, /pair-cta|mirafold\.com\/pay/);
+
+  const invalidToken = renderToStaticMarkup(
+    createElement(RemoteAccessOff, { reason: "invalid-entitlement-token" }),
+  );
+  assert.match(invalidToken, /MIRAFOLD_ENTITLEMENT_TOKEN/);
+  assert.match(invalidToken, /request header/);
+  assert.match(invalidToken, /remove that setting and relaunch/i);
+  assert.doesNotMatch(invalidToken, /pair-cta|mirafold\.com\/pay|pair-qr/);
 });
 
 // Phase PB.2: with a relay configured, the license-key read decides whether
@@ -83,10 +94,11 @@ test("a refused key: no QR, the backend's reason quoted, the pay link, the butto
 });
 
 // Review 2026-08-26: the tooltip is part of what the button claims at rest.
-test("pairTitle sells only to the unentitled; an opt-out or a bad URL gets a plain off-line", () => {
+test("pairTitle sells only to the unentitled; configuration refusals get a plain off-line", () => {
   assert.match(pairTitle({ gated: false, relayOff: "unentitled" }), /Mirafold Pro/);
   assert.doesNotMatch(pairTitle({ gated: false, relayOff: "opt-out" }), /Mirafold Pro/);
   assert.doesNotMatch(pairTitle({ gated: false, relayOff: "malformed-url" }), /Mirafold Pro/);
+  assert.doesNotMatch(pairTitle({ gated: false, relayOff: "invalid-entitlement-token" }), /Mirafold Pro/);
   assert.match(pairTitle({ gated: true }), /license key/);
   assert.match(pairTitle({ href: "http://x/#code=y", gated: false }), /scan a QR/);
 });
@@ -122,4 +134,62 @@ test("a refusal reason's control characters are made visible, not obeyed", () =>
   );
   assert.match(gate, /‹U\+202E›active/);
   assert.doesNotMatch(gate, /\u202E/);
+});
+
+
+// Captured from the existing pre-DA.2 render, before host support was added.
+// The requirement is exact terminal/browser output, across every card arm.
+const CARD_BASE = {
+  billing: true, subRequest: () => "id", manage: false, setManage() {},
+  copyState: "idle" as const, onCopy() {},
+};
+const PAIR_HREF = "http://phone.example/#code=abcdefghijklmnop";
+const CARD_CASES: [string, Partial<ComponentProps<typeof PairCardBody>>, string][] = [
+  ["unentitled", { relayOff: "unentitled", billing: false }, "1858caa8951f4eb4f38dcd68bb469b1557ff0078da6282027d5c05efac119ede"],
+  ["opt-out", { relayOff: "opt-out" }, "42ced1c4d4488d1cb1cc6810da7a3cecd93a353284ce3538d89bc98bc9f6d1bf"],
+  ["malformed URL", { relayOff: "malformed-url" }, "631dd99a4574a48aa71a82d23a56e35edc02835fd6dc15af481ad031433ff99e"],
+  ["invalid token", { relayOff: "invalid-entitlement-token", billing: false }, "f934ff19827dd25c0224aee283db195ef9d57f60b28f4e636c227782de5a9e92"],
+  ["checking", { entitlement: { state: "checking" } }, "1f96a7db617f5a9b9d19c837717eacb927bca7b43e5a3c10c13aa61649cb2a59"],
+  ["invalid", { entitlement: { state: "invalid", reason: "subscription lapsed" } }, "f860db1356163bb874230e9cc6684fdc3c06c86b6641e808914d9348f1f0986b"],
+  ["unreachable", { entitlement: { state: "unreachable", cached: false } }, "1eafc7b26c896c3fdc51fd4a064390417928fc960a41eab3b21196fc1e37b42d"],
+  ["valid", { href: PAIR_HREF, entitlement: { state: "valid" } }, "2028ac70af1293e7fa33d73b035656a057aa9440ecd69d3fc494abe9cbccd2bc"],
+  ["cached", { href: PAIR_HREF, entitlement: { state: "unreachable", cached: true } }, "088b95955b37068148c8507e591db78967bd18194c48d2cfaf8c410be164026c"],
+  ["self-hosted", { href: PAIR_HREF }, "2028ac70af1293e7fa33d73b035656a057aa9440ecd69d3fc494abe9cbccd2bc"],
+  ["copied", { href: PAIR_HREF, copyState: "copied" }, "79a28cfbfbc246ebd2acbf7ff2dc2163cef346098b6dcd7d03949ce29872a01e"],
+  ["copy failed", { href: PAIR_HREF, copyState: "failed" }, "efd4c82258aaceca9598e9c74b9b3c4d64f4df8227095c15501266e3839d951d"],
+  ["manage", { manage: true }, "b80c9c2df88425ecf11b7e341e51da598c9c0eb4394bf4b1a132edfb68071cd2"],
+];
+
+test("DA.2: every Pair card arm keeps the exact terminal markup; Desktop changes only activation offers", async (t) => {
+  assert.equal(DESKTOP_ACTIVATION_URL, "https://mirafold.com/activate");
+  for (const [name, props, beforeHash] of CARD_CASES) {
+    for (const host of [undefined, "desktop"] as const) {
+      await t.test(`${name}: ${host ?? "terminal"}`, () => {
+        const html = renderToStaticMarkup(createElement(PairCardBody, { ...CARD_BASE, ...props, host }));
+        if (host !== "desktop" || !["unentitled", "invalid"].includes(name)) {
+          assert.equal(createHash("sha256").update(html).digest("hex"), beforeHash);
+          assert.ok(!html.includes(DESKTOP_ACTIVATION_URL));
+          return;
+        }
+        assert.match(html, /Activation finishes in your system browser and returns to Mirafold Desktop automatically\./);
+        assert.doesNotMatch(html, /MIRAFOLD_LICENSE_KEY|relaunch|mirafold\.com\/pay|pair-qr/);
+        const anchors = [...html.matchAll(/<a(?: class="[^"]*")? href="([^"]+)" target="_blank" rel="noopener noreferrer"/g)];
+        assert.deepEqual(anchors.map((a) => a[1]), Array(name === "unentitled" ? 2 : 1).fill(DESKTOP_ACTIVATION_URL));
+        if (name === "unentitled") assert.match(html, /Already have a license key\?/);
+        else {
+          assert.match(html, /<q class="pair-quote">subscription lapsed<\/q>/);
+          assert.match(html, /renew or get Mirafold Pro/);
+          assert.match(html, /manage subscription/);
+        }
+      });
+    }
+  }
+});
+
+test("DA.2: host and billing hints alone never add a Pair surface to a remote viewport", () => {
+  for (const host of [undefined, "desktop"] as const) {
+    assert.equal(renderToStaticMarkup(createElement(ConnectDevice, {
+      host, billing: true, subRequest: () => "id", entitlement: { state: "invalid" },
+    })), "");
+  }
 });

--- a/web/src/components/ConnectDevice.tsx
+++ b/web/src/components/ConnectDevice.tsx
@@ -26,15 +26,32 @@ import {
 // ws(s) origin, present when `url` is a separate static app origin — it rides
 // the QR fragment so the loaded page knows where to dial.
 export type { EntitlementView, RelayInfo } from "../transport/daemon-hello";
-import type { AgentsHello, EntitlementView, RelayInfo } from "../transport/daemon-hello";
+import type {
+  AgentsHello,
+  EntitlementView,
+  RelayInfo,
+  RelayOffReason,
+} from "../transport/daemon-hello";
 
 /** Why remote access is off (hello `relayOff`) — the card's state when there
  *  is no relay to draw a QR for. */
-export type RelayOff = NonNullable<AgentsHello["relayOff"]>;
+export type RelayOff = RelayOffReason;
+export type DaemonHost = NonNullable<AgentsHello["host"]>;
 
 /** Where "get Mirafold Pro" goes. A plain link (new tab, no opener): the
  *  destination is visible on hover and nothing about it is scripted. */
 export const PAY_URL = "https://mirafold.com/pay";
+// Fixed, non-secret marker for Desktop's protected browser flow. Electron
+// main supplies callback/state; this renderer supplies no URL parameters.
+export const DESKTOP_ACTIVATION_URL = "https://mirafold.com/activate";
+
+function DesktopActivationHint() {
+  return (
+    <div className="pair-hint pair-hint-sub">
+      Activation finishes in your system browser and returns to Mirafold Desktop automatically.
+    </div>
+  );
+}
 
 // Names the dialog for a screen reader. A constant is safe: the card is
 // mounted only while open, and one status bar means one of these.
@@ -152,7 +169,7 @@ function ManageSubscription({
 // The card's body when there is no relay: the honest reason, and — when the
 // reason is that nothing is configured — the one way to get one. Shell-owned
 // copy; the pay link is an ordinary anchor so the browser shows where it goes.
-export function RemoteAccessOff({ reason }: { reason: RelayOff }) {
+export function RemoteAccessOff({ reason, host }: { reason: RelayOff; host?: DaemonHost }) {
   if (reason === "unentitled") {
     return (
       <>
@@ -160,11 +177,21 @@ export function RemoteAccessOff({ reason }: { reason: RelayOff }) {
           Pair your phone and open this daemon's sessions from anywhere — end-to-end
           encrypted, through the Mirafold relay. Remote access is part of Mirafold Pro.
         </div>
-        <a className="pair-cta" href={PAY_URL} target="_blank" rel="noopener noreferrer">
+        <a className="pair-cta" href={host === "desktop" ? DESKTOP_ACTIVATION_URL : PAY_URL} target="_blank" rel="noopener noreferrer">
           get Mirafold Pro ↗
         </a>
+        {host === "desktop" && <DesktopActivationHint />}
         <div className="pair-hint pair-hint-sub">
-          Already have a license key? Set <code>MIRAFOLD_LICENSE_KEY</code> and relaunch.
+          {host === "desktop" ? (
+            <>
+              Already have a license key?{" "}
+              <a href={DESKTOP_ACTIVATION_URL} target="_blank" rel="noopener noreferrer">
+                connect it in your system browser ↗
+              </a>.
+            </>
+          ) : (
+            <>Already have a license key? Set <code>MIRAFOLD_LICENSE_KEY</code> and relaunch.</>
+          )}
         </div>
       </>
     );
@@ -180,8 +207,17 @@ export function RemoteAccessOff({ reason }: { reason: RelayOff }) {
   if (reason === "malformed-url") {
     return (
       <div className="pair-hint">
-        <code>MIRAFOLD_RELAY_URL</code> is not a valid <code>ws://</code> or <code>wss://</code>{" "}
-        address, so remote access is off for this launch. Fix it and relaunch to pair a phone.
+        <code>MIRAFOLD_RELAY_URL</code> is not a usable Mirafold relay address. Use{" "}
+        <code>ws://</code> or <code>wss://</code> with no fragment, then relaunch to pair a phone.
+      </div>
+    );
+  }
+  if (reason === "invalid-entitlement-token") {
+    return (
+      <div className="pair-hint">
+        <code>MIRAFOLD_ENTITLEMENT_TOKEN</code> cannot be used as an HTTP request header, so
+        remote access is off for this launch. Fix or remove that setting and relaunch to pair a
+        phone.
       </div>
     );
   }
@@ -201,7 +237,7 @@ export function entitlementGates(view: EntitlementView | undefined): boolean {
 // The card's body when the relay is configured but the license key doesn't
 // carry it. Shell-owned copy; the backend's refusal line is quoted as its
 // own, never dressed up as ours. The parent keeps the manage link under it.
-export function LicenseGate({ view }: { view: EntitlementView }) {
+export function LicenseGate({ view, host }: { view: EntitlementView; host?: DaemonHost }) {
   if (view.state === "checking") {
     return <div className="sub-line sub-dim">checking your license key…</div>;
   }
@@ -217,9 +253,10 @@ export function LicenseGate({ view }: { view: EntitlementView }) {
           ) : null}
           . Remote access is off until a subscription is active — local sessions are unaffected.
         </div>
-        <a className="pair-cta" href={PAY_URL} target="_blank" rel="noopener noreferrer">
+        <a className="pair-cta" href={host === "desktop" ? DESKTOP_ACTIVATION_URL : PAY_URL} target="_blank" rel="noopener noreferrer">
           renew or get Mirafold Pro ↗
         </a>
+        {host === "desktop" && <DesktopActivationHint />}
       </>
     );
   }
@@ -249,6 +286,7 @@ export function pairTitle(a: { href?: string; gated: boolean; relayOff?: RelayOf
  *  when this daemon runs on a key — a subscriber must never lose the one
  *  path to their subscription, whatever the relay is doing. */
 export function PairCardBody({
+  host,
   href,
   relayOff,
   entitlement,
@@ -260,6 +298,7 @@ export function PairCardBody({
   copyState,
   onCopy,
 }: {
+  host?: DaemonHost;
   href?: string;
   relayOff?: RelayOff;
   entitlement?: EntitlementView;
@@ -290,7 +329,7 @@ export function PairCardBody({
     const gate = relayOff === undefined && entitlement;
     return (
       <>
-        {gate ? <LicenseGate view={entitlement} /> : <RemoteAccessOff reason={relayOff as RelayOff} />}
+        {gate ? <LicenseGate view={entitlement} host={host} /> : <RemoteAccessOff reason={relayOff as RelayOff} host={host} />}
         {manageLink}
       </>
     );
@@ -340,6 +379,7 @@ export function PairCardBody({
 // `entitlement`: the daemon's license-key read. A read that doesn't carry
 // the relay replaces the QR with the truth (LicenseGate) — the button stays.
 export function ConnectDevice({
+  host,
   relay,
   relayOff,
   entitlement,
@@ -348,6 +388,7 @@ export function ConnectDevice({
   subRequest,
   subReply,
 }: {
+  host?: DaemonHost;
   relay?: RelayInfo;
   relayOff?: RelayOff;
   entitlement?: EntitlementView;
@@ -397,6 +438,7 @@ export function ConnectDevice({
             </button>
           </div>
           <PairCardBody
+            host={host}
             href={href}
             relayOff={relayOff}
             entitlement={gated ? entitlement : relay ? entitlement : undefined}

--- a/web/src/components/FleetView.tsx
+++ b/web/src/components/FleetView.tsx
@@ -279,6 +279,7 @@ export function FleetView() {
           </span>
           <span className="fleet-spacer" />
           <ConnectDevice
+            host={daemon.host}
             relay={daemon.relay}
             relayOff={daemon.relayOff}
             entitlement={daemon.entitlement}

--- a/web/src/components/Shell.tsx
+++ b/web/src/components/Shell.tsx
@@ -635,6 +635,7 @@ export function Shell() {
               onToggleTheme={toggleMode}
               onOpenSettings={() => setSettingsOpen(true)}
               onEndSession={meta.sessionId ? bus.endSession : undefined}
+              host={daemonInfo.host}
               relay={daemonInfo.relay}
               relayOff={daemonInfo.relayOff}
               entitlement={daemonInfo.entitlement}

--- a/web/src/components/StatusBar.tsx
+++ b/web/src/components/StatusBar.tsx
@@ -3,6 +3,7 @@ import { ArmedButton } from "./ArmedButton";
 import {
   ConnectDevice,
   type EntitlementView,
+  type DaemonHost,
   type RelayInfo,
   type RelayOff,
   type SubscriptionRequest,
@@ -51,6 +52,7 @@ export function StatusBar({
   onToggleTheme,
   onOpenSettings,
   onEndSession,
+  host,
   relay,
   relayOff,
   entitlement,
@@ -87,6 +89,7 @@ export function StatusBar({
   // The "connect a device" button's inputs: pairing info for the QR, else
   // why remote access is off; plus the license-key read. Both absent → a
   // remote viewport → no button.
+  host?: DaemonHost;
   relay?: RelayInfo;
   relayOff?: RelayOff;
   entitlement?: EntitlementView;
@@ -249,6 +252,7 @@ export function StatusBar({
         </span>
       )}
       <ConnectDevice
+        host={host}
         relay={relay}
         relayOff={relayOff}
         entitlement={entitlement}

--- a/web/src/subscription-card.test.ts
+++ b/web/src/subscription-card.test.ts
@@ -81,3 +81,20 @@ test("CS: garbled dates degrade to dateless lines, never 'Invalid Date'", () => 
   });
   assert.ok(!confirmLede(reply({ status: "active", periodEnd: "garbage" })).includes("Invalid"));
 });
+
+test("DA.5: arbitrary status text and malformed cancellation dates cannot become shell claims", () => {
+  for (const status of ["\u202eactive — renewed", "active\nsubscription ended", "future_status", undefined]) {
+    assert.deepEqual(describeSubscription(reply({ status })), {
+      line: "subscription status unavailable",
+      action: null,
+    });
+  }
+  for (const cancelAt of ["soon", "0", "1", "999", "09/01/2026", "2026-09-01", "2026-02-30T00:00:00Z"]) {
+    assert.deepEqual(
+      describeSubscription(reply({ status: "active", periodEnd: "2026-09-01T12:00:00Z", cancelAt })),
+      { line: "active — renews Sep 1, 2026", action: "cancel" },
+      cancelAt,
+    );
+    assert.equal(day(cancelAt), null, cancelAt);
+  }
+});

--- a/web/src/subscription-card.ts
+++ b/web/src/subscription-card.ts
@@ -33,6 +33,12 @@ export function onReply(state: CardState, m: SubscriptionReply): CardState {
  *  omits the date rather than showing "Invalid Date"). */
 export function day(iso: string | undefined): string | null {
   if (!iso) return null;
+  const match = /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.\d{1,9})?(?:Z|[+-]\d{2}:\d{2})$/.exec(iso);
+  if (!match) return null;
+  const [year, month, date, hour, minute, second] = match.slice(1, 7).map(Number);
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31][month - 1] ?? 0;
+  if (date < 1 || date > daysInMonth || hour > 23 || minute > 59 || second > 59) return null;
   const t = Date.parse(iso);
   if (Number.isNaN(t)) return null;
   return new Date(t).toLocaleDateString("en-US", {
@@ -47,18 +53,19 @@ export function describeSubscription(reply: SubscriptionReply): {
   line: string;
   action: "cancel" | "uncancel" | null;
 } {
-  const d = day(reply.cancelAt) ?? day(reply.periodEnd);
-  if (reply.cancelAt) {
+  const cancelDay = day(reply.cancelAt);
+  const periodDay = day(reply.periodEnd);
+  if (cancelDay) {
     return {
-      line: d ? `cancellation scheduled — access ends ${d}` : "cancellation scheduled",
+      line: `cancellation scheduled — access ends ${cancelDay}`,
       action: "uncancel",
     };
   }
   switch (reply.status) {
     case "trialing":
-      return { line: d ? `free trial — first charge ${d}` : "free trial", action: "cancel" };
+      return { line: periodDay ? `free trial — first charge ${periodDay}` : "free trial", action: "cancel" };
     case "active":
-      return { line: d ? `active — renews ${d}` : "active", action: "cancel" };
+      return { line: periodDay ? `active — renews ${periodDay}` : "active", action: "cancel" };
     case "past_due":
       // Cancel stays offered: stopping future attempts is exactly what a
       // past-due customer may want. Fixing the card is Paddle's surface.
@@ -68,8 +75,10 @@ export function describeSubscription(reply: SubscriptionReply): {
       };
     case "canceled":
       return { line: "subscription ended", action: null };
+    case "paused":
+      return { line: "subscription is paused", action: null };
     default:
-      return { line: `subscription is ${reply.status ?? "unknown"}`, action: null };
+      return { line: "subscription status unavailable", action: null };
   }
 }
 

--- a/web/src/transport/daemon-hello.test.ts
+++ b/web/src/transport/daemon-hello.test.ts
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { daemonInfoFrom, withEntitlement, type AgentsHello } from "./daemon-hello";
+import { admitWireFrame } from "./ws";
 
 // Review 2026-08-26 (twice): the license-key read must never outlive the
 // daemon that produced it. It rides ON the hello, so every hello — the
@@ -32,4 +33,53 @@ test("a hello without a read drops the held one — whatever the hello says abou
   );
   assert.equal(relaunched.entitlement, undefined);
   assert.notEqual(held.entitlement, undefined);
+});
+
+
+test("legacy and Desktop hellos pass the unchanged wire parser; only the literal Desktop host is retained", () => {
+  for (const host of [undefined, "desktop", "future-host", true, { name: "desktop" }]) {
+    // Absence is the pre-DA hello fixture, still accepted by both the wire
+    // parser and hello state. Unknown future values must not select Desktop.
+    const frame = JSON.parse(JSON.stringify({ ...hello(), host }));
+    const admitted = admitWireFrame(frame);
+    assert.ok(admitted && admitted.type === "agents");
+    const info = daemonInfoFrom(admitted);
+    assert.equal(Object.hasOwn(info, "host"), host === "desktop");
+    assert.equal(info.host, host === "desktop" ? "desktop" : undefined);
+    assert.deepEqual(info.agents, []);
+  }
+});
+
+test("a new hello drops a held Desktop host; entitlement messages cannot establish or replace it", () => {
+  const desktop = daemonInfoFrom(hello({ host: "desktop" }));
+  const forged = JSON.parse('{"type":"entitlement","state":"valid","host":"desktop"}');
+  assert.equal(withEntitlement(daemonInfoFrom(hello()), forged).host, undefined);
+  assert.equal(withEntitlement(desktop, { type: "entitlement", state: "valid" }).host, "desktop");
+  const refreshed = daemonInfoFrom(hello());
+  assert.equal(Object.hasOwn(refreshed, "host"), false);
+  assert.equal(withEntitlement(refreshed, forged).host, undefined);
+});
+
+test("DA.4C: the new config-problem field maps only its exact value into current Pair state", () => {
+  const current = admitWireFrame(JSON.parse(JSON.stringify({
+    ...hello(),
+    relayConfigProblem: "invalid-entitlement-token",
+  })));
+  assert.ok(current?.type === "agents");
+  const info = daemonInfoFrom(current);
+  assert.equal(info.relayOff, "invalid-entitlement-token");
+  assert.equal(Object.hasOwn(info, "relayConfigProblem"), false);
+
+  // Future values in either wire field are ignored rather than reaching an
+  // exhaustiveness fallback as raw React text.
+  for (const frame of [
+    { ...hello(), relayConfigProblem: "future-problem" },
+    { ...hello(), relayOff: "future-reason" },
+  ]) {
+    const admitted = admitWireFrame(JSON.parse(JSON.stringify(frame)));
+    assert.ok(admitted?.type === "agents");
+    const future = daemonInfoFrom(admitted);
+    assert.equal(future.relayOff, undefined);
+    assert.equal(Object.hasOwn(future, "relayConfigProblem"), false);
+  }
 });

--- a/web/src/transport/daemon-hello.ts
+++ b/web/src/transport/daemon-hello.ts
@@ -1,4 +1,4 @@
-import type { AgentInfo, EntitlementView, WireMsg } from "@protocol";
+import type { AgentInfo, EntitlementView, RelayOffReason, WireMsg } from "@protocol";
 
 /** The daemon's `agents` hello, typed off the protocol so a new hello field
  *  reaches every consumer through the compiler instead of three hand-kept
@@ -8,14 +8,18 @@ export type AgentsHello = Extract<WireMsg, { type: "agents" }>;
 /** The pairing info a LOCAL viewport receives for the "connect a device" QR. */
 export type RelayInfo = NonNullable<AgentsHello["relay"]>;
 
-export type { EntitlementView };
+export type { EntitlementView, RelayOffReason };
 
 /** Everything the hello carries that the shell keeps: which agents the daemon
  *  offers (null until the first hello), where it was launched, its home dir,
  *  the pairing info, its version, the billing affordance, and the
- *  license-key read. */
-export type DaemonInfo = Omit<AgentsHello, "type" | "agents" | "default"> & {
+ *  license-key read, and the optional local Desktop host. */
+export type DaemonInfo = Omit<
+  AgentsHello,
+  "type" | "agents" | "default" | "relayOff" | "relayConfigProblem"
+> & {
   agents: AgentInfo[] | null;
+  relayOff?: RelayOffReason;
 };
 
 export const NO_DAEMON_INFO: DaemonInfo = { agents: null };
@@ -25,8 +29,25 @@ export const NO_DAEMON_INFO: DaemonInfo = { agents: null };
  *  exchange) drops whatever was held: nothing carries over from a previous
  *  daemon. */
 export function daemonInfoFrom(hello: AgentsHello): DaemonInfo {
-  const { type: _type, default: _default, ...info } = hello;
-  return info;
+  const {
+    type: _type,
+    default: _default,
+    host,
+    relayOff: rawRelayOff,
+    relayConfigProblem,
+    ...info
+  } = hello;
+  const relayOff: RelayOffReason | undefined =
+    rawRelayOff === "unentitled" || rawRelayOff === "opt-out" || rawRelayOff === "malformed-url"
+      ? rawRelayOff
+      : relayConfigProblem === "invalid-entitlement-token"
+        ? relayConfigProblem
+        : undefined;
+  return {
+    ...info,
+    ...(host === "desktop" ? { host } : {}),
+    ...(relayOff ? { relayOff } : {}),
+  };
 }
 
 /** Fold an `entitlement` change (between hellos) into what the shell holds. */

--- a/yarn.lock
+++ b/yarn.lock
@@ -2716,9 +2716,9 @@ qrcode-generator@^2.0.4:
   integrity sha512-mZSiP6RnbHl4xL2Ap5HfkjLnmxfKcPWpWe/c+5XxCuetEenqmNFf1FH/ftXPCtFG5/TDobjsjz6sSNL0Sr8Z9g==
 
 qs@^6.14.0, qs@^6.15.2:
-  version "6.15.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.15.3.tgz#76852132a58ed5c7c0ef67e4441b9bb5d6061b3b"
-  integrity sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==
+  version "6.16.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.16.0.tgz#c22c723a28a920f3aacdce8289fabd43eccb79fd"
+  integrity sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"


### PR DESCRIPTION
Desktop needs to start the existing Shell without placing a permanent Pro key
in process environment, command arguments, logs, child processes, or viewport
messages. This change adds a private stdin credential handoff and an additive
local-only Desktop host identity, then hardens the adjacent relay, billing,
logging, subscription, and repository-secret boundaries found by the required
correctness and security passes.

The ordinary terminal credential path, explicit self-hosting without a malformed
credential override, old Desktop launches without the private flag, public wire
compatibility, relay cryptography, and package version remain unchanged. The
complete findings and verification record are in `PLAN-ARCHIVE.md` under
“Shell DA.4 and DA.4C” and “Shell DA.5 security audit and candidate freeze.”

Validation:

- focused security surfaces: 125/125
- DA.5 permitted Tier 1: 1,222/1,222
- Tier 2: 183/183
- Tier 3: 140/140
- managed browser and visual gate: 11/11
- Desktop boundary mutations: 5/5
- installed candidate package smoke: 9/9
- post-review relay/entitlement tests: 53/53
- post-review permitted broad unit gate: 1,217/1,217
- typecheck, release-only typecheck, production build, notices, frozen install,
  and dependency audit
- protected PR CI run 34008853111: all jobs pass

Automated review found and the branch repaired two release-boundary defects.
Commit `b38fd5c` excludes the sibling-relay integration test from the
single-repository release typecheck and adds a class-level drift guard. Commit
`c28c0e5` makes every malformed token override stop remote dialing; an
explicit gated relay cannot otherwise be distinguished from an ungated
self-host, and dialing without the omitted header caused 4007 retry churn and a
false local Pair surface.

The final pre-version-bump `0.8.5` candidate contains 20 runtime files, is
1,467,420 bytes, and has SHA-256
`d0067c160fce2031e50b52d69d7153fd7c90a2cde296ef6b7863a98b187b7a70`.
DA.6 will version and publish this reviewed runtime through the protected
release flow after this PR reaches `next`.
