### PR TITLE
chore: sync v0.9.0 main into next

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirafold",
-  "version": "0.8.5",
+  "version": "0.9.0",
   "description": "A faithful browser re-skin of the coding agents you already use — Claude Agent, Codex, Gemini CLI, or OpenCode — with generative UI layered on top.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Release `v0.9.0` has been published from protected `main`. This merges that exact
release snapshot back into `next`, preserving the release merge topology and
advancing the package version from `0.8.5` to `0.9.0`.

The branch points at signed-tag target `b02f8ff17ae5316959343293b75bf573e7649c71`.
Against current `next`, the only file diff is the one-line `package.json`
version change.

Validation:

- Release workflow `34010536859` passed verification, tests, notices, packing,
  signature/hash binding, and npm trusted publication.
- Published tarball: 1,467,409 bytes.
- SHA-256: `d2c059b09ab344a183a54f6e6a7c0814c2bdb827a6da3fca131322108ff880d7`.
- Public registry verification passed, including 114 registry signatures,
  14 npm attestations, a cold global install, and the packaged browser pass 9/9.
