### PR TITLE
Fix browser CI blocked by unused Google package source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,11 @@ jobs:
           path: ~/.cache/ms-playwright
           key: ms-playwright-${{ runner.os }}-${{ hashFiles('mirafold/node_modules/playwright-core/package.json') }}
       - name: Install managed UI browsers
-        run: yarn playwright-core install --with-deps chromium firefox webkit
+        run: |
+          # Chrome already ships on the runner. Its new apt source survives
+          # the image's legacy .list cleanup and can block Ubuntu dependency setup.
+          sudo rm -f /etc/apt/sources.list.d/google-chrome.sources
+          yarn playwright-core install --with-deps chromium firefox webkit
       # Tier 3 drives real headless Chrome via playwright-core; the harness
       # reads CHROME_BIN (default /usr/bin/google-chrome). ubuntu-24.04 ships
       # google-chrome-stable — resolve its path and hand it to the suite rather


### PR DESCRIPTION
Release 0.9.1 cannot pass browser setup because Google's Chrome apt repository currently serves a package index with a different SHA-256 from its Release metadata. Three unchanged CI attempts failed before any integration or browser tests ran.

Google's package installer now creates `/etc/apt/sources.list.d/google-chrome.sources`; the pinned GitHub runner image removes only the older `.list` source. Remove the leftover `.sources` file before Playwright installs Ubuntu system dependencies. Chrome is already supplied by the runner and remains installed; all package signature/checksum checks and the complete test suite remain enabled.

This changes only the existing browser-install step in `.github/workflows/ci.yml`. No product code, dependencies, release workflow, or test cases change. Full PR CI validates the repair. After this merges into `next`, the release branch takes this fix branch alone, per docs/RELEASING.md.

Diagnosis: https://github.com/mirafold/mirafold/actions/runs/34383215904/job/102578958242
Runner cleanup: https://github.com/actions/runner-images/blob/ubuntu24/20260831.293/images/ubuntu/scripts/build/install-google-chrome.sh
